### PR TITLE
Remove redundant size/discSize parameters passed alongside cfg struct

### DIFF
--- a/cmd/codeviz/bubbletree_cmd.go
+++ b/cmd/codeviz/bubbletree_cmd.go
@@ -158,23 +158,23 @@ func (c *BubbletreeCmd) Run(flags *Flags) error {
 	width := ptrInt(flags.Config.Width, 1920)
 	height := ptrInt(flags.Config.Height, 1080)
 
-	return c.renderAndLog(root, cfg, size, width, height, fillMetric, fillPaletteName)
+	return c.renderAndLog(root, cfg, width, height, fillMetric, fillPaletteName)
 }
 
 func (c *BubbletreeCmd) renderAndLog(
 	root *model.Directory,
 	cfg *config.Bubbletree,
-	size metric.Name,
 	width, height int,
 	fillMetric metric.Name,
 	fillPaletteName palette.PaletteName,
 ) error {
+	size := metric.Name(ptrString(cfg.Size))
 	files, dirs := countAll(root)
 
 	slog.Info("Rendering image", "output", c.Output, "width", width, "height", height)
 
 	borderMetric, borderPaletteName, err := c.applyColoursAndRender(
-		cfg, root, size, width, height, fillMetric, fillPaletteName,
+		cfg, root, width, height, fillMetric, fillPaletteName,
 	)
 	if err != nil {
 		return err
@@ -200,11 +200,11 @@ func (c *BubbletreeCmd) renderAndLog(
 func (c *BubbletreeCmd) applyColoursAndRender(
 	cfg *config.Bubbletree,
 	root *model.Directory,
-	size metric.Name,
 	width, height int,
 	fillMetric metric.Name,
 	fillPaletteName palette.PaletteName,
 ) (metric.Name, palette.PaletteName, error) {
+	size := metric.Name(ptrString(cfg.Size))
 	labels := c.resolveLabels(cfg)
 	nodes := bubbletree.Layout(root, width, height, size, labels)
 	applyBubbleFillColoursTop(&nodes, root, fillMetric, fillPaletteName)

--- a/cmd/codeviz/radialtree_cmd.go
+++ b/cmd/codeviz/radialtree_cmd.go
@@ -151,21 +151,22 @@ func (c *RadialCmd) Run(flags *Flags) error {
 
 	canvasSize := min(ptrInt(flags.Config.Width, 1920), ptrInt(flags.Config.Height, 1920))
 
-	return c.renderAndLog(root, cfg, discSize, files, dirs, canvasSize, fillMetric, fillPaletteName)
+	return c.renderAndLog(root, cfg, files, dirs, canvasSize, fillMetric, fillPaletteName)
 }
 
 func (c *RadialCmd) renderAndLog(
 	root *model.Directory,
 	cfg *config.Radial,
-	discSize metric.Name,
 	files, dirs, canvasSize int,
 	fillMetric metric.Name,
 	fillPaletteName palette.PaletteName,
 ) error {
+	discSize := metric.Name(ptrString(cfg.DiscSize))
+
 	slog.Info("Rendering image", "output", c.Output, "canvas_size", canvasSize)
 
 	borderMetric, borderPaletteName, err := c.applyColoursAndRender(
-		cfg, root, discSize, canvasSize, fillMetric, fillPaletteName,
+		cfg, root, canvasSize, fillMetric, fillPaletteName,
 	)
 	if err != nil {
 		return err
@@ -190,11 +191,11 @@ func (c *RadialCmd) renderAndLog(
 func (c *RadialCmd) applyColoursAndRender(
 	cfg *config.Radial,
 	root *model.Directory,
-	discSize metric.Name,
 	canvasSize int,
 	fillMetric metric.Name,
 	fillPaletteName palette.PaletteName,
 ) (metric.Name, palette.PaletteName, error) {
+	discSize := metric.Name(ptrString(cfg.DiscSize))
 	labels := c.resolveLabels(cfg)
 	nodes := radialtree.Layout(root, canvasSize, discSize, labels)
 	applyRadialFillColoursTop(&nodes, root, fillMetric, fillPaletteName)

--- a/cmd/codeviz/treemap_cmd.go
+++ b/cmd/codeviz/treemap_cmd.go
@@ -195,7 +195,7 @@ func (c *TreemapCmd) Run(flags *Flags) error {
 	width := ptrInt(flags.Config.Width, 1920)
 	height := ptrInt(flags.Config.Height, 1080)
 
-	return c.renderAndLog(root, cfg, size, width, height, fillMetric, fillPaletteName)
+	return c.renderAndLog(root, cfg, width, height, fillMetric, fillPaletteName)
 }
 
 // minReservableSize is the smallest treemap dimension (px) that still
@@ -282,11 +282,11 @@ func resolveBorderPaletteName(cfg *config.Treemap) (metric.Name, palette.Palette
 func (c *TreemapCmd) renderAndLog(
 	root *model.Directory,
 	cfg *config.Treemap,
-	size metric.Name,
 	width, height int,
 	fillMetric metric.Name,
 	fillPaletteName palette.PaletteName,
 ) error {
+	size := metric.Name(ptrString(cfg.Size))
 	files, dirs := countAll(root)
 
 	slog.Info("Rendering image", "output", c.Output, "width", width, "height", height)


### PR DESCRIPTION
## Summary

Fixes #101

Several `renderAndLog` and `applyColoursAndRender` methods received both a config struct (`cfg`) and a `size`/`discSize metric.Name` parameter that was always a trivial extraction from that same config (`metric.Name(ptrString(cfg.Size))`). Each function now computes the size metric internally from `cfg`, eliminating the redundancy.

## Changes

**5 methods updated** across 3 files:

| File | Method |
|------|--------|
| `treemap_cmd.go` | `TreemapCmd.renderAndLog` |
| `radialtree_cmd.go` | `RadialCmd.renderAndLog` |
| `radialtree_cmd.go` | `RadialCmd.applyColoursAndRender` |
| `bubbletree_cmd.go` | `BubbletreeCmd.renderAndLog` |
| `bubbletree_cmd.go` | `BubbletreeCmd.applyColoursAndRender` |

Each function now derives `size`/`discSize` from `cfg` at its top, rather than receiving it as a separate parameter.