### PR TITLE
feat: add foliage palette for plant health metrics

### DIFF
--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -14,6 +14,13 @@
 
 <!-- Append learnings below -->
 
+### Foliage palette — issue #46 (2026-04-18)
+
+- **New palette added:** `Foliage` (`"foliage"`) in `internal/palette/palette.go` — 11-step ordered palette progressing black → brown → orange → yellow → green for plant-health visualisation.
+- **Pattern:** Adding a palette requires changes in four places: const block, `validPalettes` map, `palettes` map, and the `ColourPalette` var definition. Tests need updating in `palette_test.go` for both `IsValid` and the WCAG contrast loop.
+- **WCAG constraint:** All ordered palettes must pass adjacent-step contrast ratio >= 1.0 (checked in `TestWCAGContrastRatio`). The foliage colours were chosen with sufficient luminance steps to satisfy this.
+- **Environment note:** `gofumpt` and `golangci-lint-custom` aren't available in this shell; rely on `task test` for validation.
+
 ### PR review fixes — radialtree_cmd.go + config (2026-04-15)
 
 - **Kong defaults silently override config**: `default:"all"` on a Kong string field causes Kong to always set the value, so `applyOverrides` always writes over config file values. Fix: remove `default:` tags from Kong fields, add `""` to enum, set defaults in `config.New()` only.

--- a/.squad/agents/lambert/history.md
+++ b/.squad/agents/lambert/history.md
@@ -48,3 +48,13 @@ Followed the exact style from `internal/treemap/layout_test.go`: `t.Parallel()`,
 - `computeLeafCount` returns actual 0 for empty dir; zero-guard happens at call site in `layoutDir`
 - `buildDiscParams` sets `useEqual=true` when all non-zero metric values are equal (single-value or uniform case)
 - Render test compilation depends on Parker completing their `sort`-usage addition to `radialtree.go`
+
+### 2026-04-18 — Foliage palette tests
+
+Added `TestFoliagePalette` to `internal/palette/palette_test.go` covering:
+- 11 colour steps, ordered, correct name
+- First step near-black (R, G, B all ≤ 30)
+- Last step green-dominant (G > R and G > B)
+- Foliage already included in `TestPaletteName_IsValid` and `TestWCAGContrastRatio` by Dallas
+
+Pattern: palette tests follow a consistent shape — step count, ordered flag, name check, then endpoint colour assertions. WCAG contrast test covers all ordered palettes via a shared loop.

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -133,6 +133,27 @@ This keeps text upright on both canvas halves.
 
 **Docs:** `layout.go` computeLeafCount doc fixed (returns 0; callers guard).
 
+---
+
+### Foliage Palette — Issue #46
+
+**Author:** Dallas  
+**Date:** 2026-04-18  
+**Status:** Implemented  
+**Files:** `internal/palette/palette.go`, `internal/palette/palette_test.go`
+
+**Decision:**
+Added `Foliage` palette (`"foliage"`) — an 11-step ordered colour ramp from near-black (dead plant) through brown, orange, yellow, to intense green (healthy plant). Intended for "health" visualisations where low values = dead/brown and high values = healthy green.
+
+**Colour Progression:**
+Black → dark brown → brown → dark orange → orange → yellow-orange → yellow → yellow-green → medium green → intense green.
+
+**Rationale:**
+- Plant-health metaphor is intuitive for code-health metrics (age, churn, coverage).
+- 11 steps matches the temperature palette granularity.
+- All adjacent steps pass WCAG 2.0 contrast ratio >= 1.0.
+- Palette is `Ordered: true` so it works with the existing numeric metric mapper.
+
 ## Governance
 
 - All meaningful changes require team consensus

--- a/cmd/codeviz/radialtree_cmd.go
+++ b/cmd/codeviz/radialtree_cmd.go
@@ -27,9 +27,9 @@ type RadialCmd struct {
 	DiscSize metric.Name `enum:"file-size,file-lines,file-age,file-freshness,author-count" help:"Metric for disc size." required:"true" short:"d"` //nolint:revive // kong struct tags require long lines
 
 	Fill          string `default:"" enum:",file-size,file-lines,file-type,file-age,file-freshness,author-count" help:"Metric for fill colour." optional:"" short:"f"`   //nolint:revive // kong struct tags require long lines
-	FillPalette   string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for fill colour." name:"fill-palette" optional:""`                //nolint:revive // kong struct tags require long lines
+	FillPalette   string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for fill colour." name:"fill-palette" optional:""`        //nolint:revive // kong struct tags require long lines
 	Border        string `default:"" enum:",file-size,file-lines,file-type,file-age,file-freshness,author-count" help:"Metric for border colour." optional:"" short:"b"` //nolint:revive // kong struct tags require long lines
-	BorderPalette string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for border colour." name:"border-palette" optional:""`            //nolint:revive // kong struct tags require long lines
+	BorderPalette string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for border colour." name:"border-palette" optional:""`    //nolint:revive // kong struct tags require long lines
 
 	Labels string `enum:",all,folders,none" default:"" help:"Labels to display: all, folders, or none."`
 

--- a/cmd/codeviz/radialtree_cmd.go
+++ b/cmd/codeviz/radialtree_cmd.go
@@ -27,9 +27,9 @@ type RadialCmd struct {
 	DiscSize metric.Name `enum:"file-size,file-lines,file-age,file-freshness,author-count" help:"Metric for disc size." required:"true" short:"d"` //nolint:revive // kong struct tags require long lines
 
 	Fill          string `default:"" enum:",file-size,file-lines,file-type,file-age,file-freshness,author-count" help:"Metric for fill colour." optional:"" short:"f"`   //nolint:revive // kong struct tags require long lines
-	FillPalette   string `default:"" enum:",categorization,temperature,good-bad,neutral" help:"Palette for fill colour." name:"fill-palette" optional:""`                //nolint:revive // kong struct tags require long lines
+	FillPalette   string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for fill colour." name:"fill-palette" optional:""`                //nolint:revive // kong struct tags require long lines
 	Border        string `default:"" enum:",file-size,file-lines,file-type,file-age,file-freshness,author-count" help:"Metric for border colour." optional:"" short:"b"` //nolint:revive // kong struct tags require long lines
-	BorderPalette string `default:"" enum:",categorization,temperature,good-bad,neutral" help:"Palette for border colour." name:"border-palette" optional:""`            //nolint:revive // kong struct tags require long lines
+	BorderPalette string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for border colour." name:"border-palette" optional:""`            //nolint:revive // kong struct tags require long lines
 
 	Labels string `enum:",all,folders,none" default:"" help:"Labels to display: all, folders, or none."`
 

--- a/cmd/codeviz/treemap_cmd.go
+++ b/cmd/codeviz/treemap_cmd.go
@@ -29,9 +29,9 @@ type TreemapCmd struct {
 	Size metric.Name `enum:"file-size,file-lines,file-age,file-freshness,author-count" help:"Metric for rectangle area." required:"true" short:"s"` //nolint:revive // kong struct tags require long lines
 
 	Fill          string `default:"" enum:",file-size,file-lines,file-type,file-age,file-freshness,author-count" help:"Metric for fill colour." optional:"" short:"f"`   //nolint:revive // kong struct tags require long lines
-	FillPalette   string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for fill colour." name:"fill-palette" optional:""`                //nolint:revive // kong struct tags require long lines
+	FillPalette   string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for fill colour." name:"fill-palette" optional:""`        //nolint:revive // kong struct tags require long lines
 	Border        string `default:"" enum:",file-size,file-lines,file-type,file-age,file-freshness,author-count" help:"Metric for border colour." optional:"" short:"b"` //nolint:revive // kong struct tags require long lines
-	BorderPalette string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for border colour." name:"border-palette" optional:""`            //nolint:revive // kong struct tags require long lines
+	BorderPalette string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for border colour." name:"border-palette" optional:""`    //nolint:revive // kong struct tags require long lines
 
 	Width  int `default:"1920" help:"Image width in pixels."`
 	Height int `default:"1080" help:"Image height in pixels."`

--- a/cmd/codeviz/treemap_cmd.go
+++ b/cmd/codeviz/treemap_cmd.go
@@ -29,9 +29,9 @@ type TreemapCmd struct {
 	Size metric.Name `enum:"file-size,file-lines,file-age,file-freshness,author-count" help:"Metric for rectangle area." required:"true" short:"s"` //nolint:revive // kong struct tags require long lines
 
 	Fill          string `default:"" enum:",file-size,file-lines,file-type,file-age,file-freshness,author-count" help:"Metric for fill colour." optional:"" short:"f"`   //nolint:revive // kong struct tags require long lines
-	FillPalette   string `default:"" enum:",categorization,temperature,good-bad,neutral" help:"Palette for fill colour." name:"fill-palette" optional:""`                //nolint:revive // kong struct tags require long lines
+	FillPalette   string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for fill colour." name:"fill-palette" optional:""`                //nolint:revive // kong struct tags require long lines
 	Border        string `default:"" enum:",file-size,file-lines,file-type,file-age,file-freshness,author-count" help:"Metric for border colour." optional:"" short:"b"` //nolint:revive // kong struct tags require long lines
-	BorderPalette string `default:"" enum:",categorization,temperature,good-bad,neutral" help:"Palette for border colour." name:"border-palette" optional:""`            //nolint:revive // kong struct tags require long lines
+	BorderPalette string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for border colour." name:"border-palette" optional:""`            //nolint:revive // kong struct tags require long lines
 
 	Width  int `default:"1920" help:"Image width in pixels."`
 	Height int `default:"1080" help:"Image height in pixels."`

--- a/internal/palette/palette.go
+++ b/internal/palette/palette.go
@@ -15,6 +15,7 @@ const (
 	Temperature    PaletteName = "temperature"
 	GoodBad        PaletteName = "good-bad"
 	Neutral        PaletteName = "neutral"
+	Foliage        PaletteName = "foliage"
 )
 
 var validPalettes = map[PaletteName]struct{}{
@@ -22,6 +23,7 @@ var validPalettes = map[PaletteName]struct{}{
 	Temperature:    {},
 	GoodBad:        {},
 	Neutral:        {},
+	Foliage:        {},
 }
 
 func (p PaletteName) IsValid() bool {
@@ -59,6 +61,7 @@ var palettes = map[PaletteName]ColourPalette{
 	Categorization: categorizationPalette,
 	Temperature:    temperaturePalette,
 	GoodBad:        goodBadPalette,
+	Foliage:        foliagePalette,
 }
 
 // Categorization palette: 12 visually distinct unordered colours (ColorBrewer Paired).
@@ -118,6 +121,25 @@ var goodBadPalette = ColourPalette{
 		{R: 26, G: 152, B: 80, A: 255},
 		{R: 0, G: 104, B: 55, A: 255},
 		{R: 0, G: 68, B: 27, A: 255},
+	},
+}
+
+// Foliage palette: 11 steps, black → brown → orange → yellow → green (plant health).
+var foliagePalette = ColourPalette{
+	Name:    Foliage,
+	Ordered: true,
+	Colours: []color.RGBA{
+		{R: 15, G: 10, B: 5, A: 255},    // near black (dead)
+		{R: 45, G: 25, B: 10, A: 255},   // very dark brown
+		{R: 85, G: 45, B: 15, A: 255},   // dark brown
+		{R: 130, G: 70, B: 20, A: 255},  // brown
+		{R: 175, G: 95, B: 25, A: 255},  // dark orange
+		{R: 210, G: 130, B: 30, A: 255}, // orange
+		{R: 230, G: 175, B: 40, A: 255}, // yellow-orange
+		{R: 240, G: 215, B: 50, A: 255}, // yellow
+		{R: 165, G: 200, B: 50, A: 255}, // yellow-green
+		{R: 80, G: 165, B: 40, A: 255},  // medium green
+		{R: 25, G: 120, B: 20, A: 255},  // intense green
 	},
 }
 

--- a/internal/palette/palette.go
+++ b/internal/palette/palette.go
@@ -85,6 +85,8 @@ var categorizationPalette = ColourPalette{
 }
 
 // Temperature palette: 11 steps, dark blue → white → bright red (ColorBrewer RdBu diverging).
+//
+//nolint:dupl // palette declarations are structurally identical by design
 var temperaturePalette = ColourPalette{
 	Name:    Temperature,
 	Ordered: true,
@@ -125,6 +127,8 @@ var goodBadPalette = ColourPalette{
 }
 
 // Foliage palette: 11 steps, black → brown → orange → yellow → green (plant health).
+//
+//nolint:dupl // palette declarations are structurally identical by design
 var foliagePalette = ColourPalette{
 	Name:    Foliage,
 	Ordered: true,

--- a/internal/palette/palette_test.go
+++ b/internal/palette/palette_test.go
@@ -50,6 +50,7 @@ func TestPaletteName_IsValid(t *testing.T) {
 	g.Expect(Categorization.IsValid()).To(BeTrue())
 	g.Expect(Temperature.IsValid()).To(BeTrue())
 	g.Expect(GoodBad.IsValid()).To(BeTrue())
+	g.Expect(Foliage.IsValid()).To(BeTrue())
 	g.Expect(PaletteName("invalid").IsValid()).To(BeFalse())
 }
 
@@ -100,11 +101,30 @@ func TestGoodBadPalette(t *testing.T) {
 	g.Expect(last.G).To(BeNumerically(">", last.R))
 }
 
+func TestFoliagePalette(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	p := GetPalette(Foliage)
+	g.Expect(p.Colours).To(HaveLen(11))
+	g.Expect(p.Ordered).To(BeTrue())
+	g.Expect(p.Name).To(Equal(Foliage))
+
+	// First step: near black
+	g.Expect(p.Colours[0].R).To(BeNumerically("<=", 30))
+	g.Expect(p.Colours[0].G).To(BeNumerically("<=", 30))
+	g.Expect(p.Colours[0].B).To(BeNumerically("<=", 30))
+	// Last step: green-dominant
+	last := p.Colours[10]
+	g.Expect(last.G).To(BeNumerically(">", last.R))
+	g.Expect(last.G).To(BeNumerically(">", last.B))
+}
+
 func TestWCAGContrastRatio(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	for _, name := range []PaletteName{Neutral, Temperature, GoodBad, Categorization} {
+	for _, name := range []PaletteName{Neutral, Temperature, GoodBad, Categorization, Foliage} {
 		p := GetPalette(name)
 		if !p.Ordered {
 			continue // skip unordered palettes for adjacent contrast check


### PR DESCRIPTION
## Summary

Add a new **foliage** palette — an 11-step ordered colour progression inspired by plant health:

| Step | Colour | Meaning |
|------|--------|---------|
| 0 | Near black | Dead |
| 1–2 | Dark/medium brown | Dying |
| 3–4 | Dark orange / orange | Autumn |
| 5–6 | Yellow-orange / yellow | Stressed |
| 7 | Yellow-green | Transitioning |
| 8–10 | Medium → intense green | Healthy |

### Changes
- **`internal/palette/palette.go`** — New `Foliage` constant, palette definition, registered in maps
- **`internal/palette/palette_test.go`** — Tests for step count, ordering, color characteristics, IsValid, and WCAG contrast

### Testing
All 13 packages pass. Build succeeds.

Closes #46