### PR TITLE
fix: restore vscode ownership of Go module cache in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,5 +17,7 @@ RUN task --completion bash > "/etc/.task.completion.sh" \
     && echo 'source /etc/.task.completion.sh' >> "/etc/bash.bashrc"
 
 # Pre-download Go modules for faster builds
+# Run as root, then fix ownership so the vscode user can write to the module cache
 COPY go.mod go.sum /tmp/mod-download/
-RUN cd /tmp/mod-download && go mod download && rm -rf /tmp/mod-download
+RUN cd /tmp/mod-download && go mod download && rm -rf /tmp/mod-download \
+    && chown -R vscode:golang /go/pkg


### PR DESCRIPTION
## Problem

The `go mod download` step in the Dockerfile runs as root, creating `/go/pkg/mod` owned by root. Because the container starts as the `vscode` user (`remoteUser: vscode`), the module cache ends up read-only — causing permission errors when compiling or adding new dependencies.

## Fix

Add `chown -R vscode:golang /go/pkg` after the download step, matching the ownership set by the base image on `/go` itself.

Closes #29