### PR TITLE
Display available metrics when unknown metric is specified

### DIFF
--- a/cmd/codeviz/treemap_cmd.go
+++ b/cmd/codeviz/treemap_cmd.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/rotisserie/eris"
 
@@ -42,7 +43,7 @@ type TreemapCmd struct {
 func (c *TreemapCmd) Validate() error {
 	p, ok := provider.Get(c.Size)
 	if !ok {
-		return eris.Errorf("unknown size metric %q", c.Size)
+		return eris.Errorf("unknown size metric %q; available metrics: %s", c.Size, formatMetricNames())
 	}
 
 	if p.Kind() != metric.Quantity {
@@ -73,7 +74,7 @@ func (c *TreemapCmd) Validate() error {
 func validateMetricPalette(metricStr, paletteStr, label string) error {
 	if metricStr != "" {
 		if _, ok := provider.Get(metric.Name(metricStr)); !ok {
-			return eris.Errorf("invalid %s metric %q", label, metricStr)
+			return eris.Errorf("invalid %s metric %q; available metrics: %s", label, metricStr, formatMetricNames())
 		}
 	}
 
@@ -85,6 +86,17 @@ func validateMetricPalette(metricStr, paletteStr, label string) error {
 	}
 
 	return nil
+}
+
+func formatMetricNames() string {
+	names := provider.Names()
+	strs := make([]string, len(names))
+
+	for i, n := range names {
+		strs[i] = string(n)
+	}
+
+	return strings.Join(strs, ", ")
 }
 
 func collectRequestedMetrics(size metric.Name, fill, border string) []metric.Name {

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/bevan/code-visualizer/internal/metric"
@@ -49,6 +50,25 @@ func (r *registry) all() []Interface {
 	return result
 }
 
+func (r *registry) names() []metric.Name {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]string, 0, len(r.providers))
+	for n := range r.providers {
+		result = append(result, string(n))
+	}
+
+	sort.Strings(result)
+
+	names := make([]metric.Name, len(result))
+	for i, n := range result {
+		names[i] = metric.Name(n)
+	}
+
+	return names
+}
+
 // globalRegistry is the process-wide provider registry.
 var globalRegistry = newRegistry()
 
@@ -60,6 +80,9 @@ func Get(name metric.Name) (Interface, bool) { return globalRegistry.get(name) }
 
 // All returns all registered providers.
 func All() []Interface { return globalRegistry.all() }
+
+// Names returns the sorted names of all registered providers.
+func Names() []metric.Name { return globalRegistry.names() }
 
 // ResetRegistryForTesting clears the global registry. Test use only.
 func ResetRegistryForTesting() {

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -1,8 +1,10 @@
 package provider
 
 import (
+	"cmp"
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 	"sync"
 
 	"github.com/bevan/code-visualizer/internal/metric"
@@ -42,10 +44,12 @@ func (r *registry) all() []Interface {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	result := make([]Interface, 0, len(r.providers))
-	for _, p := range r.providers {
-		result = append(result, p)
-	}
+	result := slices.Collect(maps.Values(r.providers))
+	slices.SortFunc(
+		result,
+		func(left Interface, right Interface) int {
+			return cmp.Compare(left.Name(), right.Name())
+		})
 
 	return result
 }
@@ -54,17 +58,9 @@ func (r *registry) names() []metric.Name {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	result := make([]string, 0, len(r.providers))
-	for n := range r.providers {
-		result = append(result, string(n))
-	}
+	names := slices.Collect(maps.Keys(r.providers))
 
-	sort.Strings(result)
-
-	names := make([]metric.Name, len(result))
-	for i, n := range result {
-		names[i] = metric.Name(n)
-	}
+	slices.SortFunc(names, cmp.Compare)
 
 	return names
 }

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -74,3 +74,16 @@ func TestRegisterDuplicatePanics(t *testing.T) {
 		reg.register(&stubProvider{name: "dup", kind: metric.Quantity})
 	}).To(Panic())
 }
+
+func TestNamesSorted(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	reg := newRegistry()
+	reg.register(&stubProvider{name: "zebra", kind: metric.Quantity})
+	reg.register(&stubProvider{name: "alpha", kind: metric.Quantity})
+	reg.register(&stubProvider{name: "mid", kind: metric.Quantity})
+
+	names := reg.names()
+	g.Expect(names).To(Equal([]metric.Name{"alpha", "mid", "zebra"}))
+}

--- a/internal/provider/run.go
+++ b/internal/provider/run.go
@@ -1,6 +1,8 @@
 package provider
 
 import (
+	"strings"
+
 	"github.com/rotisserie/eris"
 	"golang.org/x/sync/errgroup"
 
@@ -70,7 +72,7 @@ func visitDep(reg *registry, name metric.Name, seen map[metric.Name]bool, result
 
 	p, ok := reg.get(name)
 	if !ok || p == nil {
-		return eris.Errorf("unknown metric %q — no provider registered", name)
+		return eris.Errorf("unknown metric %q; available metrics: %s", name, formatNames(reg.names()))
 	}
 
 	seen[name] = true
@@ -174,4 +176,13 @@ func findReady(names []metric.Name, inDegree map[metric.Name]int) []metric.Name 
 	}
 
 	return level
+}
+
+func formatNames(names []metric.Name) string {
+	strs := make([]string, len(names))
+	for i, n := range names {
+		strs[i] = string(n)
+	}
+
+	return strings.Join(strs, ", ")
 }

--- a/internal/provider/run_test.go
+++ b/internal/provider/run_test.go
@@ -129,6 +129,19 @@ func TestRunUnknownRequestedMetric(t *testing.T) {
 	g.Expect(err).To(MatchError(ContainSubstring("unknown metric")))
 }
 
+func TestRunUnknownMetricListsAvailable(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	reg := newRegistry()
+	reg.register(&mockProvider{name: "alpha", kind: metric.Quantity})
+	reg.register(&mockProvider{name: "beta", kind: metric.Quantity})
+
+	err := runWithRegistry(reg, nil, []metric.Name{"nonexistent"})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(MatchError(ContainSubstring("available metrics: alpha, beta")))
+}
+
 func TestRunErrorPropagation(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)


### PR DESCRIPTION
## Summary

When a user specifies an unknown metric — either on the command line or in a config file — error messages now include a sorted list of all available metrics so the user can easily correct their configuration.

Closes #36

## Changes

- **`internal/provider/registry.go`** — Added `names()` method (and public `Names()`) that returns sorted metric names from the registry
- **`internal/provider/run.go`** — Updated `visitDep()` error message to include available metrics list
- **`cmd/codeviz/treemap_cmd.go`** — Updated `Validate()` and `validateMetricPalette()` error messages to include available metrics list
- **`internal/provider/registry_test.go`** — Added test for `names()` sorted output
- **`internal/provider/run_test.go`** — Added test verifying unknown metric errors list available metrics

## Example

Before:
```
unknown metric "foo" — no provider registered
```

After:
```
unknown metric "foo"; available metrics: author-count, file-age, file-freshness, file-lines, file-size, file-type
```