### PR TITLE
Remove redundant numBuckets parameter passed alongside buckets struct

### DIFF
--- a/cmd/codeviz/bubbletree_cmd.go
+++ b/cmd/codeviz/bubbletree_cmd.go
@@ -420,8 +420,7 @@ func applyBubbleFillColoursTop(
 		values := collectNumericValues(root, fillMetric)
 		if len(values) > 0 {
 			buckets := metric.ComputeBuckets(values, len(fillPalette.Colours))
-			numBuckets := len(buckets.Boundaries) + 1
-			applyBubbleFillColours(nodes, root, fillMetric, buckets, numBuckets, fillPalette)
+			applyBubbleFillColours(nodes, root, fillMetric, buckets, fillPalette)
 		}
 	} else {
 		types := collectDistinctTypes(root, fillMetric)
@@ -463,8 +462,7 @@ func (*BubbletreeCmd) applyBorderColours(
 		values := collectNumericValues(root, borderMetric)
 		if len(values) > 0 {
 			buckets := metric.ComputeBuckets(values, len(borderPalette.Colours))
-			numBuckets := len(buckets.Boundaries) + 1
-			applyBubbleBorderColours(nodes, root, borderMetric, buckets, numBuckets, borderPalette)
+			applyBubbleBorderColours(nodes, root, borderMetric, buckets, borderPalette)
 		}
 	} else {
 		types := collectDistinctTypes(root, borderMetric)
@@ -500,21 +498,19 @@ func applyBubbleFillColours(
 	root *model.Directory,
 	m metric.Name,
 	buckets metric.BucketBoundaries,
-	numBuckets int,
 	p palette.ColourPalette,
 ) {
 	dirs := make(map[string]*bubbletree.BubbleNode)
 	files := make(map[string]*bubbletree.BubbleNode)
 	indexBubbleNodesByPath(node, dirs, files)
 
-	applyBubbleFillColoursWalk(root, m, buckets, numBuckets, p, dirs, files)
+	applyBubbleFillColoursWalk(root, m, buckets, p, dirs, files)
 }
 
 func applyBubbleFillColoursWalk(
 	dir *model.Directory,
 	m metric.Name,
 	buckets metric.BucketBoundaries,
-	numBuckets int,
 	p palette.ColourPalette,
 	dirs map[string]*bubbletree.BubbleNode,
 	files map[string]*bubbletree.BubbleNode,
@@ -523,13 +519,13 @@ func applyBubbleFillColoursWalk(
 		if bn, ok := files[f.Path]; ok {
 			val := extractNumeric(f, m)
 			idx := buckets.BucketIndex(val)
-			bn.FillColour = palette.MapNumericToColour(idx, numBuckets, p)
+			bn.FillColour = palette.MapNumericToColour(idx, buckets.NumBuckets(), p)
 		}
 	}
 
 	for _, d := range dir.Dirs {
 		if _, ok := dirs[d.Path]; ok {
-			applyBubbleFillColoursWalk(d, m, buckets, numBuckets, p, dirs, files)
+			applyBubbleFillColoursWalk(d, m, buckets, p, dirs, files)
 		}
 	}
 }
@@ -578,21 +574,19 @@ func applyBubbleBorderColours(
 	root *model.Directory,
 	m metric.Name,
 	buckets metric.BucketBoundaries,
-	numBuckets int,
 	p palette.ColourPalette,
 ) {
 	dirs := make(map[string]*bubbletree.BubbleNode)
 	files := make(map[string]*bubbletree.BubbleNode)
 	indexBubbleNodesByPath(node, dirs, files)
 
-	applyBubbleBorderColoursWalk(root, m, buckets, numBuckets, p, dirs, files)
+	applyBubbleBorderColoursWalk(root, m, buckets, p, dirs, files)
 }
 
 func applyBubbleBorderColoursWalk(
 	dir *model.Directory,
 	m metric.Name,
 	buckets metric.BucketBoundaries,
-	numBuckets int,
 	p palette.ColourPalette,
 	dirs map[string]*bubbletree.BubbleNode,
 	files map[string]*bubbletree.BubbleNode,
@@ -601,14 +595,14 @@ func applyBubbleBorderColoursWalk(
 		if bn, ok := files[f.Path]; ok {
 			val := extractNumeric(f, m)
 			idx := buckets.BucketIndex(val)
-			col := palette.MapNumericToColour(idx, numBuckets, p)
+			col := palette.MapNumericToColour(idx, buckets.NumBuckets(), p)
 			bn.BorderColour = &col
 		}
 	}
 
 	for _, d := range dir.Dirs {
 		if _, ok := dirs[d.Path]; ok {
-			applyBubbleBorderColoursWalk(d, m, buckets, numBuckets, p, dirs, files)
+			applyBubbleBorderColoursWalk(d, m, buckets, p, dirs, files)
 		}
 	}
 }

--- a/cmd/codeviz/legend_builder.go
+++ b/cmd/codeviz/legend_builder.go
@@ -125,7 +125,6 @@ func buildLegendEntry(
 		if len(values) > 0 {
 			buckets := metric.ComputeBuckets(values, len(pal.Colours))
 			entry.Buckets = &buckets
-			entry.NumBuckets = len(buckets.Boundaries) + 1
 		}
 	} else {
 		types := collectDistinctTypes(root, metricName)

--- a/cmd/codeviz/radialtree_cmd.go
+++ b/cmd/codeviz/radialtree_cmd.go
@@ -410,8 +410,7 @@ func applyRadialFillColoursTop(
 		values := collectNumericValues(root, fillMetric)
 		if len(values) > 0 {
 			buckets := metric.ComputeBuckets(values, len(fillPalette.Colours))
-			numBuckets := len(buckets.Boundaries) + 1
-			applyRadialFillColours(nodes, root, fillMetric, buckets, numBuckets, fillPalette)
+			applyRadialFillColours(nodes, root, fillMetric, buckets, fillPalette)
 		}
 	} else {
 		types := collectDistinctTypes(root, fillMetric)
@@ -453,8 +452,7 @@ func (*RadialCmd) applyBorderColours(
 		values := collectNumericValues(root, borderMetric)
 		if len(values) > 0 {
 			buckets := metric.ComputeBuckets(values, len(borderPalette.Colours))
-			numBuckets := len(buckets.Boundaries) + 1
-			applyRadialBorderColours(nodes, root, borderMetric, buckets, numBuckets, borderPalette)
+			applyRadialBorderColours(nodes, root, borderMetric, buckets, borderPalette)
 		}
 	} else {
 		types := collectDistinctTypes(root, borderMetric)
@@ -474,7 +472,6 @@ func applyRadialFillColours(
 	dir *model.Directory,
 	m metric.Name,
 	buckets metric.BucketBoundaries,
-	numBuckets int,
 	p palette.ColourPalette,
 ) {
 	fileIdx := 0
@@ -483,12 +480,12 @@ func applyRadialFillColours(
 	for i := range node.Children {
 		child := &node.Children[i]
 		if child.IsDirectory && dirIdx < len(dir.Dirs) {
-			applyRadialFillColours(child, dir.Dirs[dirIdx], m, buckets, numBuckets, p)
+			applyRadialFillColours(child, dir.Dirs[dirIdx], m, buckets, p)
 			dirIdx++
 		} else if !child.IsDirectory && fileIdx < len(dir.Files) {
 			val := extractNumeric(dir.Files[fileIdx], m)
 			idx := buckets.BucketIndex(val)
-			child.FillColour = palette.MapNumericToColour(idx, numBuckets, p)
+			child.FillColour = palette.MapNumericToColour(idx, buckets.NumBuckets(), p)
 			fileIdx++
 		}
 	}
@@ -531,7 +528,6 @@ func applyRadialBorderColours(
 	dir *model.Directory,
 	m metric.Name,
 	buckets metric.BucketBoundaries,
-	numBuckets int,
 	p palette.ColourPalette,
 ) {
 	fileIdx := 0
@@ -540,12 +536,12 @@ func applyRadialBorderColours(
 	for i := range node.Children {
 		child := &node.Children[i]
 		if child.IsDirectory && dirIdx < len(dir.Dirs) {
-			applyRadialBorderColours(child, dir.Dirs[dirIdx], m, buckets, numBuckets, p)
+			applyRadialBorderColours(child, dir.Dirs[dirIdx], m, buckets, p)
 			dirIdx++
 		} else if !child.IsDirectory && fileIdx < len(dir.Files) {
 			val := extractNumeric(dir.Files[fileIdx], m)
 			idx := buckets.BucketIndex(val)
-			col := palette.MapNumericToColour(idx, numBuckets, p)
+			col := palette.MapNumericToColour(idx, buckets.NumBuckets(), p)
 			child.BorderColour = &col
 			fileIdx++
 		}

--- a/cmd/codeviz/treemap_cmd.go
+++ b/cmd/codeviz/treemap_cmd.go
@@ -535,8 +535,7 @@ func applyFillColours(
 		values := collectNumericValues(root, fillMetric)
 		if len(values) > 0 {
 			buckets := metric.ComputeBuckets(values, len(fillPalette.Colours))
-			numBuckets := len(buckets.Boundaries) + 1
-			applyNumericFillColours(rects, root, fillMetric, buckets, numBuckets, fillPalette)
+			applyNumericFillColours(rects, root, fillMetric, buckets, fillPalette)
 		}
 	} else {
 		types := collectDistinctTypes(root, fillMetric)
@@ -578,8 +577,7 @@ func (*TreemapCmd) applyBorderColours(
 		values := collectNumericValues(root, borderMetric)
 		if len(values) > 0 {
 			buckets := metric.ComputeBuckets(values, len(borderPalette.Colours))
-			numBuckets := len(buckets.Boundaries) + 1
-			applyNumericBorderColours(rects, root, borderMetric, buckets, numBuckets, borderPalette)
+			applyNumericBorderColours(rects, root, borderMetric, buckets, borderPalette)
 		}
 	} else {
 		types := collectDistinctTypes(root, borderMetric)
@@ -636,7 +634,6 @@ func applyNumericFillColours(
 	node *model.Directory,
 	m metric.Name,
 	buckets metric.BucketBoundaries,
-	numBuckets int,
 	p palette.ColourPalette,
 ) {
 	fileIdx := 0
@@ -645,12 +642,12 @@ func applyNumericFillColours(
 	for i := range rect.Children {
 		child := &rect.Children[i]
 		if child.IsDirectory && dirIdx < len(node.Dirs) {
-			applyNumericFillColours(child, node.Dirs[dirIdx], m, buckets, numBuckets, p)
+			applyNumericFillColours(child, node.Dirs[dirIdx], m, buckets, p)
 			dirIdx++
 		} else if !child.IsDirectory && fileIdx < len(node.Files) {
 			val := extractNumeric(node.Files[fileIdx], m)
 			idx := buckets.BucketIndex(val)
-			child.FillColour = palette.MapNumericToColour(idx, numBuckets, p)
+			child.FillColour = palette.MapNumericToColour(idx, buckets.NumBuckets(), p)
 			fileIdx++
 		}
 	}
@@ -685,7 +682,6 @@ func applyNumericBorderColours(
 	node *model.Directory,
 	m metric.Name,
 	buckets metric.BucketBoundaries,
-	numBuckets int,
 	p palette.ColourPalette,
 ) {
 	fileIdx := 0
@@ -694,12 +690,12 @@ func applyNumericBorderColours(
 	for i := range rect.Children {
 		child := &rect.Children[i]
 		if child.IsDirectory && dirIdx < len(node.Dirs) {
-			applyNumericBorderColours(child, node.Dirs[dirIdx], m, buckets, numBuckets, p)
+			applyNumericBorderColours(child, node.Dirs[dirIdx], m, buckets, p)
 			dirIdx++
 		} else if !child.IsDirectory && fileIdx < len(node.Files) {
 			val := extractNumeric(node.Files[fileIdx], m)
 			idx := buckets.BucketIndex(val)
-			col := palette.MapNumericToColour(idx, numBuckets, p)
+			col := palette.MapNumericToColour(idx, buckets.NumBuckets(), p)
 			child.BorderColour = &col
 			fileIdx++
 		}

--- a/internal/metric/bucket.go
+++ b/internal/metric/bucket.go
@@ -62,6 +62,11 @@ func ComputeBuckets(values []float64, steps int) BucketBoundaries {
 	}
 }
 
+// NumBuckets returns the total number of buckets (len(Boundaries) + 1).
+func (b BucketBoundaries) NumBuckets() int {
+	return len(b.Boundaries) + 1
+}
+
 // BucketIndex returns the bucket index (0-based) for the given value.
 func (b BucketBoundaries) BucketIndex(value float64) int {
 	for i, boundary := range b.Boundaries {

--- a/internal/render/legend.go
+++ b/internal/render/legend.go
@@ -51,12 +51,20 @@ type LegendEntry struct {
 	Kind       metric.Kind
 
 	// For Quantity/Measure metrics:
-	Buckets    *metric.BucketBoundaries
-	NumBuckets int
-	Palette    palette.ColourPalette
+	Buckets *metric.BucketBoundaries
+	Palette palette.ColourPalette
 
 	// For Classification metrics:
 	Categories []CategorySwatch
+}
+
+// NumBuckets returns the total number of buckets for this entry.
+func (e LegendEntry) NumBuckets() int {
+	if e.Buckets == nil {
+		return 0
+	}
+
+	return e.Buckets.NumBuckets()
 }
 
 // CategorySwatch pairs a category label with its colour.

--- a/internal/render/legend_png.go
+++ b/internal/render/legend_png.go
@@ -101,7 +101,7 @@ func drawNumericSwatches(
 	entry LegendEntry,
 	x, y float64,
 ) float64 {
-	if entry.NumBuckets <= 0 || len(entry.Palette.Colours) == 0 {
+	if entry.NumBuckets() <= 0 || len(entry.Palette.Colours) == 0 {
 		return y
 	}
 
@@ -118,7 +118,7 @@ func drawNumericSwatchesV(
 	entry LegendEntry,
 	x, y float64,
 ) float64 {
-	for i := range entry.NumBuckets {
+	for i := range entry.NumBuckets() {
 		colour := mapBucketColour(i, entry)
 		dc.SetColor(colour)
 		dc.DrawRectangle(x, y, swatchSize, swatchSize)
@@ -156,7 +156,7 @@ func drawNumericSwatchesH(
 ) float64 {
 	cx := x
 
-	for i := range entry.NumBuckets {
+	for i := range entry.NumBuckets() {
 		colour := mapBucketColour(i, entry)
 		dc.SetColor(colour)
 		dc.DrawRectangle(cx, y, swatchSize, swatchSize)
@@ -362,7 +362,7 @@ func measureEntryH(dc *gg.Context, entry LegendEntry) (width, height float64) {
 
 // measureNumericV measures numeric entry in vertical layout.
 func measureNumericV(dc *gg.Context, entry LegendEntry) (width, height float64) {
-	h := float64(entry.NumBuckets) * swatchSize
+	h := float64(entry.NumBuckets()) * swatchSize
 	w := swatchSize
 
 	if entry.Buckets != nil {
@@ -380,7 +380,7 @@ func measureNumericV(dc *gg.Context, entry LegendEntry) (width, height float64) 
 
 // measureNumericH measures numeric entry in horizontal layout.
 func measureNumericH(_ *gg.Context, entry LegendEntry) (width, height float64) {
-	w := float64(entry.NumBuckets) * swatchSize
+	w := float64(entry.NumBuckets()) * swatchSize
 	h := swatchSize + legendLineHeight + labelGap
 
 	return w, h
@@ -426,7 +426,7 @@ func mapBucketColour(bucketIdx int, entry LegendEntry) color.RGBA {
 		return color.RGBA{R: 128, G: 128, B: 128, A: 255}
 	}
 
-	return palette.MapNumericToColour(bucketIdx, entry.NumBuckets, entry.Palette)
+	return palette.MapNumericToColour(bucketIdx, entry.NumBuckets(), entry.Palette)
 }
 
 // formatBreakpoint formats a numeric breakpoint for display.

--- a/internal/render/legend_svg.go
+++ b/internal/render/legend_svg.go
@@ -112,7 +112,7 @@ func writeSVGNumericSwatches(
 	entry LegendEntry,
 	x, y float64,
 ) float64 {
-	if entry.NumBuckets <= 0 || len(entry.Palette.Colours) == 0 {
+	if entry.NumBuckets() <= 0 || len(entry.Palette.Colours) == 0 {
 		return y
 	}
 
@@ -125,7 +125,7 @@ func writeSVGNumericSwatches(
 
 // writeSVGNumericV writes vertically stacked numeric swatches.
 func writeSVGNumericV(f *os.File, entry LegendEntry, x, y float64) float64 {
-	for i := range entry.NumBuckets {
+	for i := range entry.NumBuckets() {
 		colour := mapBucketColour(i, entry)
 		writeSVGSwatch(f, x, y, colourToHex(colour))
 
@@ -149,7 +149,7 @@ func writeSVGNumericV(f *os.File, entry LegendEntry, x, y float64) float64 {
 func writeSVGNumericH(f *os.File, entry LegendEntry, x, y float64) float64 {
 	cx := x
 
-	for i := range entry.NumBuckets {
+	for i := range entry.NumBuckets() {
 		colour := mapBucketColour(i, entry)
 		writeSVGSwatch(f, cx, y, colourToHex(colour))
 

--- a/internal/render/legend_test.go
+++ b/internal/render/legend_test.go
@@ -118,7 +118,6 @@ func makeSampleLegendInfo(orient LegendOrientation) *LegendInfo {
 				Role:       "Fill",
 				MetricName: "file-size",
 				Kind:       metric.Quantity,
-				NumBuckets: 5,
 				Palette:    pal,
 				Buckets: &metric.BucketBoundaries{
 					Boundaries: []float64{100, 500, 1000, 5000},


### PR DESCRIPTION
## Summary

Fixes #102

`numBuckets int` was passed as a separate parameter alongside `buckets metric.BucketBoundaries` in 8 function signatures, even though it was always trivially derived as `len(buckets.Boundaries) + 1`. The `LegendEntry` struct had the same redundancy with a `NumBuckets` field.

## Approach

Added a `NumBuckets() int` method to `metric.BucketBoundaries` that centralizes the computation. Replaced all redundant parameters and fields with calls to this method.

## Changes

**9 files changed** across 4 packages:

| File | Change |
|------|--------|
| `internal/metric/bucket.go` | Added `BucketBoundaries.NumBuckets()` method |
| `internal/render/legend.go` | Replaced `LegendEntry.NumBuckets` field with a `NumBuckets()` method that delegates to `Buckets.NumBuckets()` |
| `internal/render/legend_png.go` | Updated 6 usages: `entry.NumBuckets` → `entry.NumBuckets()` |
| `internal/render/legend_svg.go` | Updated 3 usages: `entry.NumBuckets` → `entry.NumBuckets()` |
| `internal/render/legend_test.go` | Removed redundant `NumBuckets: 5` from struct literal (now derived from `Buckets`) |
| `cmd/codeviz/legend_builder.go` | Removed manual `entry.NumBuckets = len(...) + 1` assignment |
| `cmd/codeviz/treemap_cmd.go` | Removed `numBuckets` from `applyNumericFillColours` and `applyNumericBorderColours` |
| `cmd/codeviz/radialtree_cmd.go` | Removed `numBuckets` from `applyRadialFillColours` and `applyRadialBorderColours` |
| `cmd/codeviz/bubbletree_cmd.go` | Removed `numBuckets` from 4 functions: `applyBubble{Fill,Border}Colours` and their `Walk` variants |

Net result: **-3 lines** (45 insertions, 48 deletions), eliminating ~20 lines of boilerplate `numBuckets := len(buckets.Boundaries) + 1` computation.