### PR TITLE
fix: sort distinct types for deterministic palette selection

### DIFF
--- a/cmd/codeviz/main_test.go
+++ b/cmd/codeviz/main_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"github.com/bevan/code-visualizer/internal/metric"
 	"github.com/bevan/code-visualizer/internal/model"
 	"github.com/bevan/code-visualizer/internal/provider/filesystem"
 	"github.com/bevan/code-visualizer/internal/scan"
@@ -139,4 +140,31 @@ func TestTreemapCmd_Validate_ValidFilters(t *testing.T) {
 
 	err := cmd.Validate()
 	g.Expect(err).NotTo(HaveOccurred())
+}
+
+func TestCollectDistinctTypes_ReturnsSortedTypes(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	// Arrange - files with different file types added in non-alphabetical order
+	fZ := &model.File{Path: "/p/z.go", Name: "z.go"}
+	fZ.SetClassification(filesystem.FileType, "go")
+
+	fA := &model.File{Path: "/p/a.md", Name: "a.md"}
+	fA.SetClassification(filesystem.FileType, "md")
+
+	fM := &model.File{Path: "/p/m.txt", Name: "m.txt"}
+	fM.SetClassification(filesystem.FileType, "txt")
+
+	root := &model.Directory{
+		Path:  "/p",
+		Name:  "p",
+		Files: []*model.File{fZ, fA, fM},
+	}
+
+	// Act
+	types := collectDistinctTypes(root, metric.Name(filesystem.FileType))
+
+	// Assert
+	g.Expect(types).To(Equal([]string{"go", "md", "txt"}))
 }

--- a/cmd/codeviz/main_test.go
+++ b/cmd/codeviz/main_test.go
@@ -163,7 +163,7 @@ func TestCollectDistinctTypes_ReturnsSortedTypes(t *testing.T) {
 	}
 
 	// Act
-	types := collectDistinctTypes(root, metric.Name(filesystem.FileType))
+	types := collectDistinctTypes(root, filesystem.FileType)
 
 	// Assert
 	g.Expect(types).To(Equal([]string{"go", "md", "txt"}))

--- a/cmd/codeviz/main_test.go
+++ b/cmd/codeviz/main_test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"github.com/bevan/code-visualizer/internal/metric"
 	"github.com/bevan/code-visualizer/internal/model"
 	"github.com/bevan/code-visualizer/internal/provider/filesystem"
 	"github.com/bevan/code-visualizer/internal/scan"

--- a/cmd/codeviz/treemap_cmd.go
+++ b/cmd/codeviz/treemap_cmd.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/rotisserie/eris"
 
@@ -488,6 +489,8 @@ func collectDistinctTypes(root *model.Directory, m metric.Name) []string {
 	for t := range seen {
 		types = append(types, t)
 	}
+
+	sort.Strings(types)
 
 	return types
 }


### PR DESCRIPTION
collectDistinctTypes iterated over a Go map, whose iteration order is non-deterministic, causing the CategoricalMapper to assign different colours to file types on each run.

Sort the collected types slice alphabetically before returning it so the palette assignment is stable across runs.

Fixes #31