### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,69 +4,14 @@
 # Should be automatically kept up to date by dependabot.
 FROM mcr.microsoft.com/devcontainers/go:2-1.26
 
-# https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
-
-ARG TARGETARCH
-
-# APT dependencies
-# including docker-cli for docker-from-docker pattern
-# and az-cli for interacting with azure resources
-ENV DEBIAN_FRONTEND=noninteractive
-RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list \
-    && apt-get update \
-    && apt-get -y install --no-install-recommends bash-completion lsb-release graphviz zip nodejs npm python3-pip docker-ce-cli docker-compose-plugin gnuplot\
-    # install az-cli
-    && curl -sL https://aka.ms/InstallAzureCLIDeb | bash - \
-    # Temporary fix to avoid regression in v2.77
-    && apt-get remove azure-cli --assume-yes \
-    && apt-get -y install azure-cli=2.76.0-1~bookworm \
-    && rm -rf /var/lib/apt/lists/*
-
+# Install development tools
 COPY .devcontainer/install-dependencies.sh .
 RUN ./install-dependencies.sh devcontainer && rm install-dependencies.sh
-
-# Pre-download Go modules for faster builds
-# Some of these go.mod files have replace directives that point to local directories, so we need to be careful to 
-# maintain the same relative positions as we copy them into the container.
-# v2 first (largest, most stable, needed by replace directives)
-COPY v2/go.mod v2/go.sum /tmp/mod-download/v2/
-# asoctl (has replace => ../../ which resolves to v2/)
-COPY v2/cmd/asoctl/go.mod v2/cmd/asoctl/go.sum /tmp/mod-download/v2/cmd/asoctl/
-# generator (has replace => ../../ which resolves to v2/)
-COPY v2/tools/generator/go.mod v2/tools/generator/go.sum /tmp/mod-download/v2/tools/generator/
-# mangle-test-json (standalone, no replace directives)
-COPY v2/tools/mangle-test-json/go.mod v2/tools/mangle-test-json/go.sum /tmp/mod-download/v2/tools/mangle-test-json/
-# Now do all the downloads
-RUN find /tmp/mod-download -name go.mod -execdir pwd \; -execdir go mod download \;
-
-# Clean up temporary module download directory
-RUN rm -rf /tmp/mod-download
-
-# Setup envtest
-# NB: if you change this, dev.sh also likely needs updating, also need to update the env below
-RUN setup-envtest use 1.35.0 --bin-dir /usr/local/envtest/bin
-# Set the KUBEBUILDER_ASSETS variable. Ideally we could do source <(setup-envtest use --bin-dir /usr/local/envtest/bin -i -p env)
-# but there's no way to dynamically set an env variable for all container users.
-# Many usages of this container are from docker exec task <x>, where no shell is invoked and the entrypoint is not run
-# (entrypoint is only run on start, not on exec). Due to that, the following approaches do not work:
-# - ~/.bashrc - only works for one user in a shell but we must support -u $(id -u ${USER}):$(id -g ${USER}) which means the container could run as more than 1 user
-# - /etc/profile or /etc/profile.d - only works for one user in a login shell
-ENV KUBEBUILDER_ASSETS=/usr/local/envtest/bin/k8s/1.35.0-linux-${TARGETARCH}
-ENV PATH=$KUBEBUILDER_ASSETS:$PATH
-
-# Make kubectl completions work with 'k' alias
-RUN echo 'alias k=kubectl' >> "/etc/bash.bashrc"
-RUN echo 'complete -F __start_kubectl k' >> "/etc/bash.bashrc"
-RUN echo 'source <(kubectl completion bash)' >> "/etc/bash.bashrc"
 
 # Setup go-task completions
 RUN curl -sL "https://raw.githubusercontent.com/go-task/task/v3.2.0/completion/bash/task.bash" > "/etc/.task.completion.sh" \
     && echo 'source /etc/.task.completion.sh' >> "/etc/bash.bashrc"
 
-ENV KIND_CLUSTER_NAME=aso
-
-# Add user to docker group for docker socket access
-RUN groupadd -f docker && usermod -aG docker vscode
-
-CMD ["sleep", "infinity"]
+# Pre-download Go modules for faster builds
+COPY go.mod go.sum /tmp/mod-download/
+RUN cd /tmp/mod-download && go mod download && rm -rf /tmp/mod-download

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,72 @@
+# See here for image contents: https://github.com/devcontainers/images/blob/main/src/go/.devcontainer/Dockerfile
+
+# Compound versioning - v2 of the devcontainer, v1.26 of Go. 
+# Should be automatically kept up to date by dependabot.
+FROM mcr.microsoft.com/devcontainers/go:2-1.26
+
+# https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+
+ARG TARGETARCH
+
+# APT dependencies
+# including docker-cli for docker-from-docker pattern
+# and az-cli for interacting with azure resources
+ENV DEBIAN_FRONTEND=noninteractive
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get -y install --no-install-recommends bash-completion lsb-release graphviz zip nodejs npm python3-pip docker-ce-cli docker-compose-plugin gnuplot\
+    # install az-cli
+    && curl -sL https://aka.ms/InstallAzureCLIDeb | bash - \
+    # Temporary fix to avoid regression in v2.77
+    && apt-get remove azure-cli --assume-yes \
+    && apt-get -y install azure-cli=2.76.0-1~bookworm \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY .devcontainer/install-dependencies.sh .
+RUN ./install-dependencies.sh devcontainer && rm install-dependencies.sh
+
+# Pre-download Go modules for faster builds
+# Some of these go.mod files have replace directives that point to local directories, so we need to be careful to 
+# maintain the same relative positions as we copy them into the container.
+# v2 first (largest, most stable, needed by replace directives)
+COPY v2/go.mod v2/go.sum /tmp/mod-download/v2/
+# asoctl (has replace => ../../ which resolves to v2/)
+COPY v2/cmd/asoctl/go.mod v2/cmd/asoctl/go.sum /tmp/mod-download/v2/cmd/asoctl/
+# generator (has replace => ../../ which resolves to v2/)
+COPY v2/tools/generator/go.mod v2/tools/generator/go.sum /tmp/mod-download/v2/tools/generator/
+# mangle-test-json (standalone, no replace directives)
+COPY v2/tools/mangle-test-json/go.mod v2/tools/mangle-test-json/go.sum /tmp/mod-download/v2/tools/mangle-test-json/
+# Now do all the downloads
+RUN find /tmp/mod-download -name go.mod -execdir pwd \; -execdir go mod download \;
+
+# Clean up temporary module download directory
+RUN rm -rf /tmp/mod-download
+
+# Setup envtest
+# NB: if you change this, dev.sh also likely needs updating, also need to update the env below
+RUN setup-envtest use 1.35.0 --bin-dir /usr/local/envtest/bin
+# Set the KUBEBUILDER_ASSETS variable. Ideally we could do source <(setup-envtest use --bin-dir /usr/local/envtest/bin -i -p env)
+# but there's no way to dynamically set an env variable for all container users.
+# Many usages of this container are from docker exec task <x>, where no shell is invoked and the entrypoint is not run
+# (entrypoint is only run on start, not on exec). Due to that, the following approaches do not work:
+# - ~/.bashrc - only works for one user in a shell but we must support -u $(id -u ${USER}):$(id -g ${USER}) which means the container could run as more than 1 user
+# - /etc/profile or /etc/profile.d - only works for one user in a login shell
+ENV KUBEBUILDER_ASSETS=/usr/local/envtest/bin/k8s/1.35.0-linux-${TARGETARCH}
+ENV PATH=$KUBEBUILDER_ASSETS:$PATH
+
+# Make kubectl completions work with 'k' alias
+RUN echo 'alias k=kubectl' >> "/etc/bash.bashrc"
+RUN echo 'complete -F __start_kubectl k' >> "/etc/bash.bashrc"
+RUN echo 'source <(kubectl completion bash)' >> "/etc/bash.bashrc"
+
+# Setup go-task completions
+RUN curl -sL "https://raw.githubusercontent.com/go-task/task/v3.2.0/completion/bash/task.bash" > "/etc/.task.completion.sh" \
+    && echo 'source /etc/.task.completion.sh' >> "/etc/bash.bashrc"
+
+ENV KIND_CLUSTER_NAME=aso
+
+# Add user to docker group for docker socket access
+RUN groupadd -f docker && usermod -aG docker vscode
+
+CMD ["sleep", "infinity"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,6 +4,10 @@
 # Should be automatically kept up to date by dependabot.
 FROM mcr.microsoft.com/devcontainers/go:2-1.26
 
+# APT dependencies
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends bash-completion graphviz zip python3-pip
+
 # Install development tools
 COPY .devcontainer/install-dependencies.sh .
 RUN ./install-dependencies.sh devcontainer && rm install-dependencies.sh

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,7 +13,7 @@ COPY .devcontainer/install-dependencies.sh .
 RUN ./install-dependencies.sh devcontainer && rm install-dependencies.sh
 
 # Setup go-task completions
-RUN curl -sL "https://raw.githubusercontent.com/go-task/task/v3.2.0/completion/bash/task.bash" > "/etc/.task.completion.sh" \
+RUN task --completion bash > "/etc/.task.completion.sh" \
     && echo 'source /etc/.task.completion.sh' >> "/etc/bash.bashrc"
 
 # Pre-download Go modules for faster builds

--- a/.devcontainer/Dockerfile.dockerignore
+++ b/.devcontainer/Dockerfile.dockerignore
@@ -1,0 +1,15 @@
+# Ignore everything by default
+**
+
+# Allow devcontainer files
+!.devcontainer/install-dependencies.sh
+
+# Allow go.mod/go.sum for module pre-download
+!v2/go.mod
+!v2/go.sum
+!v2/cmd/asoctl/go.mod
+!v2/cmd/asoctl/go.sum
+!v2/tools/generator/go.mod
+!v2/tools/generator/go.sum
+!v2/tools/mangle-test-json/go.mod
+!v2/tools/mangle-test-json/go.sum

--- a/.devcontainer/Dockerfile.dockerignore
+++ b/.devcontainer/Dockerfile.dockerignore
@@ -5,11 +5,5 @@
 !.devcontainer/install-dependencies.sh
 
 # Allow go.mod/go.sum for module pre-download
-!v2/go.mod
-!v2/go.sum
-!v2/cmd/asoctl/go.mod
-!v2/cmd/asoctl/go.sum
-!v2/tools/generator/go.mod
-!v2/tools/generator/go.sum
-!v2/tools/mangle-test-json/go.mod
-!v2/tools/mangle-test-json/go.sum
+!go.mod
+!go.sum

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,60 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.137.0/containers/go
+{
+	"name": "Azure Service Operator",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": ".."
+	},
+	"runArgs": [ 
+		"--cap-add=SYS_PTRACE",
+		"--security-opt", "seccomp=unconfined", 
+		"--init" // runs an init process: https://docs.docker.com/engine/reference/run/#specify-an-init-process
+	],
+
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-vscode.go",
+				"ms-azuretools.vscode-docker",
+				"redhat.vscode-yaml",
+				"ms-kubernetes-tools.vscode-kubernetes-tools",
+				"task.vscode-task",
+				"github.vscode-pull-request-github"
+			],
+			"settings": {
+				"terminal.integrated.defaultProfile.linux": "bash",
+				"terminal.integrated.profiles.linux": {
+					"bash": {
+						"path": "bash",
+						"icon": "terminal-bash"
+					}
+				},
+				"editor.formatOnSave": true,
+				"go.gopath": "/go",
+				"go.useLanguageServer": true,
+				"go.lintTool": "golangci-lint",
+				"[go]": {
+					"editor.snippetSuggestions": "none",
+					"editor.formatOnSave": true,
+					"editor.codeActionsOnSave": {
+						"source.organizeImports": "explicit"
+					}
+				}
+			}
+		}
+
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [9000],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "go version",
+
+	"remoteUser": "vscode",
+
+	// Use docker-from-docker: mount host docker socket for CI compatibility
+	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+	"overrideCommand": false
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.137.0/containers/go
 {
-	"name": "Azure Service Operator",
+	"name": "Code Visualizer",
 	"build": {
 		"dockerfile": "Dockerfile",
 		"context": ".."
@@ -16,9 +16,7 @@
 		"vscode": {
 			"extensions": [
 				"ms-vscode.go",
-				"ms-azuretools.vscode-docker",
 				"redhat.vscode-yaml",
-				"ms-kubernetes-tools.vscode-kubernetes-tools",
 				"task.vscode-task",
 				"github.vscode-pull-request-github"
 			],
@@ -46,15 +44,8 @@
 
 	},
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [9000],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "go version",
 
-	"remoteUser": "vscode",
-
-	// Use docker-from-docker: mount host docker socket for CI compatibility
-	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
-	"overrideCommand": false
+	"remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -45,7 +45,7 @@
 	},
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "go version",
+	"postCreateCommand": "bash -lc 'git config --global --add safe.directory \"${containerWorkspaceFolder}\" && go version'",
 
 	"remoteUser": "vscode"
 }

--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -160,6 +160,6 @@ fi
 
 if [ "$DEVCONTAINER" == true ]; then
     # Git Permissions
-    # Workaround for issue where /workspace has different owner because checkout happens outside the container
-    git config --global --add safe.directory /workspace
+    # Workaround for issue where /workspaces has different owner because checkout happens outside the container
+    git config --global --add safe.directory /workspaces
 fi

--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -12,10 +12,10 @@ set -eu
 #
 # - When being used to install tools locally.
 #   In this mode the code is already checked out,
-#   and we do not want to pollute the user’s system.
+#   and we do not want to pollute the user's system.
 #
 # To distinguish between these modes we will
-# have the devcontainer script pass the argument 
+# have the devcontainer script pass the argument
 # `devcontainer`
 #
 # Other available arguments
@@ -24,24 +24,12 @@ set -eu
 # -s --skip-installed   : Skip anything that's already installed
 #
 
-#
-# This file includes documentation in lines prefixed `#doc#`.
-# These lines are extracted by running `task doc:dependencies` from the root folder.
-#
-# Each dependency should be documented by a single line with the following content:
-#
-# | <name> | <version> | <details> |
-#
-# Details should include at minimum a link to the originating website. 
-# Be sure to use include the `#doc#` prefix on each line.
-#
-
 VERBOSE=false
 SKIP=false
 DEVCONTAINER=false
 
-while [[ $# -gt 0 ]]; do 
-  case $1 in 
+while [[ $# -gt 0 ]]; do
+  case $1 in
     -v | --verbose)
       VERBOSE=true
       shift
@@ -81,20 +69,15 @@ write-error() {
 
 # Configure behaviour for devcontainer mode or not
 
-if [ "$DEVCONTAINER" = true ]; then 
+if [ "$DEVCONTAINER" = true ]; then
     TOOL_DEST=/usr/local/bin
-    KUBEBUILDER_DEST=/usr/local/kubebuilder
-    BUILDX_DEST=/usr/lib/docker/cli-plugins
 else
     TOOL_DEST=$(git rev-parse --show-toplevel)/hack/tools
     mkdir -p "$TOOL_DEST"
-    KUBEBUILDER_DEST="$TOOL_DEST/kubebuilder"
-    BUILDX_DEST=$HOME/.docker/cli-plugins
 fi
 
 # Ensure we have the right version of GO
 
-#doc# | Go | 1.25 | https://golang.org/doc/install #
 if ! command -v go > /dev/null 2>&1; then
     write-error "Go must be installed manually; see https://golang.org/doc/install"
     exit 1
@@ -103,53 +86,15 @@ fi
 GOVER=$(go version)
 write-info "Go version: ${GOVER[*]}"
 
-GOVERREGEX=".*go1.([0-9]+).([0-9]+).*"
-GOVERREQUIRED="go1.25.*"
-GOVERACTUAL=$(go version | { read _ _ ver _; echo "$ver"; })
-
-if ! [[ $GOVERACTUAL =~ $GOVERREGEX ]]; then
-    write-error "Unexpected Go version format: $GOVERACTUAL"
-    exit 1
-fi
-
-GOMINORVER="${BASH_REMATCH[1]}"
-GOMINORREQUIRED=25
-GOTOOLCHAINMINVER=21
-
-# Check Go version - we require 1.21+ (for toolchain support), prefer 1.25+
-# Go 1.21+ supports automatic toolchain downloads, so versions 1.21-1.24 can still work
-if [[ $GOMINORVER -lt $GOTOOLCHAINMINVER ]]; then
-    write-error "Go must be at least version 1.$GOTOOLCHAINMINVER (for toolchain support), not $GOVERACTUAL; see: https://golang.org/doc/install"
-    exit 1
-elif [[ $GOMINORVER -lt $GOMINORREQUIRED ]]; then
-    write-info "WARNING: Go 1.$GOMINORREQUIRED is recommended, but you have $GOVERACTUAL."
-    write-info "Go's toolchain feature may automatically download the required version when building."
-    write-info "If you encounter issues, please upgrade Go: https://golang.org/doc/install"
-fi
-
 # Define os and arch
 os=$(go env GOOS)
 arch=$(go env GOARCH)
-
-# Ensure we have AZ
-
-#doc# | AZ | latest | https://docs.microsoft.com/en-us/cli/azure/install-azure-cli |
-if ! command -v az > /dev/null 2>&1; then
-    write-error "Azure CLI must be installed manually: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli"
-    exit 1
-fi
-
-#doc# | Pip3 | latest | https://pip.pypa.io/en/stable/installation/ |
-if ! command -v pip3 > /dev/null 2>&1; then
-    write-error "Pip3 must be installed manually: https://pip.pypa.io/en/stable/installation/"
-    exit 1
-fi
 
 write-verbose "Installing tools to $TOOL_DEST"
 
 # Install Go tools
 TMPDIR=$(mktemp -d)
-clean() { 
+clean() {
     # Macos wants different flag order
     if [[ ${os} == "darwin" ]]; then
         chmod -R +w "$TMPDIR"
@@ -169,10 +114,10 @@ write-verbose "Installing Go tools..."
 
 # go tools for vscode are preinstalled by base image (see first comment in Dockerfile)
 
-# should-install() is a helper function for deciding whether 
+# should-install() is a helper function for deciding whether
 # a given installation is necessary
 should-install() {
-    if [ "$SKIP" == true ] && [ -f "$1" ]; then 
+    if [ "$SKIP" == true ] && [ -f "$1" ]; then
         # We can skip installation
         return 1
     fi
@@ -181,165 +126,39 @@ should-install() {
     return 0
 }
 
-# go-install() is a helper function to trigger `go install` 
+# go-install() is a helper function to trigger `go install`
 go-install() {
     write-verbose "Checking for $GOBIN/$1"
-    if should-install "$GOBIN/$1"; then 
+    if should-install "$GOBIN/$1"; then
         write-info "Installing $1"
         shift # Discard the command name so we can pass the remaining arguments to GO
         go install $@
     fi
 }
 
-#doc# | conversion-gen | v0.34.1 | https://pkg.go.dev/k8s.io/code-generator/cmd/conversion-gen |
-go-install conversion-gen k8s.io/code-generator/cmd/conversion-gen@v0.34.1
-
-#doc# | controller-gen | v0.19.0 | https://book.kubebuilder.io/reference/controller-gen |
-go-install controller-gen sigs.k8s.io/controller-tools/cmd/controller-gen@v0.19.0
-
-#doc# | kind | v0.31.0 | https://kind.sigs.k8s.io/ |
-go-install kind sigs.k8s.io/kind@v0.31.0
-
-#doc# | kustomize | v4.5.7 | https://kustomize.io/ |
-go-install kustomize sigs.k8s.io/kustomize/kustomize/v4@v4.5.7
-
-# for docs site
-
-#doc# | hugo | v0.152.2 | https://gohugo.io/ |
-go-install hugo -tags extended github.com/gohugoio/hugo@v0.152.2
-
-#doc# | htmltest | latest | https://github.com/wjdp/htmltest (but see https://github.com/theunrepentantgeek/htmltest for our custom build )
-# Restore this to github.com/wjdp/htmltest@v?? once PR#215 is merged with the feature we need
-go-install htmltest github.com/theunrepentantgeek/htmltest@latest
-
-#doc# | crddoc | latest | https://github.com/theunrepentantgeek/crddoc |
-go-install crddoc github.com/theunrepentantgeek/crddoc@latest
-
-#doc# | go-vcr-tidy | latest | https://github.com/theunrepentantgeek/go-vcr-tidy |
-go-install go-vcr-tidy github.com/theunrepentantgeek/go-vcr-tidy@latest
-
-# Install envtest tooling
-#doc# | setup-envtest | v0.23.1 | https://book.kubebuilder.io/reference/envtest.html |
-write-verbose "Checking for $TOOL_DEST/setup-envtest"
-if should-install "$TOOL_DEST/setup-envtest"; then
-    write-info "Installing setup-envtest"
-    curl -sL "https://github.com/kubernetes-sigs/controller-runtime/releases/download/v0.23.1/setup-envtest-${os}-${arch}" --output "$TOOL_DEST/setup-envtest"
-    chmod +x "$TOOL_DEST/setup-envtest"
-fi
-
 # Stricter GO formatting
-#doc# | gofumpt | latest | https://pkg.go.dev/mvdan.cc/gofumpt |
 go-install gofumpt mvdan.cc/gofumpt@latest
 
 # Install golangci-lint
-#doc# | golangci-lint | 2.8.0 | https://github.com/golangci/golangci-lint |
 write-verbose "Checking for $TOOL_DEST/golangci-lint"
 if should-install "$TOOL_DEST/golangci-lint"; then
     write-info "Installing golangci-lint"
-    # golangci-lint is provided by base image if in devcontainer
-    # this command copied from there
     curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$TOOL_DEST" v2.8.0 2>&1
 fi
 
 # Install Task
-#doc# | Task | v3.49.1 | https://taskfile.dev/ |
-write-verbose "Checking for $TOOL_DEST/go-task"
-if should-install "$TOOL_DEST/task"; then 
+write-verbose "Checking for $TOOL_DEST/task"
+if should-install "$TOOL_DEST/task"; then
     write-info "Installing go-task"
     curl -sL "https://github.com/go-task/task/releases/download/v3.49.1/task_${os}_${arch}.tar.gz" | tar xz -C "$TOOL_DEST" task
 fi
 
-# Install Trivy
-#doc# | Trivy | v0.67.2 | https://trivy.dev/ |
-# write-verbose "Checking for $TOOL_DEST/trivy"
-# if should-install "$TOOL_DEST/trivy"; then
-#     write-info "Installing trivy"
-#     # These guys decided to use different naming conventions for os(go env GOOS) and arch(go env GOARCH) despite trivy is 98.6% written in Go
-#     # This fixes macos arm64 architechture. Every other os/arch is named differently. Consider adding a workaround of your own ¯\_(ツ)_/¯
-#     if [[ ${os} == "darwin" ]] && [[ ${arch} == "arm64" ]]; then
-#         curl -sL "https://github.com/aquasecurity/trivy/releases/download/v0.67.2/trivy_0.67.2_macOS-ARM64.tar.gz" | tar xz -C "$TOOL_DEST" trivy
-#     else
-#         curl -sL "https://github.com/aquasecurity/trivy/releases/download/v0.67.2/trivy_0.67.2_Linux-64bit.tar.gz" | tar xz -C "$TOOL_DEST" trivy
-#     fi
-# fi
-
-# Install helm
-#doc# | Helm | v3.19.0 | https://helm.sh/ |
-write-verbose "Checking for $TOOL_DEST/helm"
-if should-install "$TOOL_DEST/helm"; then
-    write-info "Installing helm..."
-    curl -sL "https://get.helm.sh/helm-v3.19.0-${os}-${arch}.tar.gz" | tar -C "$TOOL_DEST" --strip-components=1 -xz ${os}-${arch}/helm
-fi
-
-# Install yq
-#doc# | YQ | v4.48.1 | https://github.com/mikefarah/yq/ |
-yq_version=v4.48.1
-yq_binary=yq_${os}_${arch}
-write-verbose "Checking for $TOOL_DEST/yq"
-if should-install "$TOOL_DEST/yq"; then 
-    write-info "Installing yq..."
-    rm -f "$TOOL_DEST/yq" # remove yq in case we're forcing the install
-    wget "https://github.com/mikefarah/yq/releases/download/${yq_version}/${yq_binary}.tar.gz" -O - | tar -xz -C "$TOOL_DEST" && mv "$TOOL_DEST/$yq_binary" "$TOOL_DEST/yq"
-fi
-
-# Install cmctl, used to wait for cert manager installation during some tests cases
-#doc# | cmctl | latest | https://cert-manager.io/docs/reference/cmctl |
-write-verbose "Checking for $TOOL_DEST/cmctl"
-if should-install "$TOOL_DEST/cmctl"; then 
-    write-info "Installing cmctl-${os}_${arch}..."
-    curl -fL "https://github.com/cert-manager/cmctl/releases/latest/download/cmctl_${os}_${arch}" --output "$TOOL_DEST/cmctl"
-    chmod +x "$TOOL_DEST/cmctl"
-fi
-
-write-verbose "Checking for $BUILDX_DEST/docker-buildx"
-#doc# | BuildX | v0.29.1 | https://github.com/docker/buildx |
-if should-install "$BUILDX_DEST/docker-buildx"; then
-    write-info "Installing buildx-${os}_${arch} to $BUILDX_DEST ..."
-    if ! test -f $BUILDX_DEST; then
-        mkdir -p "$BUILDX_DEST"
-    fi
-    if ! test -f $BUILDX_DEST/docker-buildx; then
-        curl  -o "$BUILDX_DEST/docker-buildx" -L "https://github.com/docker/buildx/releases/download/v0.29.1/buildx-v0.29.1.${os}-${arch}"
-        chmod +x "$BUILDX_DEST/docker-buildx"
-    fi
-fi
-
-# Install azwi
-#doc# | AZWI | v1.5.1 | https://github.com/Azure/azure-workload-identity |
-write-verbose "Checking for $TOOL_DEST/azwi"
-if should-install "$TOOL_DEST/azwi"; then
-    write-info "Installing azwi..."
-    curl -sL "https://github.com/Azure/azure-workload-identity/releases/download/v1.5.1/azwi-v1.5.1-${os}-${arch}.tar.gz" | tar xz -C "$TOOL_DEST" azwi
-fi
-
-# Ensure tooling for Hugo is available
-#doc# | PostCSS | latest | https://postcss.org/ |
-write-verbose "Checking for /usr/bin/postcss"
-if ! which postcss  > /dev/null 2>&1; then 
-    write-info "Installing postcss"
-    npm config set fund false --location=global
-    npm install --global postcss postcss-cli autoprefixer
-fi
-
-if [ "$VERBOSE" == true ]; then 
+if [ "$VERBOSE" == true ]; then
     echo "Installed tools: $(ls "$TOOL_DEST")"
 fi
 
 if [ "$DEVCONTAINER" == true ]; then
-
-    # Webhook Certs
-    write-info "Setting up k8s webhook certificates"
-    mkdir -p /tmp/k8s-webhook-server/serving-certs
-    openssl genrsa 2048 > tls.key
-    openssl req -new -x509 -nodes -sha256 -days 3650 -key tls.key -subj '/' -out tls.crt
-    mv tls.key tls.crt /tmp/k8s-webhook-server/serving-certs
-
     # Git Permissions
     # Workaround for issue where /workspace has different owner because checkout happens outside the container
     git config --global --add safe.directory /workspace
 fi
-
-write-info "Setting up python virtual environment"
-
-# Install python virtualenv
-pip3 install virtualenv --break-system-packages

--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -1,0 +1,345 @@
+#!/bin/bash
+
+# -e immediate exit on error
+# -u treat unset variables as an error
+set -eu
+
+# This may be run in two modes:
+#
+# - When being used to set up a devcontainer.
+#   In this mode the code is not checked out yet,
+#   and we can install the tools globally.
+#
+# - When being used to install tools locally.
+#   In this mode the code is already checked out,
+#   and we do not want to pollute the user’s system.
+#
+# To distinguish between these modes we will
+# have the devcontainer script pass the argument 
+# `devcontainer`
+#
+# Other available arguments
+#
+# -v --verbose          : Generate more logging
+# -s --skip-installed   : Skip anything that's already installed
+#
+
+#
+# This file includes documentation in lines prefixed `#doc#`.
+# These lines are extracted by running `task doc:dependencies` from the root folder.
+#
+# Each dependency should be documented by a single line with the following content:
+#
+# | <name> | <version> | <details> |
+#
+# Details should include at minimum a link to the originating website. 
+# Be sure to use include the `#doc#` prefix on each line.
+#
+
+VERBOSE=false
+SKIP=false
+DEVCONTAINER=false
+
+while [[ $# -gt 0 ]]; do 
+  case $1 in 
+    -v | --verbose)
+      VERBOSE=true
+      shift
+      ;;
+    -s | --skip-installed)
+      SKIP=true
+      shift
+      ;;
+    -* | --*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+    devcontainer)
+      DEVCONTAINER=true
+      shift
+      ;;
+    *)
+      echo "Unknown parameter $1"
+      exit 1
+      ;;
+  esac
+done
+
+write-verbose() {
+    if [ "$VERBOSE" = true ]; then
+      echo "[VER] $1"
+    fi
+}
+
+write-info() {
+      echo "[INF] $1"
+}
+
+write-error() {
+    echo "[ERR] $1"
+}
+
+# Configure behaviour for devcontainer mode or not
+
+if [ "$DEVCONTAINER" = true ]; then 
+    TOOL_DEST=/usr/local/bin
+    KUBEBUILDER_DEST=/usr/local/kubebuilder
+    BUILDX_DEST=/usr/lib/docker/cli-plugins
+else
+    TOOL_DEST=$(git rev-parse --show-toplevel)/hack/tools
+    mkdir -p "$TOOL_DEST"
+    KUBEBUILDER_DEST="$TOOL_DEST/kubebuilder"
+    BUILDX_DEST=$HOME/.docker/cli-plugins
+fi
+
+# Ensure we have the right version of GO
+
+#doc# | Go | 1.25 | https://golang.org/doc/install #
+if ! command -v go > /dev/null 2>&1; then
+    write-error "Go must be installed manually; see https://golang.org/doc/install"
+    exit 1
+fi
+
+GOVER=$(go version)
+write-info "Go version: ${GOVER[*]}"
+
+GOVERREGEX=".*go1.([0-9]+).([0-9]+).*"
+GOVERREQUIRED="go1.25.*"
+GOVERACTUAL=$(go version | { read _ _ ver _; echo "$ver"; })
+
+if ! [[ $GOVERACTUAL =~ $GOVERREGEX ]]; then
+    write-error "Unexpected Go version format: $GOVERACTUAL"
+    exit 1
+fi
+
+GOMINORVER="${BASH_REMATCH[1]}"
+GOMINORREQUIRED=25
+GOTOOLCHAINMINVER=21
+
+# Check Go version - we require 1.21+ (for toolchain support), prefer 1.25+
+# Go 1.21+ supports automatic toolchain downloads, so versions 1.21-1.24 can still work
+if [[ $GOMINORVER -lt $GOTOOLCHAINMINVER ]]; then
+    write-error "Go must be at least version 1.$GOTOOLCHAINMINVER (for toolchain support), not $GOVERACTUAL; see: https://golang.org/doc/install"
+    exit 1
+elif [[ $GOMINORVER -lt $GOMINORREQUIRED ]]; then
+    write-info "WARNING: Go 1.$GOMINORREQUIRED is recommended, but you have $GOVERACTUAL."
+    write-info "Go's toolchain feature may automatically download the required version when building."
+    write-info "If you encounter issues, please upgrade Go: https://golang.org/doc/install"
+fi
+
+# Define os and arch
+os=$(go env GOOS)
+arch=$(go env GOARCH)
+
+# Ensure we have AZ
+
+#doc# | AZ | latest | https://docs.microsoft.com/en-us/cli/azure/install-azure-cli |
+if ! command -v az > /dev/null 2>&1; then
+    write-error "Azure CLI must be installed manually: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli"
+    exit 1
+fi
+
+#doc# | Pip3 | latest | https://pip.pypa.io/en/stable/installation/ |
+if ! command -v pip3 > /dev/null 2>&1; then
+    write-error "Pip3 must be installed manually: https://pip.pypa.io/en/stable/installation/"
+    exit 1
+fi
+
+write-verbose "Installing tools to $TOOL_DEST"
+
+# Install Go tools
+TMPDIR=$(mktemp -d)
+clean() { 
+    # Macos wants different flag order
+    if [[ ${os} == "darwin" ]]; then
+        chmod -R +w "$TMPDIR"
+    else
+        chmod +w -R "$TMPDIR"
+    fi
+    rm -rf "$TMPDIR"
+}
+trap clean EXIT
+
+export GOBIN=$TOOL_DEST
+export GOPATH=$TMPDIR
+export GOCACHE=$TMPDIR/cache
+export GO111MODULE=on
+
+write-verbose "Installing Go tools..."
+
+# go tools for vscode are preinstalled by base image (see first comment in Dockerfile)
+
+# should-install() is a helper function for deciding whether 
+# a given installation is necessary
+should-install() {
+    if [ "$SKIP" == true ] && [ -f "$1" ]; then 
+        # We can skip installation
+        return 1
+    fi
+
+    # Installation is needed
+    return 0
+}
+
+# go-install() is a helper function to trigger `go install` 
+go-install() {
+    write-verbose "Checking for $GOBIN/$1"
+    if should-install "$GOBIN/$1"; then 
+        write-info "Installing $1"
+        shift # Discard the command name so we can pass the remaining arguments to GO
+        go install $@
+    fi
+}
+
+#doc# | conversion-gen | v0.34.1 | https://pkg.go.dev/k8s.io/code-generator/cmd/conversion-gen |
+go-install conversion-gen k8s.io/code-generator/cmd/conversion-gen@v0.34.1
+
+#doc# | controller-gen | v0.19.0 | https://book.kubebuilder.io/reference/controller-gen |
+go-install controller-gen sigs.k8s.io/controller-tools/cmd/controller-gen@v0.19.0
+
+#doc# | kind | v0.31.0 | https://kind.sigs.k8s.io/ |
+go-install kind sigs.k8s.io/kind@v0.31.0
+
+#doc# | kustomize | v4.5.7 | https://kustomize.io/ |
+go-install kustomize sigs.k8s.io/kustomize/kustomize/v4@v4.5.7
+
+# for docs site
+
+#doc# | hugo | v0.152.2 | https://gohugo.io/ |
+go-install hugo -tags extended github.com/gohugoio/hugo@v0.152.2
+
+#doc# | htmltest | latest | https://github.com/wjdp/htmltest (but see https://github.com/theunrepentantgeek/htmltest for our custom build )
+# Restore this to github.com/wjdp/htmltest@v?? once PR#215 is merged with the feature we need
+go-install htmltest github.com/theunrepentantgeek/htmltest@latest
+
+#doc# | crddoc | latest | https://github.com/theunrepentantgeek/crddoc |
+go-install crddoc github.com/theunrepentantgeek/crddoc@latest
+
+#doc# | go-vcr-tidy | latest | https://github.com/theunrepentantgeek/go-vcr-tidy |
+go-install go-vcr-tidy github.com/theunrepentantgeek/go-vcr-tidy@latest
+
+# Install envtest tooling
+#doc# | setup-envtest | v0.23.1 | https://book.kubebuilder.io/reference/envtest.html |
+write-verbose "Checking for $TOOL_DEST/setup-envtest"
+if should-install "$TOOL_DEST/setup-envtest"; then
+    write-info "Installing setup-envtest"
+    curl -sL "https://github.com/kubernetes-sigs/controller-runtime/releases/download/v0.23.1/setup-envtest-${os}-${arch}" --output "$TOOL_DEST/setup-envtest"
+    chmod +x "$TOOL_DEST/setup-envtest"
+fi
+
+# Stricter GO formatting
+#doc# | gofumpt | latest | https://pkg.go.dev/mvdan.cc/gofumpt |
+go-install gofumpt mvdan.cc/gofumpt@latest
+
+# Install golangci-lint
+#doc# | golangci-lint | 2.8.0 | https://github.com/golangci/golangci-lint |
+write-verbose "Checking for $TOOL_DEST/golangci-lint"
+if should-install "$TOOL_DEST/golangci-lint"; then
+    write-info "Installing golangci-lint"
+    # golangci-lint is provided by base image if in devcontainer
+    # this command copied from there
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$TOOL_DEST" v2.8.0 2>&1
+fi
+
+# Install Task
+#doc# | Task | v3.49.1 | https://taskfile.dev/ |
+write-verbose "Checking for $TOOL_DEST/go-task"
+if should-install "$TOOL_DEST/task"; then 
+    write-info "Installing go-task"
+    curl -sL "https://github.com/go-task/task/releases/download/v3.49.1/task_${os}_${arch}.tar.gz" | tar xz -C "$TOOL_DEST" task
+fi
+
+# Install Trivy
+#doc# | Trivy | v0.67.2 | https://trivy.dev/ |
+# write-verbose "Checking for $TOOL_DEST/trivy"
+# if should-install "$TOOL_DEST/trivy"; then
+#     write-info "Installing trivy"
+#     # These guys decided to use different naming conventions for os(go env GOOS) and arch(go env GOARCH) despite trivy is 98.6% written in Go
+#     # This fixes macos arm64 architechture. Every other os/arch is named differently. Consider adding a workaround of your own ¯\_(ツ)_/¯
+#     if [[ ${os} == "darwin" ]] && [[ ${arch} == "arm64" ]]; then
+#         curl -sL "https://github.com/aquasecurity/trivy/releases/download/v0.67.2/trivy_0.67.2_macOS-ARM64.tar.gz" | tar xz -C "$TOOL_DEST" trivy
+#     else
+#         curl -sL "https://github.com/aquasecurity/trivy/releases/download/v0.67.2/trivy_0.67.2_Linux-64bit.tar.gz" | tar xz -C "$TOOL_DEST" trivy
+#     fi
+# fi
+
+# Install helm
+#doc# | Helm | v3.19.0 | https://helm.sh/ |
+write-verbose "Checking for $TOOL_DEST/helm"
+if should-install "$TOOL_DEST/helm"; then
+    write-info "Installing helm..."
+    curl -sL "https://get.helm.sh/helm-v3.19.0-${os}-${arch}.tar.gz" | tar -C "$TOOL_DEST" --strip-components=1 -xz ${os}-${arch}/helm
+fi
+
+# Install yq
+#doc# | YQ | v4.48.1 | https://github.com/mikefarah/yq/ |
+yq_version=v4.48.1
+yq_binary=yq_${os}_${arch}
+write-verbose "Checking for $TOOL_DEST/yq"
+if should-install "$TOOL_DEST/yq"; then 
+    write-info "Installing yq..."
+    rm -f "$TOOL_DEST/yq" # remove yq in case we're forcing the install
+    wget "https://github.com/mikefarah/yq/releases/download/${yq_version}/${yq_binary}.tar.gz" -O - | tar -xz -C "$TOOL_DEST" && mv "$TOOL_DEST/$yq_binary" "$TOOL_DEST/yq"
+fi
+
+# Install cmctl, used to wait for cert manager installation during some tests cases
+#doc# | cmctl | latest | https://cert-manager.io/docs/reference/cmctl |
+write-verbose "Checking for $TOOL_DEST/cmctl"
+if should-install "$TOOL_DEST/cmctl"; then 
+    write-info "Installing cmctl-${os}_${arch}..."
+    curl -fL "https://github.com/cert-manager/cmctl/releases/latest/download/cmctl_${os}_${arch}" --output "$TOOL_DEST/cmctl"
+    chmod +x "$TOOL_DEST/cmctl"
+fi
+
+write-verbose "Checking for $BUILDX_DEST/docker-buildx"
+#doc# | BuildX | v0.29.1 | https://github.com/docker/buildx |
+if should-install "$BUILDX_DEST/docker-buildx"; then
+    write-info "Installing buildx-${os}_${arch} to $BUILDX_DEST ..."
+    if ! test -f $BUILDX_DEST; then
+        mkdir -p "$BUILDX_DEST"
+    fi
+    if ! test -f $BUILDX_DEST/docker-buildx; then
+        curl  -o "$BUILDX_DEST/docker-buildx" -L "https://github.com/docker/buildx/releases/download/v0.29.1/buildx-v0.29.1.${os}-${arch}"
+        chmod +x "$BUILDX_DEST/docker-buildx"
+    fi
+fi
+
+# Install azwi
+#doc# | AZWI | v1.5.1 | https://github.com/Azure/azure-workload-identity |
+write-verbose "Checking for $TOOL_DEST/azwi"
+if should-install "$TOOL_DEST/azwi"; then
+    write-info "Installing azwi..."
+    curl -sL "https://github.com/Azure/azure-workload-identity/releases/download/v1.5.1/azwi-v1.5.1-${os}-${arch}.tar.gz" | tar xz -C "$TOOL_DEST" azwi
+fi
+
+# Ensure tooling for Hugo is available
+#doc# | PostCSS | latest | https://postcss.org/ |
+write-verbose "Checking for /usr/bin/postcss"
+if ! which postcss  > /dev/null 2>&1; then 
+    write-info "Installing postcss"
+    npm config set fund false --location=global
+    npm install --global postcss postcss-cli autoprefixer
+fi
+
+if [ "$VERBOSE" == true ]; then 
+    echo "Installed tools: $(ls "$TOOL_DEST")"
+fi
+
+if [ "$DEVCONTAINER" == true ]; then
+
+    # Webhook Certs
+    write-info "Setting up k8s webhook certificates"
+    mkdir -p /tmp/k8s-webhook-server/serving-certs
+    openssl genrsa 2048 > tls.key
+    openssl req -new -x509 -nodes -sha256 -days 3650 -key tls.key -subj '/' -out tls.crt
+    mv tls.key tls.crt /tmp/k8s-webhook-server/serving-certs
+
+    # Git Permissions
+    # Workaround for issue where /workspace has different owner because checkout happens outside the container
+    git config --global --add safe.directory /workspace
+fi
+
+write-info "Setting up python virtual environment"
+
+# Install python virtualenv
+pip3 install virtualenv --break-system-packages

--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -2,7 +2,8 @@
 
 # -e immediate exit on error
 # -u treat unset variables as an error
-set -eu
+# -o pipefail fail a pipeline if any command fails
+set -euo pipefail
 
 # This may be run in two modes:
 #

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,8 +1,9 @@
 # code-visualizer Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-04-04
+Auto-generated from all feature plans. Last updated: 2026-04-05
 
 ## Active Technologies
+- Docker, Bash, JSON (devcontainer config); Go 1.26 (project language) + `mcr.microsoft.com/devcontainers/go:2-1.26` base image (002-add-devcontainer)
 
 - Go 1.26+ + Kong (CLI parsing), fogleman/gg (PNG rendering), go-git (git metadata) (001-cli-treemap-viz)
 
@@ -34,6 +35,7 @@ internal/
 Go 1.26+: Follow standard conventions, gofumpt formatting, eris error wrapping
 
 ## Recent Changes
+- 002-add-devcontainer: Added Docker, Bash, JSON (devcontainer config); Go 1.26 (project language) + `mcr.microsoft.com/devcontainers/go:2-1.26` base image
 
 - 001-cli-treemap-viz: Added Go 1.26+ + Kong (CLI parsing), fogleman/gg (PNG rendering), go-git (git metadata)
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,15 +1,17 @@
-run:
-  timeout: 5m
-
+version: "2"
 linters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
   enable:
-    - errcheck
-    - govet
-    - staticcheck
-    - unused
-    - ineffassign
-    - gosimple
     - gofmt
-
-issues:
-  exclude-use-default: false
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/internal/treemap/layout.go
+++ b/internal/treemap/layout.go
@@ -8,10 +8,10 @@ import (
 )
 
 const (
-	HeaderHeight  = 20.0 // pixels for directory header bar
-	padding       = 4.0  // pixels between groups
-	siblingGap    = 2.0  // pixels between sibling rectangles
-	minFileSize   = 1.0  // minimum area for zero-size files (FR-013)
+	HeaderHeight = 20.0 // pixels for directory header bar
+	padding      = 4.0  // pixels between groups
+	siblingGap   = 2.0  // pixels between sibling rectangles
+	minFileSize  = 1.0  // minimum area for zero-size files (FR-013)
 )
 
 // Layout computes a squarified treemap layout from a DirectoryNode tree.

--- a/internal/treemap/layout_test.go
+++ b/internal/treemap/layout_test.go
@@ -42,9 +42,10 @@ func TestLayoutProportionalAreas(t *testing.T) {
 	var bigRect, smallRect TreemapRectangle
 	for _, c := range rects.Children {
 		if !c.IsDirectory {
-			if c.Label == "big.go" {
+			switch c.Label {
+			case "big.go":
 				bigRect = c
-			} else if c.Label == "small.go" {
+			case "small.go":
 				smallRect = c
 			}
 		}

--- a/specs/002-add-devcontainer/checklists/requirements.md
+++ b/specs/002-add-devcontainer/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Add Devcontainer
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-05
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items passed validation on the first iteration.
+- Tool names (golangci-lint, gofumpt, go-task) are referenced as user-facing requirements (what must be present), not as implementation choices.

--- a/specs/002-add-devcontainer/contracts/devcontainer-contract.md
+++ b/specs/002-add-devcontainer/contracts/devcontainer-contract.md
@@ -1,0 +1,67 @@
+# Devcontainer Contract
+
+**Feature**: 002-add-devcontainer  
+**Date**: 2026-04-05
+
+## Overview
+
+The devcontainer exposes a development environment contract: given a repository clone, opening in the devcontainer provides a fully configured workspace. This contract defines what the environment guarantees.
+
+## Environment Contract
+
+### Tools Available on PATH
+
+| Tool            | Minimum Version   | Purpose                        |
+| --------------- | ----------------- | ------------------------------ |
+| `go`            | 1.26.x            | Go compiler and tools          |
+| `gofumpt`       | latest            | Strict Go formatting           |
+| `golangci-lint` | v2.8.0            | Go linting                     |
+| `task`          | v3.49.1           | Build orchestration (Taskfile) |
+| `git`           | (from base image) | Version control                |
+
+### Pre-conditions Met at Container Start
+
+- Go module cache is populated with all dependencies from `go.mod`/`go.sum`
+- Go workspace is at `/workspace` (default devcontainer mount)
+- User is `vscode` with sudo access (from base image)
+- Git safe.directory is configured for `/workspace`
+
+### VS Code Extensions Installed
+
+| Extension ID                        | Purpose                                                |
+| ----------------------------------- | ------------------------------------------------------ |
+| `ms-vscode.go`                      | Go language support (IntelliSense, debugging, testing) |
+| `task.vscode-task`                  | Taskfile integration                                   |
+| `redhat.vscode-yaml`                | YAML language support                                  |
+| `github.vscode-pull-request-github` | GitHub PR integration                                  |
+
+### VS Code Settings Applied
+
+| Setting                                                | Value             | Purpose                       |
+| ------------------------------------------------------ | ----------------- | ----------------------------- |
+| `editor.formatOnSave`                                  | `true`            | Auto-format on save           |
+| `go.useLanguageServer`                                 | `true`            | Enable gopls                  |
+| `go.lintTool`                                          | `"golangci-lint"` | Use golangci-lint for linting |
+| `go.gopath`                                            | `"/go"`           | Standard Go path              |
+| `[go].editor.codeActionsOnSave.source.organizeImports` | `"explicit"`      | Auto-organize imports         |
+
+### Taskfile Commands That Must Work
+
+All existing Taskfile commands must work identically inside the devcontainer:
+
+| Command      | Expected Behavior                     |
+| ------------ | ------------------------------------- |
+| `task build` | Compiles `bin/codeviz` without errors |
+| `task test`  | All tests pass                        |
+| `task lint`  | Zero lint warnings                    |
+| `task fmt`   | Formats all Go files                  |
+| `task ci`    | Build + test + lint all pass          |
+
+### What Is NOT Provided
+
+The devcontainer explicitly does NOT include:
+- Docker CLI or Docker-in-Docker
+- Azure CLI or any Azure tooling
+- Kubernetes tools (kubectl, kind, kustomize, helm, envtest)
+- Node.js, npm, or Python
+- Any ASO-specific tooling

--- a/specs/002-add-devcontainer/data-model.md
+++ b/specs/002-add-devcontainer/data-model.md
@@ -1,0 +1,63 @@
+# Data Model: Add Devcontainer
+
+**Feature**: 002-add-devcontainer  
+**Date**: 2026-04-05
+
+## Overview
+
+This feature involves only configuration files (Dockerfile, devcontainer.json, shell script, dockerignore). There are no application data entities, database schemas, or domain model changes.
+
+## Configuration Artifacts
+
+### Dockerfile
+
+Defines the container image build. Key layers:
+
+1. **Base image**: `mcr.microsoft.com/devcontainers/go:2-1.26` — provides Go, git, devcontainer infrastructure
+2. **Tool installation**: `install-dependencies.sh devcontainer` — installs gofumpt, golangci-lint, go-task
+3. **Module cache**: `COPY go.mod go.sum` + `go mod download` — pre-populates Go module cache
+4. **Shell config**: go-task bash completions
+
+### devcontainer.json
+
+Defines the VS Code devcontainer experience:
+
+- **Build context**: Points to Dockerfile with repo root as context
+- **Extensions**: Go, Task, YAML, GitHub PR extensions
+- **Settings**: Format on save, golangci-lint, organize imports
+- **Runtime**: Debug-friendly `runArgs`, `vscode` user
+
+### install-dependencies.sh
+
+Dual-mode script (devcontainer vs local install) that installs:
+
+- gofumpt (via `go install`)
+- golangci-lint (via curl installer script)
+- go-task (via curl tarball)
+
+### Dockerfile.dockerignore
+
+Restricts Docker build context to only necessary files:
+
+- `.devcontainer/install-dependencies.sh`
+- `go.mod`, `go.sum` (root level)
+
+## Relationships
+
+```
+devcontainer.json
+  └── references → Dockerfile (build.dockerfile)
+        ├── invokes → install-dependencies.sh
+        └── copies → go.mod, go.sum (for module pre-download)
+
+Dockerfile.dockerignore
+  └── filters → Docker build context (allow-list pattern)
+```
+
+## State / Lifecycle
+
+No runtime state. The devcontainer is either:
+- **Not built**: Container image doesn't exist yet
+- **Building**: Docker is executing Dockerfile layers
+- **Running**: Container is active, all tools available
+- **Stale**: `go.mod`/`go.sum` changed since last build; needs rebuild to refresh module cache

--- a/specs/002-add-devcontainer/plan.md
+++ b/specs/002-add-devcontainer/plan.md
@@ -1,0 +1,68 @@
+# Implementation Plan: Add Devcontainer
+
+**Branch**: `002-add-devcontainer` | **Date**: 2026-04-05 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/002-add-devcontainer/spec.md`
+
+## Summary
+
+Adapt the Azure Service Operator devcontainer for code-visualizer by stripping all ASO-specific tooling (Azure CLI, Kubernetes, Docker-in-Docker, etc.) and retaining only Go 1.26, golangci-lint, gofumpt, and go-task. Simplify the Dockerfile, install-dependencies.sh, devcontainer.json, and dockerignore to match the single-module Go CLI project structure. Pre-populate the Go module cache at image build time.
+
+## Technical Context
+
+**Language/Version**: Docker, Bash, JSON (devcontainer config); Go 1.26 (project language)  
+**Primary Dependencies**: `mcr.microsoft.com/devcontainers/go:2-1.26` base image  
+**Storage**: N/A  
+**Testing**: Manual verification — `task ci` (build, test, lint) inside container  
+**Target Platform**: Linux container (amd64/arm64), VS Code Dev Containers  
+**Project Type**: CLI tool (devcontainer is infrastructure, not application code)  
+**Performance Goals**: Container builds in reasonable time; first `go build` requires no network  
+**Constraints**: Minimal image — no ASO-specific tools; no Docker-in-Docker  
+**Scale/Scope**: 4 configuration files to modify
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle            | Applies? | Status | Notes                                                                    |
+| -------------------- | -------- | ------ | ------------------------------------------------------------------------ |
+| I. Test-First        | Partial  | PASS   | No production Go code — config files verified via `task ci` in container |
+| II. API-First        | No       | PASS   | No public Go interfaces introduced                                       |
+| III. Type Safety     | No       | PASS   | Configuration files only                                                 |
+| IV. Simplicity/YAGNI | Yes      | PASS   | Spec explicitly requires stripping to minimum; no speculative tooling    |
+| V. Performance       | Partial  | PASS   | Paring down reduces build time; module pre-download speeds first-run     |
+| VI. Accessibility    | No       | PASS   | N/A for infrastructure                                                   |
+| VII. Observability   | No       | PASS   | N/A for infrastructure                                                   |
+| VIII. Documentation  | Yes      | PASS   | quickstart.md provides usage guidance                                    |
+
+**Post-Phase 1 re-check**: All principles remain satisfied. No gate violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-add-devcontainer/
+├── plan.md                              # This file
+├── research.md                          # Phase 0: ASO removal inventory, decisions
+├── data-model.md                        # Phase 1: Configuration artifact relationships
+├── quickstart.md                        # Phase 1: How to use the devcontainer
+├── contracts/
+│   └── devcontainer-contract.md         # Phase 1: Environment guarantees
+└── tasks.md                             # Phase 2 output (not created by plan)
+```
+
+### Source Code (repository root)
+
+```text
+.devcontainer/
+├── Dockerfile                 # Container image definition (to be simplified)
+├── Dockerfile.dockerignore    # Build context filter (to be updated for root module)
+├── devcontainer.json          # VS Code devcontainer config (to be updated)
+└── install-dependencies.sh    # Tool installer script (to be simplified)
+```
+
+**Structure Decision**: All changes are within the existing `.devcontainer/` directory. No new directories or project structure changes needed. The four files are already present (copied from ASO) and need modification, not creation.
+
+## Complexity Tracking
+
+No constitution violations to justify. This feature is straightforward infrastructure configuration.

--- a/specs/002-add-devcontainer/quickstart.md
+++ b/specs/002-add-devcontainer/quickstart.md
@@ -1,0 +1,53 @@
+# Quickstart: Devcontainer
+
+## Prerequisites
+
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) or a compatible container runtime
+- [VS Code](https://code.visualstudio.com/) with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+
+## Opening the Devcontainer
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/theunrepentantgeek/code-visualizer.git
+   cd code-visualizer
+   ```
+
+2. Open in VS Code:
+   ```bash
+   code .
+   ```
+
+3. When prompted "Reopen in Container", click **Reopen in Container**.
+   - Alternatively, open the Command Palette (`Ctrl+Shift+P`) and select **Dev Containers: Reopen in Container**.
+
+4. Wait for the container to build (first time only — subsequent opens use the cached image).
+
+5. Verify the environment:
+   ```bash
+   task ci
+   ```
+   This runs build, test, and lint — all should pass.
+
+## What's Included
+
+The devcontainer provides:
+- **Go 1.26** — matching the project's `go.mod`
+- **golangci-lint** — for linting (`task lint`)
+- **gofumpt** — for formatting (`task fmt`)
+- **go-task** — for running Taskfile commands
+- **Pre-downloaded Go modules** — first build doesn't need network access
+
+## Working Without the Devcontainer
+
+The devcontainer is optional. The project works with standard Go tooling:
+
+```bash
+# Install dependencies manually
+go install mvdan.cc/gofumpt@latest
+# Install golangci-lint: https://golangci-lint.run/welcome/install/
+# Install task: https://taskfile.dev/installation/
+
+# Then use normally
+task ci
+```

--- a/specs/002-add-devcontainer/research.md
+++ b/specs/002-add-devcontainer/research.md
@@ -1,0 +1,177 @@
+# Research: Add Devcontainer
+
+**Feature**: 002-add-devcontainer  
+**Date**: 2026-04-05
+
+## R1: ASO Components to Remove
+
+### Decision: Remove all ASO-specific tooling and configuration
+
+### Rationale
+
+The ASO devcontainer was designed for a large Kubernetes operator project. code-visualizer is a Go CLI tool with no Azure, Kubernetes, or Docker dependencies. Every ASO-specific component adds build time, image size, and maintenance burden without any benefit.
+
+### Inventory of ASO-specific components
+
+#### Dockerfile — APT packages to REMOVE
+
+| Package               | ASO Purpose                          | code-visualizer Need |
+| --------------------- | ------------------------------------ | -------------------- |
+| docker-ce-cli         | Docker-from-docker pattern for CI    | None                 |
+| docker-compose-plugin | Docker compose for integration tests | None                 |
+| azure-cli             | Azure resource management            | None                 |
+| graphviz              | DOT graph generation in ASO          | None                 |
+| nodejs, npm           | Hugo docs site tooling (PostCSS)     | None                 |
+| python3-pip           | Python virtualenv for tooling        | None                 |
+| gnuplot               | Performance graphing                 | None                 |
+
+#### Dockerfile — APT packages to KEEP
+
+| Package         | Reason                                                           |
+| --------------- | ---------------------------------------------------------------- |
+| bash-completion | Developer convenience in terminal                                |
+| lsb-release     | Used during APT setup (can be dropped if Docker repo is removed) |
+
+**Note**: `lsb-release` is only needed for the Docker APT repo setup. Since we're removing Docker CLI, the entire Docker APT repo block can be removed, and `lsb-release` is no longer needed either. Only `bash-completion` is worth keeping, and it's likely already in the base image.
+
+#### Dockerfile — Sections to REMOVE entirely
+
+- Docker APT repository setup (GPG key, sources list, docker-ce-cli install)
+- Azure CLI installation
+- `install-dependencies.sh` invocation (script will be replaced or eliminated)
+- ASO multi-module `go mod download` block (v2/, v2/cmd/asoctl/, etc.)
+- envtest setup (`setup-envtest use`, `KUBEBUILDER_ASSETS` env)
+- kubectl completions (alias, completion, source)
+- `KIND_CLUSTER_NAME=aso` env var
+- Docker group setup (`groupadd docker`, `usermod -aG docker vscode`)
+- `CMD ["sleep", "infinity"]`
+
+#### Dockerfile — Sections to ADD or MODIFY
+
+- Simple `go mod download` for the single root module (COPY go.mod go.sum, RUN go mod download)
+- go-task completion setup (keep from ASO)
+- gofumpt installation (keep, via `go install`)
+- golangci-lint installation (keep, via curl installer)
+- go-task installation (keep, via curl)
+
+#### install-dependencies.sh — Tools to REMOVE
+
+| Tool           | ASO Purpose                       |
+| -------------- | --------------------------------- |
+| conversion-gen | Kubernetes CRD code generation    |
+| controller-gen | Kubernetes controller scaffolding |
+| kind           | Local Kubernetes clusters         |
+| kustomize      | Kubernetes manifest management    |
+| hugo           | ASO documentation site            |
+| htmltest       | HTML link checking for docs       |
+| crddoc         | CRD documentation generator       |
+| go-vcr-tidy    | VCR test recording cleanup        |
+| setup-envtest  | Kubernetes envtest binary setup   |
+| helm           | Kubernetes package manager        |
+| yq             | YAML processing                   |
+| cmctl          | cert-manager CLI                  |
+| docker-buildx  | Docker multi-arch builds          |
+| azwi           | Azure Workload Identity CLI       |
+| postcss        | Hugo CSS processing               |
+| Trivy          | Container security scanning       |
+
+#### install-dependencies.sh — Tools to KEEP
+
+| Tool          | Version | Reason                                     |
+| ------------- | ------- | ------------------------------------------ |
+| gofumpt       | latest  | Go formatting (required by Taskfile)       |
+| golangci-lint | v2.8.0  | Go linting (required by Taskfile)          |
+| go-task       | v3.49.1 | Build orchestration (required by Taskfile) |
+
+#### install-dependencies.sh — Sections to REMOVE
+
+- Azure CLI check (`command -v az`)
+- Pip3 check (`command -v pip3`)
+- `KUBEBUILDER_DEST` and `BUILDX_DEST` variables
+- Webhook certs setup
+- Python virtualenv installation
+- All ASO-specific go-install calls
+
+#### devcontainer.json — Changes needed
+
+| Field                                                     | Current (ASO)                  | Target (code-visualizer) |
+| --------------------------------------------------------- | ------------------------------ | ------------------------ |
+| `name`                                                    | "Azure Service Operator"       | "Code Visualizer"        |
+| Extensions: `ms-azuretools.vscode-docker`                 | Remove                         | —                        |
+| Extensions: `ms-kubernetes-tools.vscode-kubernetes-tools` | Remove                         | —                        |
+| Extensions: `redhat.vscode-yaml`                          | Keep (useful for YAML editing) | —                        |
+| `mounts` (Docker socket)                                  | Remove                         | —                        |
+| `overrideCommand`                                         | Remove (not needed)            | —                        |
+
+#### Dockerfile.dockerignore — Changes needed
+
+- Remove all `v2/` paths
+- Add `!go.mod` and `!go.sum` at root level
+
+### Alternatives considered
+
+1. **Keep install-dependencies.sh as-is, just remove tools**: Rejected — the script has complex ASO-specific logic (kubebuilder dest, buildx dest, az/pip3 checks) that would be dead code.
+2. **Eliminate install-dependencies.sh entirely, inline in Dockerfile**: Preferred for simplicity — the remaining tools (gofumpt, golangci-lint, go-task) can be installed directly in the Dockerfile with fewer layers. However, keeping the script preserves the dual-mode pattern (devcontainer vs local install) which may be useful later.
+3. **Keep install-dependencies.sh but simplify**: Best balance — retains the useful shell structure and dual-mode capability while removing all ASO content.
+
+**Decision**: Simplify `install-dependencies.sh` to only install gofumpt, golangci-lint, and go-task. Keep the dual-mode structure (devcontainer vs local) and the helper functions (`should-install`, `go-install`, `write-info`, etc.) as they are well-written and useful.
+
+## R2: Go Module Cache Pre-population
+
+### Decision: Use simple COPY + `go mod download` pattern
+
+### Rationale
+
+code-visualizer has a single Go module at the repository root with no replace directives. The ASO pattern of copying multiple `go.mod`/`go.sum` files from nested modules is unnecessary.
+
+### Approach
+
+```dockerfile
+# Pre-download Go modules
+COPY go.mod go.sum /tmp/mod-download/
+RUN cd /tmp/mod-download && go mod download && rm -rf /tmp/mod-download
+```
+
+This leverages Docker layer caching: the module download layer only rebuilds when `go.mod` or `go.sum` change, not on every source code change.
+
+### Alternatives considered
+
+1. **Mount go module cache as a volume**: Rejected — module cache wouldn't persist across container rebuilds, defeating the purpose.
+2. **Use go build cache instead**: Rejected — module download is the bottleneck for first-run, not compilation.
+3. **Skip pre-population entirely**: Rejected — spec FR-005 requires it.
+
+## R3: Devcontainer Base Image
+
+### Decision: Keep `mcr.microsoft.com/devcontainers/go:2-1.26`
+
+### Rationale
+
+The Microsoft Go devcontainer base image provides:
+- Go 1.26 pre-installed (matching `go.mod`)
+- Standard devcontainer infrastructure (user `vscode`, sudo, git, etc.)
+- Multi-arch support (amd64/arm64)
+- Dependabot-trackable version tag
+
+The `2-` prefix is the devcontainer image version (v2), and `1.26` is the Go version. This matches the project's `go 1.26.1` in `go.mod`.
+
+### Alternatives considered
+
+1. **Official Go image (`golang:1.26`)**: Rejected — lacks devcontainer infrastructure (vscode user, SSH, etc.).
+2. **Build from scratch**: Rejected — unnecessary complexity for no benefit.
+
+## R4: Devcontainer runArgs
+
+### Decision: Keep `--cap-add=SYS_PTRACE`, `--security-opt seccomp=unconfined`, `--init`
+
+### Rationale
+
+- `SYS_PTRACE`: Required for Go's `dlv` debugger to attach to processes. Standard for Go devcontainers.
+- `seccomp=unconfined`: Required for `dlv` debugger. Without this, ptrace-based debugging fails.
+- `--init`: Ensures proper signal handling and zombie process cleanup. Good practice for any container.
+
+These are not ASO-specific; they're standard Go devcontainer settings.
+
+### Alternatives considered
+
+1. **Remove all runArgs**: Rejected — would break Go debugging in the container.
+2. **Add only `--init`**: Rejected — debugging is a core developer workflow.

--- a/specs/002-add-devcontainer/spec.md
+++ b/specs/002-add-devcontainer/spec.md
@@ -1,0 +1,93 @@
+# Feature Specification: Add Devcontainer
+
+**Feature Branch**: `002-add-devcontainer`  
+**Created**: 2026-04-05  
+**Status**: Draft  
+**Input**: User description: "Add a devcontainer as described in GH issue #5."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Open Project in Devcontainer (Priority: P1)
+
+A contributor clones the repository and opens it in VS Code. VS Code detects the devcontainer configuration and prompts them to reopen in the container. After the container builds, the contributor has a fully working development environment with all required tools preinstalled and the Go module cache populated, ready to build, test, and lint without any manual setup.
+
+**Why this priority**: This is the core value of the feature — eliminating manual setup and ensuring every contributor has an identical, working environment from the start.
+
+**Independent Test**: Can be fully tested by opening the repository in a devcontainer and running `task ci` (build, test, lint) successfully without any additional setup steps.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh clone of the repository, **When** a contributor opens the project in VS Code and reopens in the devcontainer, **Then** the container builds successfully and all required tools are available.
+2. **Given** a running devcontainer, **When** the contributor runs `task ci`, **Then** the build, test, and lint steps all pass without errors.
+3. **Given** a running devcontainer, **When** the contributor opens a Go file, **Then** the Go language server, linting, and formatting work correctly in the editor.
+
+---
+
+### User Story 2 - Pare Down from ASO Devcontainer (Priority: P1)
+
+The devcontainer is based on the Azure Service Operator devcontainer structure but stripped down to only include the tools and configuration relevant to this project. ASO-specific dependencies (Azure CLI, Kubernetes tools, Docker-in-Docker, envtest, kind, controller-gen, etc.) are removed, leaving only what code-visualizer needs: Go, golangci-lint, gofumpt, go-task, and relevant VS Code extensions.
+
+**Why this priority**: Equally critical to P1 — an overly bloated container increases build time, image size, and maintenance burden, directly undermining the value of having a devcontainer.
+
+**Independent Test**: Can be tested by verifying the Dockerfile does not install ASO-specific tools, and that the resulting container image is significantly smaller than the ASO devcontainer.
+
+**Acceptance Scenarios**:
+
+1. **Given** the devcontainer configuration, **When** the container is built, **Then** it does not contain Azure CLI, Kubernetes tools, Docker CLI, envtest, kind, controller-gen, or other ASO-specific dependencies.
+2. **Given** the devcontainer configuration, **When** the container is built, **Then** it contains Go, golangci-lint, gofumpt, and go-task.
+3. **Given** the devcontainer configuration, **When** reviewed, **Then** the devcontainer.json name, extensions, settings, and mounts are appropriate for code-visualizer (not ASO).
+
+---
+
+### User Story 3 - Pre-populated Go Module Cache (Priority: P2)
+
+When the devcontainer finishes building, the Go module cache is already populated with the project's dependencies. This means the first `go build` or `go test` does not need to download modules, making the initial development experience faster.
+
+**Why this priority**: A nice-to-have optimization that improves the first-run experience but is not essential for the devcontainer to be functional.
+
+**Independent Test**: Can be tested by opening the devcontainer and running `go build ./...` and confirming no modules are downloaded during the build.
+
+**Acceptance Scenarios**:
+
+1. **Given** a freshly built devcontainer, **When** the contributor runs `go build ./...`, **Then** no module downloads occur because they are already cached.
+2. **Given** the Dockerfile, **When** the project's `go.mod` or `go.sum` changes, **Then** rebuilding the devcontainer picks up the updated dependencies.
+
+---
+
+### Edge Cases
+
+- What happens when the contributor's machine does not have Docker installed? The devcontainer cannot be used; the project must remain buildable without the devcontainer using standard Go tooling.
+- What happens when the container image base is updated (e.g., new Go version)? The Dockerfile should use a versioned base image tag so updates are intentional and trackable (e.g., via Dependabot).
+- What happens when the Dockerfile.dockerignore is not aligned with the project structure? Only the files needed for the container build (devcontainer scripts, go.mod, go.sum) should be allowed through; everything else should be ignored for build performance.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The devcontainer MUST provide a working Go development environment with the same Go version specified in the project's `go.mod`.
+- **FR-002**: The devcontainer MUST include golangci-lint, gofumpt, and go-task preinstalled and available on the PATH.
+- **FR-003**: The devcontainer MUST configure VS Code with the Go extension, Task extension, and appropriate editor settings (format on save, organize imports on save, golangci-lint as the lint tool).
+- **FR-004**: The devcontainer MUST NOT include ASO-specific tools or configuration (Azure CLI, Kubernetes tools, Docker-in-Docker, envtest, kind, controller-gen, etc.).
+- **FR-005**: The devcontainer MUST pre-download Go modules so the first build does not require a network fetch.
+- **FR-006**: The `Dockerfile.dockerignore` MUST be updated to match the project's structure (single `go.mod`/`go.sum` at root, no `v2/` subtree).
+- **FR-007**: The `devcontainer.json` MUST use a project-appropriate name (not "Azure Service Operator").
+- **FR-008**: The devcontainer MUST NOT require Docker-in-Docker or mount the host Docker socket.
+- **FR-009**: The project MUST remain fully buildable and testable outside the devcontainer using standard Go tooling.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A new contributor can go from cloning the repository to a passing `task ci` run in under 5 minutes (excluding container image download time).
+- **SC-002**: The devcontainer image contains only tools relevant to this project — no ASO-specific dependencies remain.
+- **SC-003**: All existing tests pass inside the devcontainer (`task test` exits with 0).
+- **SC-004**: VS Code language features (IntelliSense, formatting, linting) work correctly inside the devcontainer without additional manual configuration.
+- **SC-005**: The first `go build` inside a freshly built container completes without downloading any modules.
+
+## Assumptions
+
+- Contributors use VS Code (or a compatible editor with devcontainer support such as GitHub Codespaces) as their primary development environment.
+- Contributors have Docker (or a compatible container runtime) installed on their machine.
+- The devcontainer is not required for CI — CI has its own environment setup. The devcontainer is purely for local development convenience.
+- The existing Taskfile.yml commands (`task build`, `task test`, `task lint`, etc.) are the standard way to interact with the project and should work identically inside and outside the devcontainer.
+- The Go devcontainer base image from Microsoft (`mcr.microsoft.com/devcontainers/go`) is used as the foundation, consistent with the ASO model.

--- a/specs/002-add-devcontainer/tasks.md
+++ b/specs/002-add-devcontainer/tasks.md
@@ -61,7 +61,7 @@ _(No tasks — proceed directly to Phase 2)_
 
 **Purpose**: Final validation and documentation alignment
 
-- [ ] T008 Verify `task ci` passes inside the built devcontainer (manual validation)
+- [ ] T008 Verify `task ci` passes both inside the built devcontainer and outside it (manual validation, covers FR-009)
 - [ ] T009 [P] Run quickstart.md validation — confirm the steps in `specs/002-add-devcontainer/quickstart.md` match the actual devcontainer experience
 
 ---
@@ -125,4 +125,4 @@ T009 (in parallel with T008)
 
 1. Complete Phase 2 (T001–T006) → Core devcontainer building and working
 2. Complete Phase 3 (T007) → Module cache pre-populated
-3. Complete Phase 4 (T007–T008) → Validated and documented
+3. Complete Phase 4 (T008–T009) → Validated and documented

--- a/specs/002-add-devcontainer/tasks.md
+++ b/specs/002-add-devcontainer/tasks.md
@@ -31,13 +31,13 @@ _(No tasks — proceed directly to Phase 2)_
 
 ### Implementation
 
-- [ ] T001 [P] [US1] [US2] Update devcontainer name, extensions, mounts, and remove ASO-specific settings in `.devcontainer/devcontainer.json`
-- [ ] T002 [P] [US1] [US2] Strip ASO APT packages (Azure CLI, Docker CLI, nodejs, npm, python3-pip, graphviz, gnuplot) and remove envtest, kubectl, kind, and Docker group setup from `.devcontainer/Dockerfile`
-- [ ] T003 [P] [US1] [US2] Simplify install-dependencies.sh to only install gofumpt, golangci-lint, and go-task; remove all ASO tools, az/pip3 checks, kubebuilder/buildx dest, webhook certs, and python virtualenv from `.devcontainer/install-dependencies.sh`
-- [ ] T004 [P] [US1] [US2] Update Dockerfile.dockerignore to reference root-level go.mod/go.sum instead of v2/ paths in `.devcontainer/Dockerfile.dockerignore`
-- [ ] T005 [US1] Configure git safe.directory for /workspace in postCreateCommand in `.devcontainer/devcontainer.json`
+- [x] T001 [P] [US1] [US2] Update devcontainer name, extensions, mounts, and remove ASO-specific settings in `.devcontainer/devcontainer.json`
+- [x] T002 [P] [US1] [US2] Strip ASO APT packages (Azure CLI, Docker CLI, nodejs, npm, python3-pip, graphviz, gnuplot) and remove envtest, kubectl, kind, and Docker group setup from `.devcontainer/Dockerfile`
+- [x] T003 [P] [US1] [US2] Simplify install-dependencies.sh to only install gofumpt, golangci-lint, and go-task; remove all ASO tools, az/pip3 checks, kubebuilder/buildx dest, webhook certs, and python virtualenv from `.devcontainer/install-dependencies.sh`
+- [x] T004 [P] [US1] [US2] Update Dockerfile.dockerignore to reference root-level go.mod/go.sum instead of v2/ paths in `.devcontainer/Dockerfile.dockerignore`
+- [x] T005 [US1] Configure git safe.directory for /workspace in postCreateCommand in `.devcontainer/devcontainer.json`
 
-- [ ] T006 [US1] [US2] Run `docker build -f .devcontainer/Dockerfile .` to verify the container image builds successfully after ASO stripping
+- [x] T006 [US1] [US2] Run `docker build -f .devcontainer/Dockerfile .` to verify the container image builds successfully after ASO stripping
 
 **Checkpoint**: At this point, the devcontainer configuration should be clean of all ASO content and properly configured for code-visualizer. Container should build successfully.
 
@@ -51,7 +51,7 @@ _(No tasks — proceed directly to Phase 2)_
 
 ### Implementation
 
-- [ ] T007 [US3] Replace ASO multi-module COPY/download block with single-module `COPY go.mod go.sum` + `go mod download` in `.devcontainer/Dockerfile`
+- [x] T007 [US3] Replace ASO multi-module COPY/download block with single-module `COPY go.mod go.sum` + `go mod download` in `.devcontainer/Dockerfile`
 
 **Checkpoint**: First `go build` inside the container completes without downloading modules.
 
@@ -61,8 +61,8 @@ _(No tasks — proceed directly to Phase 2)_
 
 **Purpose**: Final validation and documentation alignment
 
-- [ ] T008 Verify `task ci` passes both inside the built devcontainer and outside it (manual validation, covers FR-009)
-- [ ] T009 [P] Run quickstart.md validation — confirm the steps in `specs/002-add-devcontainer/quickstart.md` match the actual devcontainer experience
+- [x] T008 Verify `task ci` passes both inside the built devcontainer and outside it (manual validation, covers FR-009)
+- [x] T009 [P] Run quickstart.md validation — confirm the steps in `specs/002-add-devcontainer/quickstart.md` match the actual devcontainer experience
 
 ---
 

--- a/specs/002-add-devcontainer/tasks.md
+++ b/specs/002-add-devcontainer/tasks.md
@@ -1,0 +1,128 @@
+# Tasks: Add Devcontainer
+
+**Input**: Design documents from `/specs/002-add-devcontainer/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/devcontainer-contract.md, quickstart.md
+
+**Tests**: Not required — this feature involves configuration files only. Verification is manual (`task ci` inside the container).
+
+**Organization**: US1 (working devcontainer) and US2 (strip ASO) are both P1 and deeply intertwined — stripping ASO tooling IS the work of making the devcontainer correct. They are combined into a single phase. US3 (module cache) is a separate P2 phase.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No setup needed — the `.devcontainer/` directory and all four files already exist (copied from ASO). This feature is entirely about modifying existing files.
+
+_(No tasks — proceed directly to Phase 2)_
+
+---
+
+## Phase 2: User Stories 1 & 2 — Working Devcontainer with ASO Stripped (Priority: P1)
+
+**Goal**: Simplify the ASO devcontainer so it provides a minimal, working Go development environment for code-visualizer with no ASO-specific tooling.
+
+**Independent Test**: Open the project in the devcontainer, run `task ci`, and confirm build/test/lint all pass. Verify no ASO-specific tools are present.
+
+### Implementation
+
+- [ ] T001 [P] [US1] [US2] Update devcontainer name, extensions, mounts, and remove ASO-specific settings in `.devcontainer/devcontainer.json`
+- [ ] T002 [P] [US1] [US2] Strip ASO APT packages (Azure CLI, Docker CLI, nodejs, npm, python3-pip, graphviz, gnuplot) and remove envtest, kubectl, kind, and Docker group setup from `.devcontainer/Dockerfile`
+- [ ] T003 [P] [US1] [US2] Simplify install-dependencies.sh to only install gofumpt, golangci-lint, and go-task; remove all ASO tools, az/pip3 checks, kubebuilder/buildx dest, webhook certs, and python virtualenv from `.devcontainer/install-dependencies.sh`
+- [ ] T004 [P] [US1] [US2] Update Dockerfile.dockerignore to reference root-level go.mod/go.sum instead of v2/ paths in `.devcontainer/Dockerfile.dockerignore`
+- [ ] T005 [US1] Configure git safe.directory for /workspace in postCreateCommand in `.devcontainer/devcontainer.json`
+
+- [ ] T006 [US1] [US2] Run `docker build -f .devcontainer/Dockerfile .` to verify the container image builds successfully after ASO stripping
+
+**Checkpoint**: At this point, the devcontainer configuration should be clean of all ASO content and properly configured for code-visualizer. Container should build successfully.
+
+---
+
+## Phase 3: User Story 3 — Pre-populated Go Module Cache (Priority: P2)
+
+**Goal**: Pre-download Go modules during container build so the first `go build` or `go test` requires no network access.
+
+**Independent Test**: Open the devcontainer, run `go build ./...`, and confirm no module downloads occur.
+
+### Implementation
+
+- [ ] T007 [US3] Replace ASO multi-module COPY/download block with single-module `COPY go.mod go.sum` + `go mod download` in `.devcontainer/Dockerfile`
+
+**Checkpoint**: First `go build` inside the container completes without downloading modules.
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation and documentation alignment
+
+- [ ] T008 Verify `task ci` passes inside the built devcontainer (manual validation)
+- [ ] T009 [P] Run quickstart.md validation — confirm the steps in `specs/002-add-devcontainer/quickstart.md` match the actual devcontainer experience
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: Skipped — files already exist
+- **Phase 2 (US1 & US2)**: No dependencies — can start immediately
+- **Phase 3 (US3)**: Can run in parallel with Phase 2 (different Dockerfile section) but logically depends on the Dockerfile being cleaned up in T002 first
+- **Phase 4 (Polish)**: Depends on Phases 2 and 3 being complete
+
+### Within Phase 2
+
+- T001, T002, T003, T004 are all [P] — they modify different files and can be done in parallel
+- T005 depends on T001 (modifies the same file: devcontainer.json)
+- T006 depends on T001–T005 (builds the image to verify all edits)
+
+### Task File Mapping
+
+| Task       | File                                       |
+| ---------- | ------------------------------------------ |
+| T001, T005 | `.devcontainer/devcontainer.json`          |
+| T002, T007 | `.devcontainer/Dockerfile`                 |
+| T003       | `.devcontainer/install-dependencies.sh`    |
+| T004       | `.devcontainer/Dockerfile.dockerignore`    |
+| T006       | `docker build` verification (no file edit) |
+| T008       | Manual verification (no file)              |
+| T009       | `specs/002-add-devcontainer/quickstart.md` |
+
+### Parallel Opportunities
+
+```
+T001 ─┐
+T002 ─┤ (all in parallel — different files)
+T003 ─┤
+T004 ─┘
+  │
+T005 (after T001 — same file)
+  │
+T006 (docker build — verifies T001–T005)
+T007 (after T002 — same file, module cache)
+  │
+T008 (after all implementation tasks)
+T009 (in parallel with T008)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (Phase 2 Only)
+
+1. Complete T001–T005 (strip ASO, configure for code-visualizer)
+2. Run T006 (`docker build`) to verify the image builds
+3. **STOP and VALIDATE**: Open in devcontainer, run `task ci`
+4. If passing, the devcontainer is usable — module pre-caching (Phase 3) is a bonus
+
+### Full Delivery
+
+1. Complete Phase 2 (T001–T006) → Core devcontainer building and working
+2. Complete Phase 3 (T007) → Module cache pre-populated
+3. Complete Phase 4 (T007–T008) → Validated and documented


### PR DESCRIPTION
This pull request introduces a complete, minimal devcontainer setup for the project, enabling a reproducible development environment using Docker and VS Code. It adds and configures all necessary files to support Go 1.26 development with strict linting, formatting, and build tooling,. The devcontainer ensures all developers have a consistent, ready-to-code workspace, with pre-installed tools and pre-cached Go modules for faster onboarding.
