### PR TITLE
Fix binary file detection for PNG and other image files

### DIFF
--- a/internal/provider/filesystem/metrics.go
+++ b/internal/provider/filesystem/metrics.go
@@ -3,7 +3,9 @@ package filesystem
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
+	"io"
 	"log/slog"
 	"os"
 
@@ -75,7 +77,11 @@ func (FileLinesProvider) Load(root *model.Directory) error {
 	return nil
 }
 
-var errBinaryFile = errors.New("file appears to be binary (line exceeds 64KB)")
+var errBinaryFile = errors.New("file appears to be binary")
+
+// binaryProbeSize is the number of bytes read from the start of a file to
+// detect binary content. This matches the heuristic used by Git.
+const binaryProbeSize = 8000
 
 func countLines(path string) (int64, error) {
 	file, err := os.Open(path)
@@ -83,6 +89,12 @@ func countLines(path string) (int64, error) {
 		return 0, eris.Wrap(err, "opening file for line count")
 	}
 	defer file.Close()
+
+	if isBinary, err := probeBinary(file); err != nil {
+		return 0, err
+	} else if isBinary {
+		return 0, errBinaryFile
+	}
 
 	scanner := bufio.NewScanner(file)
 
@@ -100,4 +112,54 @@ func countLines(path string) (int64, error) {
 	}
 
 	return count, nil
+}
+
+// probeBinary reads the first binaryProbeSize bytes of f and reports whether
+// the content looks like a binary file. It uses a null-byte heuristic (same
+// approach as Git) but skips the check for files that start with a UTF-16 BOM,
+// since UTF-16 text legitimately contains null bytes.
+//
+// On return the file is seeked back to the start, ready for line counting.
+func probeBinary(f *os.File) (bool, error) {
+	header := make([]byte, binaryProbeSize)
+
+	n, err := f.Read(header)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, eris.Wrap(err, "reading file header for binary probe")
+	}
+
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return false, eris.Wrap(err, "seeking back to start after binary probe")
+	}
+
+	if n == 0 {
+		return false, nil
+	}
+
+	buf := header[:n]
+
+	if hasUTF16BOM(buf) {
+		return false, nil
+	}
+
+	return bytes.IndexByte(buf, 0) >= 0, nil
+}
+
+// hasUTF16BOM reports whether buf starts with a UTF-16 byte-order mark.
+func hasUTF16BOM(buf []byte) bool {
+	if len(buf) < 2 {
+		return false
+	}
+
+	// UTF-16 LE: FF FE (but not FF FE 00 00, which is UTF-32 LE)
+	if buf[0] == 0xFF && buf[1] == 0xFE {
+		if len(buf) >= 4 && buf[2] == 0x00 && buf[3] == 0x00 {
+			return false // UTF-32 LE — not text we can handle
+		}
+
+		return true
+	}
+
+	// UTF-16 BE: FE FF
+	return buf[0] == 0xFE && buf[1] == 0xFF
 }

--- a/internal/provider/filesystem/metrics_test.go
+++ b/internal/provider/filesystem/metrics_test.go
@@ -128,3 +128,85 @@ func TestFileLinesProviderMetadata(t *testing.T) {
 	g.Expect(p.DefaultPalette()).NotTo(BeEmpty())
 	g.Expect(p.Dependencies()).To(BeNil())
 }
+
+func TestFileLinesProviderDetectsBinaryByNullByte(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir := t.TempDir()
+
+	// A short file with null bytes (like a small PNG) — no line exceeds 64KB
+	_ = os.WriteFile(filepath.Join(dir, "icon.png"), []byte("PNG\x00\x00data\nmore\nlines\n"), 0o600)
+
+	f := &model.File{Path: filepath.Join(dir, "icon.png"), Name: "icon.png"}
+	root := &model.Directory{Path: dir, Name: "root", Files: []*model.File{f}}
+
+	p := FileLinesProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	_, ok := f.Quantity(FileLines)
+	g.Expect(ok).To(BeFalse())
+	g.Expect(f.IsBinary).To(BeTrue())
+}
+
+func TestFileLinesProviderAllowsUTF16LEWithBOM(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir := t.TempDir()
+
+	// UTF-16 LE BOM (FF FE) followed by ASCII 'a' in UTF-16 LE (61 00) + newline (0A 00)
+	content := []byte{0xFF, 0xFE, 0x61, 0x00, 0x0A, 0x00, 0x62, 0x00, 0x0A, 0x00}
+	_ = os.WriteFile(filepath.Join(dir, "code.cs"), content, 0o600)
+
+	f := &model.File{Path: filepath.Join(dir, "code.cs"), Name: "code.cs"}
+	root := &model.Directory{Path: dir, Name: "root", Files: []*model.File{f}}
+
+	p := FileLinesProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(f.IsBinary).To(BeFalse())
+}
+
+func TestFileLinesProviderAllowsUTF16BEWithBOM(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir := t.TempDir()
+
+	// UTF-16 BE BOM (FE FF) followed by ASCII 'a' in UTF-16 BE (00 61) + newline (00 0A)
+	content := []byte{0xFE, 0xFF, 0x00, 0x61, 0x00, 0x0A, 0x00, 0x62, 0x00, 0x0A}
+	_ = os.WriteFile(filepath.Join(dir, "code.cs"), content, 0o600)
+
+	f := &model.File{Path: filepath.Join(dir, "code.cs"), Name: "code.cs"}
+	root := &model.Directory{Path: dir, Name: "root", Files: []*model.File{f}}
+
+	p := FileLinesProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(f.IsBinary).To(BeFalse())
+}
+
+func TestFileLinesProviderHandlesEmptyFile(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "empty.txt"), []byte{}, 0o600)
+
+	f := &model.File{Path: filepath.Join(dir, "empty.txt"), Name: "empty.txt"}
+	root := &model.Directory{Path: dir, Name: "root", Files: []*model.File{f}}
+
+	p := FileLinesProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(f.IsBinary).To(BeFalse())
+
+	v, ok := f.Quantity(FileLines)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(v).To(Equal(int64(0)))
+}


### PR DESCRIPTION
## Summary

Fixes #93

PNG and other image files were not being detected as binary because the existing detection only triggered when `bufio.Scanner` encountered a line exceeding 64KB. Image files have binary content but their data between `\n` bytes is typically shorter than that threshold.

## Approach

Added a null-byte probe at the start of `countLines()` that reads the first 8000 bytes (matching Git's heuristic) and checks for null bytes. This catches binary files early before line scanning begins.

**UTF-16 awareness:** Files starting with a UTF-16 BOM (`FF FE` for LE, `FE FF` for BE) skip the null-byte check, since UTF-16 text legitimately contains null bytes. Note: correct line counting for UTF-16 files is tracked separately in #105.

The existing `bufio.ErrTooLong` fallback is retained as a safety net for binary files that happen to have no null bytes in their first 8KB.

## Changes

| File | Change |
|------|--------|
| `internal/provider/filesystem/metrics.go` | Added `probeBinary()` and `hasUTF16BOM()` functions; `countLines()` now probes before scanning |
| `internal/provider/filesystem/metrics_test.go` | Added 4 new tests: null-byte detection, UTF-16 LE BOM, UTF-16 BE BOM, empty file |

## Tests

- **TestFileLinesProviderDetectsBinaryByNullByte** — short file with null bytes (PNG-like) is correctly flagged binary
- **TestFileLinesProviderAllowsUTF16LEWithBOM** — UTF-16 LE file with BOM is not flagged binary
- **TestFileLinesProviderAllowsUTF16BEWithBOM** — UTF-16 BE file with BOM is not flagged binary
- **TestFileLinesProviderHandlesEmptyFile** — empty file: 0 lines, not binary
- Existing `TestFileLinesProviderSkipsBinaryFiles` (64KB fallback) still passes