### PR TITLE
Extend provider capabilities and add new metrics

### DIFF
--- a/cmd/codeviz/main.go
+++ b/cmd/codeviz/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bevan/code-visualizer/internal/metric"
 	"github.com/bevan/code-visualizer/internal/model"
 	"github.com/bevan/code-visualizer/internal/provider/filesystem"
+	"github.com/bevan/code-visualizer/internal/provider/folder"
 	"github.com/bevan/code-visualizer/internal/provider/git"
 )
 
@@ -60,6 +61,7 @@ func countAll(node *model.Directory) (files int, dirs int) {
 func main() {
 	filesystem.Register()
 	git.Register()
+	folder.Register()
 
 	cli := CLI{}
 

--- a/internal/model/walk.go
+++ b/internal/model/walk.go
@@ -10,3 +10,13 @@ func WalkFiles(dir *Directory, fn func(*File)) {
 		WalkFiles(d, fn)
 	}
 }
+
+// WalkDirectories calls fn for every directory in the tree, post-order (deepest first).
+// This ensures child directories are visited before their parents, enabling bottom-up aggregation.
+func WalkDirectories(dir *Directory, fn func(*Directory)) {
+	for _, d := range dir.Dirs {
+		WalkDirectories(d, fn)
+	}
+
+	fn(dir)
+}

--- a/internal/model/walk_test.go
+++ b/internal/model/walk_test.go
@@ -1,0 +1,67 @@
+package model
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestWalkDirectoriesPostOrder(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	leaf1 := &Directory{Path: "/root/a/leaf1", Name: "leaf1"}
+	leaf2 := &Directory{Path: "/root/a/leaf2", Name: "leaf2"}
+	a := &Directory{Path: "/root/a", Name: "a", Dirs: []*Directory{leaf1, leaf2}}
+	b := &Directory{Path: "/root/b", Name: "b"}
+	root := &Directory{Path: "/root", Name: "root", Dirs: []*Directory{a, b}}
+
+	var visited []string
+
+	WalkDirectories(root, func(d *Directory) {
+		visited = append(visited, d.Name)
+	})
+
+	// Post-order: leaves before parents, root last
+	g.Expect(visited).To(Equal([]string{"leaf1", "leaf2", "a", "b", "root"}))
+}
+
+func TestWalkDirectoriesLeafOnly(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := &Directory{Path: "/root", Name: "root"}
+
+	var visited []string
+
+	WalkDirectories(root, func(d *Directory) {
+		visited = append(visited, d.Name)
+	})
+
+	g.Expect(visited).To(Equal([]string{"root"}))
+}
+
+func TestWalkDirectoriesIncludesRoot(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	child := &Directory{Path: "/root/child", Name: "child"}
+	root := &Directory{Path: "/root", Name: "root", Dirs: []*Directory{child}}
+
+	var visited []string
+
+	WalkDirectories(root, func(d *Directory) {
+		visited = append(visited, d.Name)
+	})
+
+	g.Expect(visited).To(ContainElement("root"))
+	g.Expect(visited).To(ContainElement("child"))
+
+	if len(visited) < 2 {
+		return
+	}
+
+	// child must appear before root (post-order)
+	g.Expect(visited[0]).To(Equal("child"))
+	g.Expect(visited[1]).To(Equal("root"))
+}

--- a/internal/provider/filesystem/metrics.go
+++ b/internal/provider/filesystem/metrics.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bevan/code-visualizer/internal/metric"
 	"github.com/bevan/code-visualizer/internal/model"
 	"github.com/bevan/code-visualizer/internal/palette"
+	"github.com/bevan/code-visualizer/internal/provider"
 )
 
 // Metric name constants for filesystem metrics.
@@ -26,6 +27,8 @@ type FileSizeProvider struct{}
 
 func (FileSizeProvider) Name() metric.Name                   { return FileSize }
 func (FileSizeProvider) Kind() metric.Kind                   { return metric.Quantity }
+func (FileSizeProvider) Scope() provider.Scope               { return provider.ScopeFile }
+func (FileSizeProvider) Description() string                 { return "Size in bytes" }
 func (FileSizeProvider) Dependencies() []metric.Name         { return nil }
 func (FileSizeProvider) DefaultPalette() palette.PaletteName { return palette.Neutral }
 func (FileSizeProvider) Load(_ *model.Directory) error       { return nil }
@@ -35,6 +38,8 @@ type FileTypeProvider struct{}
 
 func (FileTypeProvider) Name() metric.Name                   { return FileType }
 func (FileTypeProvider) Kind() metric.Kind                   { return metric.Classification }
+func (FileTypeProvider) Scope() provider.Scope               { return provider.ScopeFile }
+func (FileTypeProvider) Description() string                 { return "File extension, normalized to lowercase" }
 func (FileTypeProvider) Dependencies() []metric.Name         { return nil }
 func (FileTypeProvider) DefaultPalette() palette.PaletteName { return palette.Categorization }
 func (FileTypeProvider) Load(_ *model.Directory) error       { return nil }
@@ -44,6 +49,8 @@ type FileLinesProvider struct{}
 
 func (FileLinesProvider) Name() metric.Name                   { return FileLines }
 func (FileLinesProvider) Kind() metric.Kind                   { return metric.Quantity }
+func (FileLinesProvider) Scope() provider.Scope               { return provider.ScopeFile }
+func (FileLinesProvider) Description() string                 { return "Number of text lines in the file" }
 func (FileLinesProvider) Dependencies() []metric.Name         { return nil }
 func (FileLinesProvider) DefaultPalette() palette.PaletteName { return palette.Neutral }
 

--- a/internal/provider/filesystem/metrics_test.go
+++ b/internal/provider/filesystem/metrics_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bevan/code-visualizer/internal/metric"
 	"github.com/bevan/code-visualizer/internal/model"
+	"github.com/bevan/code-visualizer/internal/provider"
 )
 
 func TestFileSizeProvider(t *testing.T) {
@@ -18,6 +19,8 @@ func TestFileSizeProvider(t *testing.T) {
 	p := FileSizeProvider{}
 	g.Expect(p.Name()).To(Equal(FileSize))
 	g.Expect(p.Kind()).To(Equal(metric.Quantity))
+	g.Expect(p.Scope()).To(Equal(provider.ScopeFile))
+	g.Expect(p.Description()).NotTo(BeEmpty())
 	g.Expect(p.Dependencies()).To(BeNil())
 
 	root := &model.Directory{Path: "/root", Name: "root"}
@@ -31,6 +34,8 @@ func TestFileTypeProvider(t *testing.T) {
 	p := FileTypeProvider{}
 	g.Expect(p.Name()).To(Equal(FileType))
 	g.Expect(p.Kind()).To(Equal(metric.Classification))
+	g.Expect(p.Scope()).To(Equal(provider.ScopeFile))
+	g.Expect(p.Description()).NotTo(BeEmpty())
 	g.Expect(p.Dependencies()).To(BeNil())
 
 	root := &model.Directory{Path: "/root", Name: "root"}
@@ -54,6 +59,8 @@ func TestFileLinesProvider(t *testing.T) {
 	}
 
 	p := FileLinesProvider{}
+	g.Expect(p.Scope()).To(Equal(provider.ScopeFile))
+	g.Expect(p.Description()).NotTo(BeEmpty())
 	err := p.Load(root)
 	g.Expect(err).NotTo(HaveOccurred())
 

--- a/internal/provider/folder/filesystem_metrics.go
+++ b/internal/provider/folder/filesystem_metrics.go
@@ -24,17 +24,7 @@ func (*TotalFolderLinesProvider) Dependencies() []metric.Name {
 func (*TotalFolderLinesProvider) DefaultPalette() palette.PaletteName { return palette.Neutral }
 
 func (*TotalFolderLinesProvider) Load(root *model.Directory) error {
-	model.WalkDirectories(root, func(d *model.Directory) {
-		total, found := sumQuantityFromFiles(d, filesystem.FileLines)
-		if v, ok := sumQuantityFromDirs(d, TotalFolderLines); ok {
-			total += v
-			found = true
-		}
-
-		if found {
-			d.SetQuantity(TotalFolderLines, total)
-		}
-	})
+	loadSumQuantity(root, filesystem.FileLines, TotalFolderLines)
 
 	return nil
 }
@@ -55,17 +45,7 @@ func (*TotalFolderSizeProvider) Dependencies() []metric.Name {
 func (*TotalFolderSizeProvider) DefaultPalette() palette.PaletteName { return palette.Neutral }
 
 func (*TotalFolderSizeProvider) Load(root *model.Directory) error {
-	model.WalkDirectories(root, func(d *model.Directory) {
-		total, found := sumQuantityFromFiles(d, filesystem.FileSize)
-		if v, ok := sumQuantityFromDirs(d, TotalFolderSize); ok {
-			total += v
-			found = true
-		}
-
-		if found {
-			d.SetQuantity(TotalFolderSize, total)
-		}
-	})
+	loadSumQuantity(root, filesystem.FileSize, TotalFolderSize)
 
 	return nil
 }
@@ -77,7 +57,7 @@ func (*MeanFileLinesProvider) Name() metric.Name     { return MeanFileLines }
 func (*MeanFileLinesProvider) Kind() metric.Kind     { return metric.Measure }
 func (*MeanFileLinesProvider) Scope() provider.Scope { return provider.ScopeFolder }
 func (*MeanFileLinesProvider) Description() string {
-	return "Mean count of file lines in all contained text files, including nested folders"
+	return "Mean count of file lines in all contained text files, including nested folders; skips binary files"
 }
 
 func (*MeanFileLinesProvider) Dependencies() []metric.Name {
@@ -86,20 +66,7 @@ func (*MeanFileLinesProvider) Dependencies() []metric.Name {
 func (*MeanFileLinesProvider) DefaultPalette() palette.PaletteName { return palette.Neutral }
 
 func (*MeanFileLinesProvider) Load(root *model.Directory) error {
-	stats := make(map[string]*sumCount)
-
-	model.WalkDirectories(root, func(d *model.Directory) {
-		sc := &sumCount{}
-
-		addPositiveSumCountFromFiles(sc, d, filesystem.FileLines)
-		addSumCountFromDirs(sc, d, stats)
-
-		stats[d.Path] = sc
-
-		if sc.count > 0 {
-			d.SetMeasure(MeanFileLines, sc.sum/float64(sc.count))
-		}
-	})
+	loadPositiveMeanMeasure(root, filesystem.FileLines, MeanFileLines)
 
 	return nil
 }
@@ -117,20 +84,7 @@ func (*MeanFileSizeProvider) Dependencies() []metric.Name         { return []met
 func (*MeanFileSizeProvider) DefaultPalette() palette.PaletteName { return palette.Neutral }
 
 func (*MeanFileSizeProvider) Load(root *model.Directory) error {
-	stats := make(map[string]*sumCount)
-
-	model.WalkDirectories(root, func(d *model.Directory) {
-		sc := &sumCount{}
-
-		addSumCountFromFiles(sc, d, filesystem.FileSize)
-		addSumCountFromDirs(sc, d, stats)
-
-		stats[d.Path] = sc
-
-		if sc.count > 0 {
-			d.SetMeasure(MeanFileSize, sc.sum/float64(sc.count))
-		}
-	})
+	loadMeanMeasure(root, filesystem.FileSize, MeanFileSize)
 
 	return nil
 }

--- a/internal/provider/folder/filesystem_metrics.go
+++ b/internal/provider/folder/filesystem_metrics.go
@@ -1,0 +1,136 @@
+package folder
+
+import (
+	"github.com/bevan/code-visualizer/internal/metric"
+	"github.com/bevan/code-visualizer/internal/model"
+	"github.com/bevan/code-visualizer/internal/palette"
+	"github.com/bevan/code-visualizer/internal/provider"
+	"github.com/bevan/code-visualizer/internal/provider/filesystem"
+)
+
+// TotalFolderLinesProvider sums the line counts of all text files in a folder.
+type TotalFolderLinesProvider struct{}
+
+func (*TotalFolderLinesProvider) Name() metric.Name     { return TotalFolderLines }
+func (*TotalFolderLinesProvider) Kind() metric.Kind     { return metric.Quantity }
+func (*TotalFolderLinesProvider) Scope() provider.Scope { return provider.ScopeFolder }
+func (*TotalFolderLinesProvider) Description() string {
+	return "Total number of text lines in all contained files, including nested folders"
+}
+
+func (*TotalFolderLinesProvider) Dependencies() []metric.Name {
+	return []metric.Name{filesystem.FileLines}
+}
+func (*TotalFolderLinesProvider) DefaultPalette() palette.PaletteName { return palette.Neutral }
+
+func (*TotalFolderLinesProvider) Load(root *model.Directory) error {
+	model.WalkDirectories(root, func(d *model.Directory) {
+		total, found := sumQuantityFromFiles(d, filesystem.FileLines)
+		if v, ok := sumQuantityFromDirs(d, TotalFolderLines); ok {
+			total += v
+			found = true
+		}
+
+		if found {
+			d.SetQuantity(TotalFolderLines, total)
+		}
+	})
+
+	return nil
+}
+
+// TotalFolderSizeProvider sums the file sizes of all files in a folder.
+type TotalFolderSizeProvider struct{}
+
+func (*TotalFolderSizeProvider) Name() metric.Name     { return TotalFolderSize }
+func (*TotalFolderSizeProvider) Kind() metric.Kind     { return metric.Quantity }
+func (*TotalFolderSizeProvider) Scope() provider.Scope { return provider.ScopeFolder }
+func (*TotalFolderSizeProvider) Description() string {
+	return "Total Size in bytes of all contained files, including nested folders"
+}
+
+func (*TotalFolderSizeProvider) Dependencies() []metric.Name {
+	return []metric.Name{filesystem.FileSize}
+}
+func (*TotalFolderSizeProvider) DefaultPalette() palette.PaletteName { return palette.Neutral }
+
+func (*TotalFolderSizeProvider) Load(root *model.Directory) error {
+	model.WalkDirectories(root, func(d *model.Directory) {
+		total, found := sumQuantityFromFiles(d, filesystem.FileSize)
+		if v, ok := sumQuantityFromDirs(d, TotalFolderSize); ok {
+			total += v
+			found = true
+		}
+
+		if found {
+			d.SetQuantity(TotalFolderSize, total)
+		}
+	})
+
+	return nil
+}
+
+// MeanFileLinesProvider reports the mean line count of text files in a folder, skipping binary files.
+type MeanFileLinesProvider struct{}
+
+func (*MeanFileLinesProvider) Name() metric.Name     { return MeanFileLines }
+func (*MeanFileLinesProvider) Kind() metric.Kind     { return metric.Measure }
+func (*MeanFileLinesProvider) Scope() provider.Scope { return provider.ScopeFolder }
+func (*MeanFileLinesProvider) Description() string {
+	return "Mean count of file lines in all contained text files, including nested folders"
+}
+
+func (*MeanFileLinesProvider) Dependencies() []metric.Name {
+	return []metric.Name{filesystem.FileLines}
+}
+func (*MeanFileLinesProvider) DefaultPalette() palette.PaletteName { return palette.Neutral }
+
+func (*MeanFileLinesProvider) Load(root *model.Directory) error {
+	stats := make(map[string]*sumCount)
+
+	model.WalkDirectories(root, func(d *model.Directory) {
+		sc := &sumCount{}
+
+		addPositiveSumCountFromFiles(sc, d, filesystem.FileLines)
+		addSumCountFromDirs(sc, d, stats)
+
+		stats[d.Path] = sc
+
+		if sc.count > 0 {
+			d.SetMeasure(MeanFileLines, sc.sum/float64(sc.count))
+		}
+	})
+
+	return nil
+}
+
+// MeanFileSizeProvider reports the mean file size in bytes of all files in a folder.
+type MeanFileSizeProvider struct{}
+
+func (*MeanFileSizeProvider) Name() metric.Name     { return MeanFileSize }
+func (*MeanFileSizeProvider) Kind() metric.Kind     { return metric.Measure }
+func (*MeanFileSizeProvider) Scope() provider.Scope { return provider.ScopeFolder }
+func (*MeanFileSizeProvider) Description() string {
+	return "Mean size in bytes of all files, including nested folders"
+}
+func (*MeanFileSizeProvider) Dependencies() []metric.Name         { return []metric.Name{filesystem.FileSize} }
+func (*MeanFileSizeProvider) DefaultPalette() palette.PaletteName { return palette.Neutral }
+
+func (*MeanFileSizeProvider) Load(root *model.Directory) error {
+	stats := make(map[string]*sumCount)
+
+	model.WalkDirectories(root, func(d *model.Directory) {
+		sc := &sumCount{}
+
+		addSumCountFromFiles(sc, d, filesystem.FileSize)
+		addSumCountFromDirs(sc, d, stats)
+
+		stats[d.Path] = sc
+
+		if sc.count > 0 {
+			d.SetMeasure(MeanFileSize, sc.sum/float64(sc.count))
+		}
+	})
+
+	return nil
+}

--- a/internal/provider/folder/git_metrics.go
+++ b/internal/provider/folder/git_metrics.go
@@ -22,7 +22,10 @@ func (*FolderAuthorCountProvider) Scope() provider.Scope { return provider.Scope
 func (*FolderAuthorCountProvider) Description() string {
 	return "Count of distinct authors who have contributed to folder"
 }
-func (*FolderAuthorCountProvider) Dependencies() []metric.Name         { return nil }
+
+func (*FolderAuthorCountProvider) Dependencies() []metric.Name {
+	return []metric.Name{gitprovider.AuthorCount}
+}
 func (*FolderAuthorCountProvider) DefaultPalette() palette.PaletteName { return palette.GoodBad }
 
 func (*FolderAuthorCountProvider) Load(root *model.Directory) error {
@@ -113,17 +116,7 @@ func (*FolderAgeProvider) Dependencies() []metric.Name         { return []metric
 func (*FolderAgeProvider) DefaultPalette() palette.PaletteName { return palette.Temperature }
 
 func (*FolderAgeProvider) Load(root *model.Directory) error {
-	model.WalkDirectories(root, func(d *model.Directory) {
-		maxVal, found := maxQuantityFromFiles(d, gitprovider.FileAge)
-		if v, ok := maxQuantityFromDirs(d, FolderAge); ok && (!found || v > maxVal) {
-			maxVal = v
-			found = true
-		}
-
-		if found {
-			d.SetQuantity(FolderAge, maxVal)
-		}
-	})
+	loadMaxQuantity(root, gitprovider.FileAge, FolderAge)
 
 	return nil
 }
@@ -144,17 +137,7 @@ func (*FolderFreshnessProvider) Dependencies() []metric.Name {
 func (*FolderFreshnessProvider) DefaultPalette() palette.PaletteName { return palette.Temperature }
 
 func (*FolderFreshnessProvider) Load(root *model.Directory) error {
-	model.WalkDirectories(root, func(d *model.Directory) {
-		minVal, found := minQuantityFromFiles(d, gitprovider.FileFreshness)
-		if v, ok := minQuantityFromDirs(d, FolderFreshness); ok && (!found || v < minVal) {
-			minVal = v
-			found = true
-		}
-
-		if found {
-			d.SetQuantity(FolderFreshness, minVal)
-		}
-	})
+	loadMinQuantity(root, gitprovider.FileFreshness, FolderFreshness)
 
 	return nil
 }
@@ -172,20 +155,7 @@ func (*MeanFileAgeProvider) Dependencies() []metric.Name         { return []metr
 func (*MeanFileAgeProvider) DefaultPalette() palette.PaletteName { return palette.Temperature }
 
 func (*MeanFileAgeProvider) Load(root *model.Directory) error {
-	stats := make(map[string]*sumCount)
-
-	model.WalkDirectories(root, func(d *model.Directory) {
-		sc := &sumCount{}
-
-		addSumCountFromFiles(sc, d, gitprovider.FileAge)
-		addSumCountFromDirs(sc, d, stats)
-
-		stats[d.Path] = sc
-
-		if sc.count > 0 {
-			d.SetMeasure(MeanFileAge, sc.sum/float64(sc.count))
-		}
-	})
+	loadMeanMeasure(root, gitprovider.FileAge, MeanFileAge)
 
 	return nil
 }
@@ -206,20 +176,7 @@ func (*MeanFileFreshnessProvider) Dependencies() []metric.Name {
 func (*MeanFileFreshnessProvider) DefaultPalette() palette.PaletteName { return palette.Temperature }
 
 func (*MeanFileFreshnessProvider) Load(root *model.Directory) error {
-	stats := make(map[string]*sumCount)
-
-	model.WalkDirectories(root, func(d *model.Directory) {
-		sc := &sumCount{}
-
-		addSumCountFromFiles(sc, d, gitprovider.FileFreshness)
-		addSumCountFromDirs(sc, d, stats)
-
-		stats[d.Path] = sc
-
-		if sc.count > 0 {
-			d.SetMeasure(MeanFileFreshness, sc.sum/float64(sc.count))
-		}
-	})
+	loadMeanMeasure(root, gitprovider.FileFreshness, MeanFileFreshness)
 
 	return nil
 }

--- a/internal/provider/folder/git_metrics.go
+++ b/internal/provider/folder/git_metrics.go
@@ -1,0 +1,225 @@
+package folder
+
+import (
+	"log/slog"
+	"path/filepath"
+
+	"github.com/rotisserie/eris"
+
+	"github.com/bevan/code-visualizer/internal/metric"
+	"github.com/bevan/code-visualizer/internal/model"
+	"github.com/bevan/code-visualizer/internal/palette"
+	"github.com/bevan/code-visualizer/internal/provider"
+	gitprovider "github.com/bevan/code-visualizer/internal/provider/git"
+)
+
+// FolderAuthorCountProvider reports the count of distinct authors across all files in a folder.
+type FolderAuthorCountProvider struct{}
+
+func (*FolderAuthorCountProvider) Name() metric.Name     { return FolderAuthorCount }
+func (*FolderAuthorCountProvider) Kind() metric.Kind     { return metric.Quantity }
+func (*FolderAuthorCountProvider) Scope() provider.Scope { return provider.ScopeFolder }
+func (*FolderAuthorCountProvider) Description() string {
+	return "Count of distinct authors who have contributed to folder"
+}
+func (*FolderAuthorCountProvider) Dependencies() []metric.Name         { return nil }
+func (*FolderAuthorCountProvider) DefaultPalette() palette.PaletteName { return palette.GoodBad }
+
+func (*FolderAuthorCountProvider) Load(root *model.Directory) error {
+	if err := gitprovider.VerifyRepository(root.Path); err != nil {
+		return eris.Wrap(err, "folder-author-count requires a git repository")
+	}
+
+	fileAuthors := collectFileAuthors(root)
+	applyFolderAuthorCounts(root, fileAuthors)
+
+	return nil
+}
+
+// collectFileAuthors walks all files and returns a map of file path → set of author emails.
+func collectFileAuthors(root *model.Directory) map[string]map[string]bool {
+	fileAuthors := make(map[string]map[string]bool)
+
+	model.WalkFiles(root, func(f *model.File) {
+		relPath, err := filepath.Rel(root.Path, f.Path)
+		if err != nil {
+			slog.Warn("could not compute relative path", "path", f.Path, "error", err)
+
+			return
+		}
+
+		authors, err := gitprovider.FileAuthors(root.Path, relPath)
+		if err != nil {
+			slog.Debug("could not get file authors", "path", relPath, "error", err)
+
+			return
+		}
+
+		if len(authors) > 0 {
+			fileAuthors[f.Path] = authors
+		}
+	})
+
+	return fileAuthors
+}
+
+// applyFolderAuthorCounts sets folder-author-count on every directory using bottom-up union.
+func applyFolderAuthorCounts(root *model.Directory, fileAuthors map[string]map[string]bool) {
+	dirAuthors := make(map[string]map[string]bool)
+
+	model.WalkDirectories(root, func(d *model.Directory) {
+		all := unionAuthors(d, fileAuthors, dirAuthors)
+		dirAuthors[d.Path] = all
+
+		if len(all) > 0 {
+			d.SetQuantity(FolderAuthorCount, int64(len(all)))
+		}
+	})
+}
+
+// unionAuthors builds the union of author sets from direct files and subdirs of d.
+func unionAuthors(
+	d *model.Directory,
+	fileAuthors map[string]map[string]bool,
+	dirAuthors map[string]map[string]bool,
+) map[string]bool {
+	all := make(map[string]bool)
+
+	for _, f := range d.Files {
+		for author := range fileAuthors[f.Path] {
+			all[author] = true
+		}
+	}
+
+	for _, sub := range d.Dirs {
+		for author := range dirAuthors[sub.Path] {
+			all[author] = true
+		}
+	}
+
+	return all
+}
+
+// FolderAgeProvider reports days since the oldest file in the folder was first committed.
+type FolderAgeProvider struct{}
+
+func (*FolderAgeProvider) Name() metric.Name     { return FolderAge }
+func (*FolderAgeProvider) Kind() metric.Kind     { return metric.Quantity }
+func (*FolderAgeProvider) Scope() provider.Scope { return provider.ScopeFolder }
+func (*FolderAgeProvider) Description() string {
+	return "Number of days since the folder was first committed to git"
+}
+func (*FolderAgeProvider) Dependencies() []metric.Name         { return []metric.Name{gitprovider.FileAge} }
+func (*FolderAgeProvider) DefaultPalette() palette.PaletteName { return palette.Temperature }
+
+func (*FolderAgeProvider) Load(root *model.Directory) error {
+	model.WalkDirectories(root, func(d *model.Directory) {
+		maxVal, found := maxQuantityFromFiles(d, gitprovider.FileAge)
+		if v, ok := maxQuantityFromDirs(d, FolderAge); ok && (!found || v > maxVal) {
+			maxVal = v
+			found = true
+		}
+
+		if found {
+			d.SetQuantity(FolderAge, maxVal)
+		}
+	})
+
+	return nil
+}
+
+// FolderFreshnessProvider reports days since the most recently modified file in the folder.
+type FolderFreshnessProvider struct{}
+
+func (*FolderFreshnessProvider) Name() metric.Name     { return FolderFreshness }
+func (*FolderFreshnessProvider) Kind() metric.Kind     { return metric.Quantity }
+func (*FolderFreshnessProvider) Scope() provider.Scope { return provider.ScopeFolder }
+func (*FolderFreshnessProvider) Description() string {
+	return "Number of days since the folder was last modified in git"
+}
+
+func (*FolderFreshnessProvider) Dependencies() []metric.Name {
+	return []metric.Name{gitprovider.FileFreshness}
+}
+func (*FolderFreshnessProvider) DefaultPalette() palette.PaletteName { return palette.Temperature }
+
+func (*FolderFreshnessProvider) Load(root *model.Directory) error {
+	model.WalkDirectories(root, func(d *model.Directory) {
+		minVal, found := minQuantityFromFiles(d, gitprovider.FileFreshness)
+		if v, ok := minQuantityFromDirs(d, FolderFreshness); ok && (!found || v < minVal) {
+			minVal = v
+			found = true
+		}
+
+		if found {
+			d.SetQuantity(FolderFreshness, minVal)
+		}
+	})
+
+	return nil
+}
+
+// MeanFileAgeProvider reports the mean file age (days) across all files in a folder.
+type MeanFileAgeProvider struct{}
+
+func (*MeanFileAgeProvider) Name() metric.Name     { return MeanFileAge }
+func (*MeanFileAgeProvider) Kind() metric.Kind     { return metric.Measure }
+func (*MeanFileAgeProvider) Scope() provider.Scope { return provider.ScopeFolder }
+func (*MeanFileAgeProvider) Description() string {
+	return "Mean age of all contained files, including nested folders"
+}
+func (*MeanFileAgeProvider) Dependencies() []metric.Name         { return []metric.Name{gitprovider.FileAge} }
+func (*MeanFileAgeProvider) DefaultPalette() palette.PaletteName { return palette.Temperature }
+
+func (*MeanFileAgeProvider) Load(root *model.Directory) error {
+	stats := make(map[string]*sumCount)
+
+	model.WalkDirectories(root, func(d *model.Directory) {
+		sc := &sumCount{}
+
+		addSumCountFromFiles(sc, d, gitprovider.FileAge)
+		addSumCountFromDirs(sc, d, stats)
+
+		stats[d.Path] = sc
+
+		if sc.count > 0 {
+			d.SetMeasure(MeanFileAge, sc.sum/float64(sc.count))
+		}
+	})
+
+	return nil
+}
+
+// MeanFileFreshnessProvider reports the mean file freshness (days) across all files in a folder.
+type MeanFileFreshnessProvider struct{}
+
+func (*MeanFileFreshnessProvider) Name() metric.Name     { return MeanFileFreshness }
+func (*MeanFileFreshnessProvider) Kind() metric.Kind     { return metric.Measure }
+func (*MeanFileFreshnessProvider) Scope() provider.Scope { return provider.ScopeFolder }
+func (*MeanFileFreshnessProvider) Description() string {
+	return "Mean freshness of all contained files, including nested folders"
+}
+
+func (*MeanFileFreshnessProvider) Dependencies() []metric.Name {
+	return []metric.Name{gitprovider.FileFreshness}
+}
+func (*MeanFileFreshnessProvider) DefaultPalette() palette.PaletteName { return palette.Temperature }
+
+func (*MeanFileFreshnessProvider) Load(root *model.Directory) error {
+	stats := make(map[string]*sumCount)
+
+	model.WalkDirectories(root, func(d *model.Directory) {
+		sc := &sumCount{}
+
+		addSumCountFromFiles(sc, d, gitprovider.FileFreshness)
+		addSumCountFromDirs(sc, d, stats)
+
+		stats[d.Path] = sc
+
+		if sc.count > 0 {
+			d.SetMeasure(MeanFileFreshness, sc.sum/float64(sc.count))
+		}
+	})
+
+	return nil
+}

--- a/internal/provider/folder/metrics.go
+++ b/internal/provider/folder/metrics.go
@@ -159,3 +159,86 @@ func addSumCountFromDirs(sc *sumCount, d *model.Directory, stats map[string]*sum
 		}
 	}
 }
+
+// loadMaxQuantity sets dstMetric on each directory to the maximum srcMetric value across its file tree.
+func loadMaxQuantity(root *model.Directory, srcMetric, dstMetric metric.Name) {
+	model.WalkDirectories(root, func(d *model.Directory) {
+		maxVal, found := maxQuantityFromFiles(d, srcMetric)
+		if v, ok := maxQuantityFromDirs(d, dstMetric); ok && (!found || v > maxVal) {
+			maxVal = v
+			found = true
+		}
+
+		if found {
+			d.SetQuantity(dstMetric, maxVal)
+		}
+	})
+}
+
+// loadMinQuantity sets dstMetric on each directory to the minimum srcMetric value across its file tree.
+func loadMinQuantity(root *model.Directory, srcMetric, dstMetric metric.Name) {
+	model.WalkDirectories(root, func(d *model.Directory) {
+		minVal, found := minQuantityFromFiles(d, srcMetric)
+		if v, ok := minQuantityFromDirs(d, dstMetric); ok && (!found || v < minVal) {
+			minVal = v
+			found = true
+		}
+
+		if found {
+			d.SetQuantity(dstMetric, minVal)
+		}
+	})
+}
+
+// loadSumQuantity sets dstMetric on each directory to the sum of srcMetric values across its file tree.
+func loadSumQuantity(root *model.Directory, srcMetric, dstMetric metric.Name) {
+	model.WalkDirectories(root, func(d *model.Directory) {
+		total, found := sumQuantityFromFiles(d, srcMetric)
+		if v, ok := sumQuantityFromDirs(d, dstMetric); ok {
+			total += v
+			found = true
+		}
+
+		if found {
+			d.SetQuantity(dstMetric, total)
+		}
+	})
+}
+
+// loadMeanMeasure sets dstMetric on each directory to the arithmetic mean of srcMetric values across
+// its file tree, counting all files that have the metric set.
+func loadMeanMeasure(root *model.Directory, srcMetric, dstMetric metric.Name) {
+	stats := make(map[string]*sumCount)
+
+	model.WalkDirectories(root, func(d *model.Directory) {
+		sc := &sumCount{}
+
+		addSumCountFromFiles(sc, d, srcMetric)
+		addSumCountFromDirs(sc, d, stats)
+
+		stats[d.Path] = sc
+
+		if sc.count > 0 {
+			d.SetMeasure(dstMetric, sc.sum/float64(sc.count))
+		}
+	})
+}
+
+// loadPositiveMeanMeasure sets dstMetric on each directory to the arithmetic mean of srcMetric values
+// across its file tree, counting only files where the value is greater than zero (skips binary files).
+func loadPositiveMeanMeasure(root *model.Directory, srcMetric, dstMetric metric.Name) {
+	stats := make(map[string]*sumCount)
+
+	model.WalkDirectories(root, func(d *model.Directory) {
+		sc := &sumCount{}
+
+		addPositiveSumCountFromFiles(sc, d, srcMetric)
+		addSumCountFromDirs(sc, d, stats)
+
+		stats[d.Path] = sc
+
+		if sc.count > 0 {
+			d.SetMeasure(dstMetric, sc.sum/float64(sc.count))
+		}
+	})
+}

--- a/internal/provider/folder/metrics.go
+++ b/internal/provider/folder/metrics.go
@@ -1,0 +1,161 @@
+// Package folder provides metric providers for folder-level aggregate metrics.
+package folder
+
+import (
+	"github.com/bevan/code-visualizer/internal/metric"
+	"github.com/bevan/code-visualizer/internal/model"
+)
+
+// Metric name constants for folder-level metrics.
+const (
+	FolderAuthorCount metric.Name = "folder-author-count"
+	FolderAge         metric.Name = "folder-age"
+	FolderFreshness   metric.Name = "folder-freshness"
+	TotalFolderLines  metric.Name = "total-folder-lines"
+	TotalFolderSize   metric.Name = "total-folder-size"
+	MeanFileAge       metric.Name = "mean-file-age"
+	MeanFileFreshness metric.Name = "mean-file-freshness"
+	MeanFileLines     metric.Name = "mean-file-lines"
+	MeanFileSize      metric.Name = "mean-file-size"
+)
+
+// sumCount accumulates a running total for computing arithmetic means.
+type sumCount struct {
+	sum   float64
+	count int64
+}
+
+// maxQuantityFromFiles returns the maximum quantity value from the direct files in d.
+func maxQuantityFromFiles(d *model.Directory, name metric.Name) (int64, bool) {
+	var result int64
+
+	found := false
+
+	for _, f := range d.Files {
+		if v, ok := f.Quantity(name); ok {
+			if !found || v > result {
+				result = v
+				found = true
+			}
+		}
+	}
+
+	return result, found
+}
+
+// maxQuantityFromDirs returns the maximum quantity value from the direct subdirectories of d.
+func maxQuantityFromDirs(d *model.Directory, name metric.Name) (int64, bool) {
+	var result int64
+
+	found := false
+
+	for _, sub := range d.Dirs {
+		if v, ok := sub.Quantity(name); ok {
+			if !found || v > result {
+				result = v
+				found = true
+			}
+		}
+	}
+
+	return result, found
+}
+
+// minQuantityFromFiles returns the minimum quantity value from the direct files in d.
+func minQuantityFromFiles(d *model.Directory, name metric.Name) (int64, bool) {
+	var result int64
+
+	found := false
+
+	for _, f := range d.Files {
+		if v, ok := f.Quantity(name); ok {
+			if !found || v < result {
+				result = v
+				found = true
+			}
+		}
+	}
+
+	return result, found
+}
+
+// minQuantityFromDirs returns the minimum quantity value from the direct subdirectories of d.
+func minQuantityFromDirs(d *model.Directory, name metric.Name) (int64, bool) {
+	var result int64
+
+	found := false
+
+	for _, sub := range d.Dirs {
+		if v, ok := sub.Quantity(name); ok {
+			if !found || v < result {
+				result = v
+				found = true
+			}
+		}
+	}
+
+	return result, found
+}
+
+// sumQuantityFromFiles returns the sum of quantity values from the direct files in d.
+func sumQuantityFromFiles(d *model.Directory, name metric.Name) (int64, bool) {
+	var total int64
+
+	found := false
+
+	for _, f := range d.Files {
+		if v, ok := f.Quantity(name); ok {
+			total += v
+			found = true
+		}
+	}
+
+	return total, found
+}
+
+// sumQuantityFromDirs returns the sum of quantity values from direct subdirectories of d.
+func sumQuantityFromDirs(d *model.Directory, name metric.Name) (int64, bool) {
+	var total int64
+
+	found := false
+
+	for _, sub := range d.Dirs {
+		if v, ok := sub.Quantity(name); ok {
+			total += v
+			found = true
+		}
+	}
+
+	return total, found
+}
+
+// addSumCountFromFiles adds the quantity values from direct files in d to sc.
+func addSumCountFromFiles(sc *sumCount, d *model.Directory, name metric.Name) {
+	for _, f := range d.Files {
+		if v, ok := f.Quantity(name); ok {
+			sc.sum += float64(v)
+			sc.count++
+		}
+	}
+}
+
+// addPositiveSumCountFromFiles adds positive quantity values from direct files in d to sc.
+// Files where the value is zero are skipped (used to exclude binary files from line-count means).
+func addPositiveSumCountFromFiles(sc *sumCount, d *model.Directory, name metric.Name) {
+	for _, f := range d.Files {
+		if v, ok := f.Quantity(name); ok && v > 0 {
+			sc.sum += float64(v)
+			sc.count++
+		}
+	}
+}
+
+// addSumCountFromDirs merges accumulated stats from direct subdirectories of d into sc.
+func addSumCountFromDirs(sc *sumCount, d *model.Directory, stats map[string]*sumCount) {
+	for _, sub := range d.Dirs {
+		if ss, ok := stats[sub.Path]; ok {
+			sc.sum += ss.sum
+			sc.count += ss.count
+		}
+	}
+}

--- a/internal/provider/folder/metrics_test.go
+++ b/internal/provider/folder/metrics_test.go
@@ -52,13 +52,20 @@ func setupGitRepo(t *testing.T) (dir string, sub string) {
 	run(dir, aliceEnv, "git", "config", "user.email", "alice@example.com")
 	run(dir, aliceEnv, "git", "config", "user.name", "Alice")
 
-	_ = os.WriteFile(filepath.Join(dir, "root.go"), []byte("package root\n"), 0o600)
-	_ = os.WriteFile(filepath.Join(sub, "pkg.go"), []byte("package pkg\n"), 0o600)
+	if err := os.WriteFile(filepath.Join(dir, "root.go"), []byte("package root\n"), 0o600); err != nil {
+		t.Fatalf("write root.go: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(sub, "pkg.go"), []byte("package pkg\n"), 0o600); err != nil {
+		t.Fatalf("write pkg.go: %v", err)
+	}
 
 	run(dir, aliceEnv, "git", "add", ".")
 	run(dir, aliceEnv, "git", "commit", "-m", "initial", "--date=2023-01-01T00:00:00+00:00")
 
-	_ = os.WriteFile(filepath.Join(sub, "pkg.go"), []byte("package pkg\n// updated\n"), 0o600)
+	if err := os.WriteFile(filepath.Join(sub, "pkg.go"), []byte("package pkg\n// updated\n"), 0o600); err != nil {
+		t.Fatalf("update pkg.go: %v", err)
+	}
 
 	run(dir, bobEnv, "git", "add", "pkg/pkg.go")
 	run(dir, bobEnv, "git", "commit", "-m", "bob update", "--date=2024-06-01T00:00:00+00:00")
@@ -93,7 +100,7 @@ func TestFolderAuthorCountProviderMetadata(t *testing.T) {
 	g.Expect(p.Kind()).To(Equal(metric.Quantity))
 	g.Expect(p.Scope()).To(Equal(provider.ScopeFolder))
 	g.Expect(p.Description()).NotTo(BeEmpty())
-	g.Expect(p.Dependencies()).To(BeEmpty())
+	g.Expect(p.Dependencies()).To(ConsistOf(gitprovider.AuthorCount))
 }
 
 func TestFolderAuthorCountProvider(t *testing.T) {

--- a/internal/provider/folder/metrics_test.go
+++ b/internal/provider/folder/metrics_test.go
@@ -1,0 +1,501 @@
+package folder
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/bevan/code-visualizer/internal/metric"
+	"github.com/bevan/code-visualizer/internal/model"
+	"github.com/bevan/code-visualizer/internal/provider"
+	"github.com/bevan/code-visualizer/internal/provider/filesystem"
+	gitprovider "github.com/bevan/code-visualizer/internal/provider/git"
+)
+
+// setupGitRepo creates a temporary git repo with two files committed by different authors.
+func setupGitRepo(t *testing.T) (dir string, sub string) {
+	t.Helper()
+	dir = t.TempDir()
+	sub = filepath.Join(dir, "pkg")
+
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	run := func(workdir string, env []string, args ...string) {
+		t.Helper()
+
+		cmd := exec.Command(args[0], args[1:]...) //nolint:gosec // test helper runs known safe commands
+		cmd.Dir = workdir
+
+		cmd.Env = append(os.Environ(), env...)
+
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("command %v failed: %s\n%s", args, err, out)
+		}
+	}
+
+	aliceEnv := []string{
+		"GIT_AUTHOR_NAME=Alice", "GIT_AUTHOR_EMAIL=alice@example.com",
+		"GIT_COMMITTER_NAME=Alice", "GIT_COMMITTER_EMAIL=alice@example.com",
+	}
+	bobEnv := []string{
+		"GIT_AUTHOR_NAME=Bob", "GIT_AUTHOR_EMAIL=bob@example.com",
+		"GIT_COMMITTER_NAME=Bob", "GIT_COMMITTER_EMAIL=bob@example.com",
+	}
+
+	run(dir, aliceEnv, "git", "init")
+	run(dir, aliceEnv, "git", "config", "user.email", "alice@example.com")
+	run(dir, aliceEnv, "git", "config", "user.name", "Alice")
+
+	_ = os.WriteFile(filepath.Join(dir, "root.go"), []byte("package root\n"), 0o600)
+	_ = os.WriteFile(filepath.Join(sub, "pkg.go"), []byte("package pkg\n"), 0o600)
+
+	run(dir, aliceEnv, "git", "add", ".")
+	run(dir, aliceEnv, "git", "commit", "-m", "initial", "--date=2023-01-01T00:00:00+00:00")
+
+	_ = os.WriteFile(filepath.Join(sub, "pkg.go"), []byte("package pkg\n// updated\n"), 0o600)
+
+	run(dir, bobEnv, "git", "add", "pkg/pkg.go")
+	run(dir, bobEnv, "git", "commit", "-m", "bob update", "--date=2024-06-01T00:00:00+00:00")
+
+	return dir, sub
+}
+
+// buildTreeWithSub builds a model tree: root with one file and one subdir with one file.
+func buildTreeWithSub(dir, sub string) *model.Directory {
+	rootFile := &model.File{Path: filepath.Join(dir, "root.go"), Name: "root.go"}
+	subFile := &model.File{Path: filepath.Join(sub, "pkg.go"), Name: "pkg.go"}
+	subDir := &model.Directory{
+		Path:  sub,
+		Name:  "pkg",
+		Files: []*model.File{subFile},
+	}
+
+	return &model.Directory{
+		Path:  dir,
+		Name:  filepath.Base(dir),
+		Files: []*model.File{rootFile},
+		Dirs:  []*model.Directory{subDir},
+	}
+}
+
+func TestFolderAuthorCountProviderMetadata(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	p := &FolderAuthorCountProvider{}
+	g.Expect(p.Name()).To(Equal(FolderAuthorCount))
+	g.Expect(p.Kind()).To(Equal(metric.Quantity))
+	g.Expect(p.Scope()).To(Equal(provider.ScopeFolder))
+	g.Expect(p.Description()).NotTo(BeEmpty())
+	g.Expect(p.Dependencies()).To(BeEmpty())
+}
+
+func TestFolderAuthorCountProvider(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir, sub := setupGitRepo(t)
+	root := buildTreeWithSub(dir, sub)
+
+	p := &FolderAuthorCountProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// subdir pkg: only pkg.go which has 2 authors
+	subDir := root.Dirs[0]
+	count, ok := subDir.Quantity(FolderAuthorCount)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(count).To(Equal(int64(2)))
+
+	// root: root.go (1 author) + pkg.go (2 authors) → 2 unique (Alice + Bob)
+	rootCount, ok := root.Quantity(FolderAuthorCount)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(rootCount).To(Equal(int64(2)))
+}
+
+func TestFolderAuthorCountProviderNotGitRepo(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir := t.TempDir()
+	root := &model.Directory{Path: dir, Name: "root"}
+
+	p := &FolderAuthorCountProvider{}
+	err := p.Load(root)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(MatchError(ContainSubstring("git")))
+}
+
+func TestFolderAgeProviderMetadata(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	p := &FolderAgeProvider{}
+	g.Expect(p.Name()).To(Equal(FolderAge))
+	g.Expect(p.Kind()).To(Equal(metric.Quantity))
+	g.Expect(p.Scope()).To(Equal(provider.ScopeFolder))
+	g.Expect(p.Description()).NotTo(BeEmpty())
+	g.Expect(p.Dependencies()).To(ConsistOf(gitprovider.FileAge))
+}
+
+func TestFolderAgeProvider(t *testing.T) { //nolint:dupl // similar structure is intentional — distinct metrics
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	rootFile := &model.File{Path: "/root/a.go", Name: "a.go"}
+	subFile := &model.File{Path: "/root/pkg/b.go", Name: "b.go"}
+	subDir := &model.Directory{Path: "/root/pkg", Name: "pkg", Files: []*model.File{subFile}}
+	root := &model.Directory{
+		Path:  "/root",
+		Name:  "root",
+		Files: []*model.File{rootFile},
+		Dirs:  []*model.Directory{subDir},
+	}
+
+	rootFile.SetQuantity(gitprovider.FileAge, 100)
+	subFile.SetQuantity(gitprovider.FileAge, 500)
+
+	p := &FolderAgeProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// subdir: max(500) = 500
+	age, ok := subDir.Quantity(FolderAge)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(age).To(Equal(int64(500)))
+
+	// root: max(100, 500) = 500
+	rootAge, ok := root.Quantity(FolderAge)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(rootAge).To(Equal(int64(500)))
+}
+
+func TestFolderFreshnessProviderMetadata(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	p := &FolderFreshnessProvider{}
+	g.Expect(p.Name()).To(Equal(FolderFreshness))
+	g.Expect(p.Kind()).To(Equal(metric.Quantity))
+	g.Expect(p.Scope()).To(Equal(provider.ScopeFolder))
+	g.Expect(p.Description()).NotTo(BeEmpty())
+	g.Expect(p.Dependencies()).To(ConsistOf(gitprovider.FileFreshness))
+}
+
+func TestFolderFreshnessProvider(t *testing.T) { //nolint:dupl // similar structure is intentional — distinct metrics
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	rootFile := &model.File{Path: "/root/a.go", Name: "a.go"}
+	subFile := &model.File{Path: "/root/pkg/b.go", Name: "b.go"}
+	subDir := &model.Directory{Path: "/root/pkg", Name: "pkg", Files: []*model.File{subFile}}
+	root := &model.Directory{
+		Path:  "/root",
+		Name:  "root",
+		Files: []*model.File{rootFile},
+		Dirs:  []*model.Directory{subDir},
+	}
+
+	rootFile.SetQuantity(gitprovider.FileFreshness, 30)
+	subFile.SetQuantity(gitprovider.FileFreshness, 5)
+
+	p := &FolderFreshnessProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// subdir: min(5) = 5
+	fresh, ok := subDir.Quantity(FolderFreshness)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(fresh).To(Equal(int64(5)))
+
+	// root: min(30, 5) = 5
+	rootFresh, ok := root.Quantity(FolderFreshness)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(rootFresh).To(Equal(int64(5)))
+}
+
+func TestTotalFolderLinesProviderMetadata(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	p := &TotalFolderLinesProvider{}
+	g.Expect(p.Name()).To(Equal(TotalFolderLines))
+	g.Expect(p.Kind()).To(Equal(metric.Quantity))
+	g.Expect(p.Scope()).To(Equal(provider.ScopeFolder))
+	g.Expect(p.Description()).NotTo(BeEmpty())
+	g.Expect(p.Dependencies()).To(ConsistOf(filesystem.FileLines))
+}
+
+func TestTotalFolderLinesProvider(t *testing.T) { //nolint:dupl // similar structure is intentional — distinct metrics
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	f1 := &model.File{Path: "/root/a.go", Name: "a.go"}
+	f2 := &model.File{Path: "/root/pkg/b.go", Name: "b.go"}
+	subDir := &model.Directory{Path: "/root/pkg", Name: "pkg", Files: []*model.File{f2}}
+	root := &model.Directory{
+		Path:  "/root",
+		Name:  "root",
+		Files: []*model.File{f1},
+		Dirs:  []*model.Directory{subDir},
+	}
+
+	f1.SetQuantity(filesystem.FileLines, 10)
+	f2.SetQuantity(filesystem.FileLines, 20)
+
+	p := &TotalFolderLinesProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	subTotal, ok := subDir.Quantity(TotalFolderLines)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(subTotal).To(Equal(int64(20)))
+
+	rootTotal, ok := root.Quantity(TotalFolderLines)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(rootTotal).To(Equal(int64(30)))
+}
+
+func TestTotalFolderSizeProviderMetadata(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	p := &TotalFolderSizeProvider{}
+	g.Expect(p.Name()).To(Equal(TotalFolderSize))
+	g.Expect(p.Kind()).To(Equal(metric.Quantity))
+	g.Expect(p.Scope()).To(Equal(provider.ScopeFolder))
+	g.Expect(p.Description()).NotTo(BeEmpty())
+	g.Expect(p.Dependencies()).To(ConsistOf(filesystem.FileSize))
+}
+
+func TestTotalFolderSizeProvider(t *testing.T) { //nolint:dupl // similar structure is intentional — distinct metrics
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	f1 := &model.File{Path: "/root/a.go", Name: "a.go"}
+	f2 := &model.File{Path: "/root/pkg/b.go", Name: "b.go"}
+	subDir := &model.Directory{Path: "/root/pkg", Name: "pkg", Files: []*model.File{f2}}
+	root := &model.Directory{
+		Path:  "/root",
+		Name:  "root",
+		Files: []*model.File{f1},
+		Dirs:  []*model.Directory{subDir},
+	}
+
+	f1.SetQuantity(filesystem.FileSize, 100)
+	f2.SetQuantity(filesystem.FileSize, 200)
+
+	p := &TotalFolderSizeProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	subSize, ok := subDir.Quantity(TotalFolderSize)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(subSize).To(Equal(int64(200)))
+
+	rootSize, ok := root.Quantity(TotalFolderSize)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(rootSize).To(Equal(int64(300)))
+}
+
+func TestMeanFileAgeProviderMetadata(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	p := &MeanFileAgeProvider{}
+	g.Expect(p.Name()).To(Equal(MeanFileAge))
+	g.Expect(p.Kind()).To(Equal(metric.Measure))
+	g.Expect(p.Scope()).To(Equal(provider.ScopeFolder))
+	g.Expect(p.Description()).NotTo(BeEmpty())
+	g.Expect(p.Dependencies()).To(ConsistOf(gitprovider.FileAge))
+}
+
+func TestMeanFileAgeProvider(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	f1 := &model.File{Path: "/root/a.go", Name: "a.go"}
+	f2 := &model.File{Path: "/root/pkg/b.go", Name: "b.go"}
+	f3 := &model.File{Path: "/root/pkg/c.go", Name: "c.go"}
+	subDir := &model.Directory{Path: "/root/pkg", Name: "pkg", Files: []*model.File{f2, f3}}
+	root := &model.Directory{
+		Path:  "/root",
+		Name:  "root",
+		Files: []*model.File{f1},
+		Dirs:  []*model.Directory{subDir},
+	}
+
+	f1.SetQuantity(gitprovider.FileAge, 100)
+	f2.SetQuantity(gitprovider.FileAge, 200)
+	f3.SetQuantity(gitprovider.FileAge, 300)
+
+	p := &MeanFileAgeProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// subdir mean: (200+300)/2 = 250
+	subMean, ok := subDir.Measure(MeanFileAge)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(subMean).To(BeNumerically("~", 250.0, 0.001))
+
+	// root mean: (100+200+300)/3 = 200
+	rootMean, ok := root.Measure(MeanFileAge)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(rootMean).To(BeNumerically("~", 200.0, 0.001))
+}
+
+func TestMeanFileFreshnessProviderMetadata(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	p := &MeanFileFreshnessProvider{}
+	g.Expect(p.Name()).To(Equal(MeanFileFreshness))
+	g.Expect(p.Kind()).To(Equal(metric.Measure))
+	g.Expect(p.Scope()).To(Equal(provider.ScopeFolder))
+	g.Expect(p.Description()).NotTo(BeEmpty())
+	g.Expect(p.Dependencies()).To(ConsistOf(gitprovider.FileFreshness))
+}
+
+func TestMeanFileFreshnessProvider(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	f1 := &model.File{Path: "/root/a.go", Name: "a.go"}
+	f2 := &model.File{Path: "/root/b.go", Name: "b.go"}
+	root := &model.Directory{
+		Path:  "/root",
+		Name:  "root",
+		Files: []*model.File{f1, f2},
+	}
+
+	f1.SetQuantity(gitprovider.FileFreshness, 10)
+	f2.SetQuantity(gitprovider.FileFreshness, 30)
+
+	p := &MeanFileFreshnessProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	mean, ok := root.Measure(MeanFileFreshness)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(mean).To(BeNumerically("~", 20.0, 0.001))
+}
+
+func TestMeanFileLinesProviderMetadata(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	p := &MeanFileLinesProvider{}
+	g.Expect(p.Name()).To(Equal(MeanFileLines))
+	g.Expect(p.Kind()).To(Equal(metric.Measure))
+	g.Expect(p.Scope()).To(Equal(provider.ScopeFolder))
+	g.Expect(p.Description()).NotTo(BeEmpty())
+	g.Expect(p.Dependencies()).To(ConsistOf(filesystem.FileLines))
+}
+
+func TestMeanFileLinesProviderSkipsBinaryFiles(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	text1 := &model.File{Path: "/root/a.go", Name: "a.go"}
+	text2 := &model.File{Path: "/root/b.go", Name: "b.go"}
+	binary := &model.File{Path: "/root/c.bin", Name: "c.bin", IsBinary: true}
+	root := &model.Directory{
+		Path:  "/root",
+		Name:  "root",
+		Files: []*model.File{text1, text2, binary},
+	}
+
+	text1.SetQuantity(filesystem.FileLines, 10)
+	text2.SetQuantity(filesystem.FileLines, 20)
+	// binary file: file-lines not set (as FileLinesProvider would leave it)
+
+	p := &MeanFileLinesProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// mean of text files only: (10+20)/2 = 15
+	mean, ok := root.Measure(MeanFileLines)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(mean).To(BeNumerically("~", 15.0, 0.001))
+}
+
+func TestMeanFileSizeProviderMetadata(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	p := &MeanFileSizeProvider{}
+	g.Expect(p.Name()).To(Equal(MeanFileSize))
+	g.Expect(p.Kind()).To(Equal(metric.Measure))
+	g.Expect(p.Scope()).To(Equal(provider.ScopeFolder))
+	g.Expect(p.Description()).NotTo(BeEmpty())
+	g.Expect(p.Dependencies()).To(ConsistOf(filesystem.FileSize))
+}
+
+func TestMeanFileSizeProvider(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	f1 := &model.File{Path: "/root/a.go", Name: "a.go"}
+	f2 := &model.File{Path: "/root/pkg/b.go", Name: "b.go"}
+	subDir := &model.Directory{Path: "/root/pkg", Name: "pkg", Files: []*model.File{f2}}
+	root := &model.Directory{
+		Path:  "/root",
+		Name:  "root",
+		Files: []*model.File{f1},
+		Dirs:  []*model.Directory{subDir},
+	}
+
+	f1.SetQuantity(filesystem.FileSize, 100)
+	f2.SetQuantity(filesystem.FileSize, 300)
+
+	p := &MeanFileSizeProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	subMean, ok := subDir.Measure(MeanFileSize)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(subMean).To(BeNumerically("~", 300.0, 0.001))
+
+	rootMean, ok := root.Measure(MeanFileSize)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(rootMean).To(BeNumerically("~", 200.0, 0.001))
+}
+
+func TestFolderMetricsEmptyDirectory(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := &model.Directory{Path: "/root", Name: "root"}
+
+	for _, p := range []interface {
+		Load(root *model.Directory) error
+	}{
+		&FolderAgeProvider{},
+		&FolderFreshnessProvider{},
+		&TotalFolderLinesProvider{},
+		&TotalFolderSizeProvider{},
+		&MeanFileAgeProvider{},
+		&MeanFileFreshnessProvider{},
+		&MeanFileLinesProvider{},
+		&MeanFileSizeProvider{},
+	} {
+		err := p.Load(root)
+		g.Expect(err).NotTo(HaveOccurred())
+	}
+
+	// No metrics should be set on an empty directory
+	_, okAge := root.Quantity(FolderAge)
+	g.Expect(okAge).To(BeFalse())
+
+	_, okFresh := root.Quantity(FolderFreshness)
+	g.Expect(okFresh).To(BeFalse())
+
+	_, okLines := root.Quantity(TotalFolderLines)
+	g.Expect(okLines).To(BeFalse())
+}

--- a/internal/provider/folder/register.go
+++ b/internal/provider/folder/register.go
@@ -1,0 +1,16 @@
+package folder
+
+import "github.com/bevan/code-visualizer/internal/provider"
+
+// Register adds all folder metric providers to the global registry.
+func Register() {
+	provider.Register(&FolderAuthorCountProvider{})
+	provider.Register(&FolderAgeProvider{})
+	provider.Register(&FolderFreshnessProvider{})
+	provider.Register(&TotalFolderLinesProvider{})
+	provider.Register(&TotalFolderSizeProvider{})
+	provider.Register(&MeanFileAgeProvider{})
+	provider.Register(&MeanFileFreshnessProvider{})
+	provider.Register(&MeanFileLinesProvider{})
+	provider.Register(&MeanFileSizeProvider{})
+}

--- a/internal/provider/git/metrics.go
+++ b/internal/provider/git/metrics.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"errors"
 	"log/slog"
 	"path/filepath"
 
@@ -47,9 +46,7 @@ func (*FileAgeProvider) Load(root *model.Directory) error {
 
 		age, err := s.fileAge(relPath)
 		if err != nil {
-			if !errors.Is(err, errUntracked) {
-				slog.Debug("could not get file age", "path", relPath, "error", err)
-			}
+			slog.Debug("could not get file age", "path", relPath, "error", err)
 
 			return
 		}
@@ -88,9 +85,7 @@ func (*FileFreshnessProvider) Load(root *model.Directory) error {
 
 		freshness, err := s.fileFreshness(relPath)
 		if err != nil {
-			if !errors.Is(err, errUntracked) {
-				slog.Debug("could not get file freshness", "path", relPath, "error", err)
-			}
+			slog.Debug("could not get file freshness", "path", relPath, "error", err)
 
 			return
 		}
@@ -129,9 +124,7 @@ func (*AuthorCountProvider) Load(root *model.Directory) error {
 
 		count, err := s.authorCount(relPath)
 		if err != nil {
-			if !errors.Is(err, errUntracked) {
-				slog.Debug("could not get author count", "path", relPath, "error", err)
-			}
+			slog.Debug("could not get author count", "path", relPath, "error", err)
 
 			return
 		}

--- a/internal/provider/git/metrics.go
+++ b/internal/provider/git/metrics.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bevan/code-visualizer/internal/metric"
 	"github.com/bevan/code-visualizer/internal/model"
 	"github.com/bevan/code-visualizer/internal/palette"
+	"github.com/bevan/code-visualizer/internal/provider"
 )
 
 const (
@@ -18,11 +19,15 @@ const (
 	AuthorCount   metric.Name = "author-count"
 )
 
-// FileAgeProvider reports time since first commit in seconds.
+// FileAgeProvider reports the number of days since the file's first commit.
 type FileAgeProvider struct{}
 
-func (*FileAgeProvider) Name() metric.Name                   { return FileAge }
-func (*FileAgeProvider) Kind() metric.Kind                   { return metric.Quantity }
+func (*FileAgeProvider) Name() metric.Name     { return FileAge }
+func (*FileAgeProvider) Kind() metric.Kind     { return metric.Quantity }
+func (*FileAgeProvider) Scope() provider.Scope { return provider.ScopeFile }
+func (*FileAgeProvider) Description() string {
+	return "Number of days since the file was first committed to git"
+}
 func (*FileAgeProvider) Dependencies() []metric.Name         { return nil }
 func (*FileAgeProvider) DefaultPalette() palette.PaletteName { return palette.Temperature }
 
@@ -55,11 +60,15 @@ func (*FileAgeProvider) Load(root *model.Directory) error {
 	return nil
 }
 
-// FileFreshnessProvider reports time since most recent commit in seconds.
+// FileFreshnessProvider reports the number of days since the file's most recent commit.
 type FileFreshnessProvider struct{}
 
-func (*FileFreshnessProvider) Name() metric.Name                   { return FileFreshness }
-func (*FileFreshnessProvider) Kind() metric.Kind                   { return metric.Quantity }
+func (*FileFreshnessProvider) Name() metric.Name     { return FileFreshness }
+func (*FileFreshnessProvider) Kind() metric.Kind     { return metric.Quantity }
+func (*FileFreshnessProvider) Scope() provider.Scope { return provider.ScopeFile }
+func (*FileFreshnessProvider) Description() string {
+	return "Number of days since the file was last modified in git"
+}
 func (*FileFreshnessProvider) Dependencies() []metric.Name         { return nil }
 func (*FileFreshnessProvider) DefaultPalette() palette.PaletteName { return palette.Temperature }
 
@@ -92,11 +101,15 @@ func (*FileFreshnessProvider) Load(root *model.Directory) error {
 	return nil
 }
 
-// AuthorCountProvider reports the number of distinct commit authors.
+// AuthorCountProvider reports the number of distinct commit authors for a file.
 type AuthorCountProvider struct{}
 
-func (*AuthorCountProvider) Name() metric.Name                   { return AuthorCount }
-func (*AuthorCountProvider) Kind() metric.Kind                   { return metric.Quantity }
+func (*AuthorCountProvider) Name() metric.Name     { return AuthorCount }
+func (*AuthorCountProvider) Kind() metric.Kind     { return metric.Quantity }
+func (*AuthorCountProvider) Scope() provider.Scope { return provider.ScopeFile }
+func (*AuthorCountProvider) Description() string {
+	return "Count of distinct authors who have contributed to this file"
+}
 func (*AuthorCountProvider) Dependencies() []metric.Name         { return nil }
 func (*AuthorCountProvider) DefaultPalette() palette.PaletteName { return palette.GoodBad }
 

--- a/internal/provider/git/metrics_test.go
+++ b/internal/provider/git/metrics_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/bevan/code-visualizer/internal/metric"
 	"github.com/bevan/code-visualizer/internal/model"
+	"github.com/bevan/code-visualizer/internal/provider"
 )
 
 func setupTestGitRepo(t *testing.T) string {
@@ -102,16 +103,18 @@ func TestFileAgeProvider(t *testing.T) {
 	p := &FileAgeProvider{}
 	g.Expect(p.Name()).To(Equal(FileAge))
 	g.Expect(p.Kind()).To(Equal(metric.Quantity))
+	g.Expect(p.Scope()).To(Equal(provider.ScopeFile))
+	g.Expect(p.Description()).NotTo(BeEmpty())
 
 	err := p.Load(root)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	// old.go has age > 0
+	// old.go was committed 2024-01-01, so age should be > 365 days
 	ageOld, ok := root.Files[0].Quantity(FileAge)
 	g.Expect(ok).To(BeTrue())
-	g.Expect(ageOld).To(BeNumerically(">", 0))
+	g.Expect(ageOld).To(BeNumerically(">", 365))
 
-	// new.go has age >= 0 (just committed)
+	// new.go was just committed, age in days >= 0
 	ageNew, ok := root.Files[1].Quantity(FileAge)
 	g.Expect(ok).To(BeTrue())
 	g.Expect(ageNew).To(BeNumerically(">=", 0))
@@ -130,10 +133,12 @@ func TestFileFreshnessProvider(t *testing.T) {
 	resetService()
 
 	p := &FileFreshnessProvider{}
+	g.Expect(p.Scope()).To(Equal(provider.ScopeFile))
+	g.Expect(p.Description()).NotTo(BeEmpty())
 	err := p.Load(root)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	// new.go was just committed — should be very fresh (small number)
+	// new.go was just committed — should be very fresh (0 days)
 	freshNew, ok := root.Files[1].Quantity(FileFreshness)
 	g.Expect(ok).To(BeTrue())
 	g.Expect(freshNew).To(BeNumerically(">=", 0))
@@ -149,6 +154,8 @@ func TestAuthorCountProvider(t *testing.T) {
 	resetService()
 
 	p := &AuthorCountProvider{}
+	g.Expect(p.Scope()).To(Equal(provider.ScopeFile))
+	g.Expect(p.Description()).NotTo(BeEmpty())
 	err := p.Load(root)
 	g.Expect(err).NotTo(HaveOccurred())
 

--- a/internal/provider/git/service.go
+++ b/internal/provider/git/service.go
@@ -90,7 +90,7 @@ func (s *repoService) fileAge(relPath string) (int64, error) {
 	oldest := commits[len(commits)-1]
 	age := time.Since(oldest)
 
-	return int64(age.Hours() / 24), nil
+	return int64(age / (24 * time.Hour)), nil
 }
 
 func (s *repoService) fileFreshness(relPath string) (int64, error) {
@@ -106,7 +106,7 @@ func (s *repoService) fileFreshness(relPath string) (int64, error) {
 	newest := commits[0]
 	freshness := time.Since(newest)
 
-	return int64(freshness.Hours() / 24), nil
+	return int64(freshness / (24 * time.Hour)), nil
 }
 
 func (s *repoService) authorCount(relPath string) (int64, error) {

--- a/internal/provider/git/service.go
+++ b/internal/provider/git/service.go
@@ -56,6 +56,25 @@ func resetService() {
 	services = make(map[string]*serviceResult)
 }
 
+// VerifyRepository returns an error if repoPath is not within a git repository.
+func VerifyRepository(repoPath string) error {
+	_, err := getService(repoPath)
+
+	return err
+}
+
+// FileAuthors returns the set of distinct author emails for the file at relPath.
+// relPath must be relative to the repository root. repoPath is searched upward for a .git directory.
+// Returns an empty map for untracked files (no error).
+func FileAuthors(repoPath, relPath string) (map[string]bool, error) {
+	s, err := getService(repoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.fileAuthors(relPath)
+}
+
 var errUntracked = errors.New("file has no git history")
 
 func (s *repoService) fileAge(relPath string) (int64, error) {
@@ -71,7 +90,7 @@ func (s *repoService) fileAge(relPath string) (int64, error) {
 	oldest := commits[len(commits)-1]
 	age := time.Since(oldest)
 
-	return int64(age.Seconds()), nil
+	return int64(age.Hours() / 24), nil
 }
 
 func (s *repoService) fileFreshness(relPath string) (int64, error) {
@@ -87,25 +106,13 @@ func (s *repoService) fileFreshness(relPath string) (int64, error) {
 	newest := commits[0]
 	freshness := time.Since(newest)
 
-	return int64(freshness.Seconds()), nil
+	return int64(freshness.Hours() / 24), nil
 }
 
 func (s *repoService) authorCount(relPath string) (int64, error) {
-	log, err := s.repo.Log(&gogit.LogOptions{FileName: &relPath})
+	authors, err := s.fileAuthors(relPath)
 	if err != nil {
-		return 0, eris.Wrap(err, "failed to get git log")
-	}
-	defer log.Close()
-
-	authors := map[string]bool{}
-
-	err = log.ForEach(func(c *object.Commit) error {
-		authors[c.Author.Email] = true
-
-		return nil
-	})
-	if err != nil {
-		return 0, eris.Wrap(err, "failed to iterate commits")
+		return 0, err
 	}
 
 	if len(authors) == 0 {
@@ -113,6 +120,27 @@ func (s *repoService) authorCount(relPath string) (int64, error) {
 	}
 
 	return int64(len(authors)), nil
+}
+
+func (s *repoService) fileAuthors(relPath string) (map[string]bool, error) {
+	log, err := s.repo.Log(&gogit.LogOptions{FileName: &relPath})
+	if err != nil {
+		return nil, eris.Wrap(err, "failed to get git log")
+	}
+	defer log.Close()
+
+	authors := make(map[string]bool)
+
+	err = log.ForEach(func(c *object.Commit) error {
+		authors[c.Author.Email] = true
+
+		return nil
+	})
+	if err != nil {
+		return nil, eris.Wrap(err, "failed to iterate commits")
+	}
+
+	return authors, nil
 }
 
 func (s *repoService) fileCommitTimes(relPath string) ([]time.Time, error) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -7,10 +7,20 @@ import (
 	"github.com/bevan/code-visualizer/internal/palette"
 )
 
+// Scope describes what a metric applies to.
+type Scope string
+
+const (
+	ScopeFile   Scope = "File"
+	ScopeFolder Scope = "Folder"
+)
+
 // Interface is the contract every metric provider implements.
 type Interface interface {
 	Name() metric.Name
 	Kind() metric.Kind
+	Scope() Scope
+	Description() string
 	Dependencies() []metric.Name
 	DefaultPalette() palette.PaletteName
 	Load(root *model.Directory) error

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -18,6 +18,8 @@ type stubProvider struct {
 
 func (s *stubProvider) Name() metric.Name                 { return s.name }
 func (s *stubProvider) Kind() metric.Kind                 { return s.kind }
+func (*stubProvider) Scope() Scope                        { return ScopeFile }
+func (*stubProvider) Description() string                 { return "" }
 func (*stubProvider) Dependencies() []metric.Name         { return nil }
 func (*stubProvider) DefaultPalette() palette.PaletteName { return palette.Neutral }
 func (*stubProvider) Load(_ *model.Directory) error       { return nil }

--- a/internal/provider/run_test.go
+++ b/internal/provider/run_test.go
@@ -38,6 +38,8 @@ type mockProvider struct {
 
 func (m *mockProvider) Name() metric.Name                 { return m.name }
 func (m *mockProvider) Kind() metric.Kind                 { return m.kind }
+func (*mockProvider) Scope() Scope                        { return ScopeFile }
+func (*mockProvider) Description() string                 { return "" }
 func (m *mockProvider) Dependencies() []metric.Name       { return m.deps }
 func (*mockProvider) DefaultPalette() palette.PaletteName { return palette.Neutral }
 
@@ -163,6 +165,8 @@ type concurrentProvider struct {
 
 func (c *concurrentProvider) Name() metric.Name                 { return c.name }
 func (*concurrentProvider) Kind() metric.Kind                   { return metric.Quantity }
+func (*concurrentProvider) Scope() Scope                        { return ScopeFile }
+func (*concurrentProvider) Description() string                 { return "" }
 func (*concurrentProvider) Dependencies() []metric.Name         { return nil }
 func (*concurrentProvider) DefaultPalette() palette.PaletteName { return palette.Neutral }
 

--- a/internal/scan/scanner.go
+++ b/internal/scan/scanner.go
@@ -123,7 +123,7 @@ func processDir(node *model.Directory, entry os.DirEntry, entryPath, rootPath st
 }
 
 func processFile(node *model.Directory, entry os.DirEntry, info os.FileInfo, entryPath string) {
-	ext := strings.TrimPrefix(filepath.Ext(entry.Name()), ".")
+	ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(entry.Name()), "."))
 
 	fileType := ext
 	if fileType == "" {


### PR DESCRIPTION
Closes #38

## Summary

Extends `provider.Interface` with `Scope()` and `Description()` methods, adds 9 new folder-level metrics, and fixes two existing metric implementations.

## Changes

### Interface extension
- Added `Scope() Scope` and `Description() string` to `provider.Interface`
- Added `ScopeFile` and `ScopeFolder` constants

### Side quest fixes
- **file-age / file-freshness**: Were returning seconds — fixed to return **days** per their descriptions
- **file-type**: Added `strings.ToLower` normalization to match "normalized to lowercase" description

### New `provider/folder` package
Nine new folder-level providers, all scope `ScopeFolder`:

| Metric | Kind | Description |
|---|---|---|
| folder-author-count | Quantity | Distinct authors across all files (git union, not sum) |
| folder-age | Quantity | Days since oldest file was first committed (max of file-age) |
| folder-freshness | Quantity | Days since most recent file modification (min of file-freshness) |
| total-folder-lines | Quantity | Sum of file-lines across all contained files |
| total-folder-size | Quantity | Sum of file-size across all contained files |
| mean-file-age | Measure | Mean file-age across all contained files |
| mean-file-freshness | Measure | Mean file-freshness across all contained files |
| mean-file-lines | Measure | Mean file-lines (skips binary/empty files) |
| mean-file-size | Measure | Mean file-size across all contained files |

All folder metrics use bottom-up aggregation via new `model.WalkDirectories` (post-order traversal).

## Verification

`task ci` passes (build + test + lint, 0 issues).