### PR TITLE
Use int64 for quantity metrics

### DIFF
--- a/cmd/codeviz/main_test.go
+++ b/cmd/codeviz/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -13,7 +12,7 @@ import (
 
 func TestMain(m *testing.M) {
 	filesystem.Register()
-	os.Exit(m.Run())
+	m.Run()
 }
 
 func TestClassifyNoFilesAfterFilterError(t *testing.T) {

--- a/internal/model/directory.go
+++ b/internal/model/directory.go
@@ -14,13 +14,13 @@ type Directory struct {
 	Dirs  []*Directory
 
 	mu              sync.RWMutex
-	quantities      map[metric.Name]int
+	quantities      map[metric.Name]int64
 	measures        map[metric.Name]float64
 	classifications map[metric.Name]string
 }
 
-// Quantity returns the int value for the named metric and whether it was set.
-func (d *Directory) Quantity(name metric.Name) (int, bool) {
+// Quantity returns the int64 value for the named metric and whether it was set.
+func (d *Directory) Quantity(name metric.Name) (int64, bool) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
@@ -49,13 +49,13 @@ func (d *Directory) Classification(name metric.Name) (string, bool) {
 	return v, ok
 }
 
-// SetQuantity stores an int metric value identified by name.
-func (d *Directory) SetQuantity(name metric.Name, v int) {
+// SetQuantity stores an int64 metric value identified by name.
+func (d *Directory) SetQuantity(name metric.Name, v int64) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
 	if d.quantities == nil {
-		d.quantities = make(map[metric.Name]int)
+		d.quantities = make(map[metric.Name]int64)
 	}
 
 	d.quantities[name] = v

--- a/internal/model/directory_test.go
+++ b/internal/model/directory_test.go
@@ -16,7 +16,7 @@ func TestDirectorySetAndGetQuantity(t *testing.T) {
 
 	v, ok := d.Quantity("folder-size")
 	g.Expect(ok).To(BeTrue())
-	g.Expect(v).To(Equal(9999))
+	g.Expect(v).To(Equal(int64(9999)))
 }
 
 func TestDirectoryGetUnsetMetric(t *testing.T) {

--- a/internal/model/file.go
+++ b/internal/model/file.go
@@ -15,13 +15,13 @@ type File struct {
 	IsBinary  bool
 
 	mu              sync.RWMutex
-	quantities      map[metric.Name]int
+	quantities      map[metric.Name]int64
 	measures        map[metric.Name]float64
 	classifications map[metric.Name]string
 }
 
-// Quantity returns the int value for the named metric and whether it was set.
-func (f *File) Quantity(name metric.Name) (int, bool) {
+// Quantity returns the int64 value for the named metric and whether it was set.
+func (f *File) Quantity(name metric.Name) (int64, bool) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
@@ -50,13 +50,13 @@ func (f *File) Classification(name metric.Name) (string, bool) {
 	return v, ok
 }
 
-// SetQuantity stores an int metric value identified by name.
-func (f *File) SetQuantity(name metric.Name, v int) {
+// SetQuantity stores an int64 metric value identified by name.
+func (f *File) SetQuantity(name metric.Name, v int64) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
 	if f.quantities == nil {
-		f.quantities = make(map[metric.Name]int)
+		f.quantities = make(map[metric.Name]int64)
 	}
 
 	f.quantities[name] = v

--- a/internal/model/file_test.go
+++ b/internal/model/file_test.go
@@ -17,7 +17,7 @@ func TestFileSetAndGetQuantity(t *testing.T) {
 
 	v, ok := f.Quantity("file-size")
 	g.Expect(ok).To(BeTrue())
-	g.Expect(v).To(Equal(1024))
+	g.Expect(v).To(Equal(int64(1024)))
 }
 
 func TestFileSetAndGetMeasure(t *testing.T) {
@@ -72,7 +72,7 @@ func TestFileConcurrentAccess(t *testing.T) {
 
 	wg.Go(func() {
 		for i := range 100 {
-			f.SetQuantity("size", i)
+			f.SetQuantity("size", int64(i))
 		}
 	})
 
@@ -86,7 +86,7 @@ func TestFileConcurrentAccess(t *testing.T) {
 
 	v, ok := f.Quantity("size")
 	g.Expect(ok).To(BeTrue())
-	g.Expect(v).To(Equal(99))
+	g.Expect(v).To(Equal(int64(99)))
 
 	s, ok := f.Classification("type")
 	g.Expect(ok).To(BeTrue())

--- a/internal/provider/filesystem/metrics.go
+++ b/internal/provider/filesystem/metrics.go
@@ -74,7 +74,7 @@ func (FileLinesProvider) Load(root *model.Directory) error {
 
 var errBinaryFile = errors.New("file appears to be binary (line exceeds 64KB)")
 
-func countLines(path string) (int, error) {
+func countLines(path string) (int64, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return 0, eris.Wrap(err, "opening file for line count")
@@ -83,7 +83,7 @@ func countLines(path string) (int, error) {
 
 	scanner := bufio.NewScanner(file)
 
-	count := 0
+	var count int64
 	for scanner.Scan() {
 		count++
 	}

--- a/internal/provider/filesystem/metrics_test.go
+++ b/internal/provider/filesystem/metrics_test.go
@@ -59,11 +59,11 @@ func TestFileLinesProvider(t *testing.T) {
 
 	v1, ok := f1.Quantity(FileLines)
 	g.Expect(ok).To(BeTrue())
-	g.Expect(v1).To(Equal(3))
+	g.Expect(v1).To(Equal(int64(3)))
 
 	v2, ok := f2.Quantity(FileLines)
 	g.Expect(ok).To(BeTrue())
-	g.Expect(v2).To(Equal(1))
+	g.Expect(v2).To(Equal(int64(1)))
 }
 
 func TestFileLinesProviderSkipsBinaryFiles(t *testing.T) {
@@ -110,5 +110,5 @@ func TestFileLinesProviderNestedDirs(t *testing.T) {
 
 	v, ok := f.Quantity(FileLines)
 	g.Expect(ok).To(BeTrue())
-	g.Expect(v).To(Equal(2))
+	g.Expect(v).To(Equal(int64(2)))
 }

--- a/internal/provider/git/metrics_test.go
+++ b/internal/provider/git/metrics_test.go
@@ -155,12 +155,12 @@ func TestAuthorCountProvider(t *testing.T) {
 	// shared.go: 2 authors (Alice + Bob)
 	count, ok := root.Files[0].Quantity(AuthorCount)
 	g.Expect(ok).To(BeTrue())
-	g.Expect(count).To(Equal(2))
+	g.Expect(count).To(Equal(int64(2)))
 
 	// old.go: 1 author (Alice)
 	count, ok = root.Files[1].Quantity(AuthorCount)
 	g.Expect(ok).To(BeTrue())
-	g.Expect(count).To(Equal(1))
+	g.Expect(count).To(Equal(int64(1)))
 }
 
 func TestGitProviderNotAGitRepo(t *testing.T) {

--- a/internal/provider/git/service.go
+++ b/internal/provider/git/service.go
@@ -58,7 +58,7 @@ func resetService() {
 
 var errUntracked = errors.New("file has no git history")
 
-func (s *repoService) fileAge(relPath string) (int, error) {
+func (s *repoService) fileAge(relPath string) (int64, error) {
 	commits, err := s.fileCommitTimes(relPath)
 	if err != nil {
 		return 0, err
@@ -71,10 +71,10 @@ func (s *repoService) fileAge(relPath string) (int, error) {
 	oldest := commits[len(commits)-1]
 	age := time.Since(oldest)
 
-	return int(age.Seconds()), nil
+	return int64(age.Seconds()), nil
 }
 
-func (s *repoService) fileFreshness(relPath string) (int, error) {
+func (s *repoService) fileFreshness(relPath string) (int64, error) {
 	commits, err := s.fileCommitTimes(relPath)
 	if err != nil {
 		return 0, err
@@ -87,10 +87,10 @@ func (s *repoService) fileFreshness(relPath string) (int, error) {
 	newest := commits[0]
 	freshness := time.Since(newest)
 
-	return int(freshness.Seconds()), nil
+	return int64(freshness.Seconds()), nil
 }
 
-func (s *repoService) authorCount(relPath string) (int, error) {
+func (s *repoService) authorCount(relPath string) (int64, error) {
 	log, err := s.repo.Log(&gogit.LogOptions{FileName: &relPath})
 	if err != nil {
 		return 0, eris.Wrap(err, "failed to get git log")
@@ -112,7 +112,7 @@ func (s *repoService) authorCount(relPath string) (int, error) {
 		return 0, errUntracked
 	}
 
-	return len(authors), nil
+	return int64(len(authors)), nil
 }
 
 func (s *repoService) fileCommitTimes(relPath string) ([]time.Time, error) {

--- a/internal/render/renderer_test.go
+++ b/internal/render/renderer_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/bevan/code-visualizer/internal/treemap"
 )
 
-func makeFile(name, ext string, size int) *model.File {
+func makeFile(name, ext string, size int64) *model.File {
 	f := &model.File{Name: name, Extension: ext}
 	f.SetQuantity(filesystem.FileSize, size)
 	f.SetClassification(filesystem.FileType, ext)

--- a/internal/scan/scanner.go
+++ b/internal/scan/scanner.go
@@ -136,7 +136,7 @@ func processFile(node *model.Directory, entry os.DirEntry, info os.FileInfo, ent
 		Extension: ext,
 	}
 
-	f.SetQuantity(filesystem.FileSize, int(info.Size()))
+	f.SetQuantity(filesystem.FileSize, info.Size())
 	f.SetClassification(filesystem.FileType, fileType)
 
 	node.Files = append(node.Files, f)

--- a/internal/scan/scanner_test.go
+++ b/internal/scan/scanner_test.go
@@ -31,7 +31,7 @@ func TestScanFlat(t *testing.T) {
 	g.Expect(root.Files).To(HaveLen(3))
 	g.Expect(root.Dirs).To(BeEmpty())
 
-	sizes := map[string]int{}
+	sizes := map[string]int64{}
 
 	for _, f := range root.Files {
 		v, ok := f.Quantity(filesystem.FileSize)
@@ -40,9 +40,9 @@ func TestScanFlat(t *testing.T) {
 		sizes[f.Name] = v
 	}
 
-	g.Expect(sizes["small.txt"]).To(Equal(5))
-	g.Expect(sizes["medium.go"]).To(Equal(100))
-	g.Expect(sizes["large.rs"]).To(Equal(1000))
+	g.Expect(sizes["small.txt"]).To(Equal(int64(5)))
+	g.Expect(sizes["medium.go"]).To(Equal(int64(100)))
+	g.Expect(sizes["large.rs"]).To(Equal(int64(1000)))
 }
 
 func TestScanNested(t *testing.T) {

--- a/internal/treemap/layout_test.go
+++ b/internal/treemap/layout_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/bevan/code-visualizer/internal/provider/filesystem"
 )
 
-func makeFile(name string, size int) *model.File {
+func makeFile(name string, size int64) *model.File {
 	f := &model.File{Name: name}
 	f.SetQuantity(filesystem.FileSize, size)
 


### PR DESCRIPTION
Change all quantity metric storage and accessors from int to int64 to avoid lossy downcasting, particularly from os.FileInfo.Size() which returns int64 natively.

Fixes #27