### PR TITLE
feat: add --export-data flag to export metrics

### DIFF
--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -9,10 +9,21 @@
 ## Recent Work
 
 - **PR #39 resolution (2026-04-15)**: Fixed FolderAuthorCountProvider dependencies, mean-file-lines description, git error logging. Extracted folder load helpers. Fixed float-to-days conversion and test error handling. Branch squad/38-extend-provider-capabilities task ci passed and pushed.
+- **PR #98 — Legend fixes (#89, #90)**: Fixed horizontal legend layout to arrange entries side-by-side instead of stacking vertically. Made legend margin carve-out respect orientation at corner positions. Branch squad/89-90-legend-fixes.
 
 ## Learnings
 
 <!-- Append learnings below -->
+
+### Export package — issue #107 (2026-04-26)
+
+- **New package:** `internal/export/` — serializes model tree + computed metrics to JSON or YAML files.
+- **Public API:** `Export(root *model.Directory, requested []metric.Name, outputPath string) error` — walks tree recursively, collects only requested metrics, infers format from file extension.
+- **Data structures:** `ExportData` (wrapper with `Root`), `DirectoryExport` (recursive), `FileExport` (leaf) — all carry `json` + `yaml` struct tags with `omitempty` on collection fields.
+- **Format inference:** `.json` → `json.MarshalIndent` (2-space indent + trailing newline), `.yaml`/`.yml` → `gopkg.in/yaml.v3`. Unsupported/missing extensions return descriptive eris errors.
+- **Metric collection pattern:** Lazy-init maps — only allocate `Quantities`/`Measures`/`Classifications` maps when a metric value is actually present. Combined with `omitempty`, this keeps output clean.
+- **Dependency added:** `gopkg.in/yaml.v3` (direct dependency in go.mod).
+- **No tests created** — Lambert owns the test suite. No CLI wiring — Kane handles that.
 
 ### Curved bubble labels — issue #65 (2026-04-20)
 
@@ -109,3 +120,23 @@
 - **Fix:** Added `Path string` field to `BubbleNode` (populated from `model.Directory.Path` and `model.File.Path` during layout). Replaced all four index-based colour walkers with path-indexed lookup via `indexBubbleNodesByPath` helper. Sort stays — it's good for packing. Path makes ordering irrelevant for colour mapping.
 - **Key pattern:** Use direct references (paths, pointers), not positional indices, when correlating two trees that may be independently reordered.
 - **Test added:** `TestLayoutPathPopulated` verifies that Path is propagated through the full tree.
+
+### Legend rendering fixes — issues #89, #90
+
+- **Legend code structure:** Legend rendering is split across four files: `legend.go` (types, constants, `ReserveLegendSpace`, `legendOrigin`), `legend_png.go` (PNG draw + measure), `legend_svg.go` (SVG write), `legend_test.go`.
+- **Horizontal layout bug:** `drawLegendEntries` and `writeSVGLegendEntries` always stacked entries vertically (incrementing Y). Added `drawLegendEntriesH`/`writeSVGLegendEntriesH` that increment X for horizontal orientation.
+- **Measurement symmetry:** `measureLegendH` was structurally identical to `measureLegendV` (summing heights). Fixed to sum widths and take max height. Added `measureSingleEntryH` to measure one entry including title for reuse by both PNG and SVG draw paths.
+- **Orientation-aware carve-out:** `ReserveLegendSpace` only used position (center-left/right → width, everything else → height). For corner positions, vertical legends now carve width; horizontal legends carve height. Center positions remain fixed.
+- **`legendLayoutOffset` in `treemap_cmd.go`:** Updated to handle the new orientation-based offsets for corner positions — left corners offset by wReduce when vertical, top corners offset by hReduce when horizontal.
+- **Key pattern:** When rendering code has H/V variants for swatches but not for the entry-level layout loop, bugs silently produce correct-looking but suboptimal output. Always verify the outer loop handles orientation too.
+
+### Issue #107 — Export Package Implementation (2026-04-26)
+
+- **New package:** `internal/export/` containing `export.go` with main Export() function.
+- **Public API:** `Export(root *model.Directory, requested []metric.Name, outputPath string) error` — recursive tree walk, format inference from extension.
+- **Data structures:** ExportData wrapper, DirectoryExport (recursive), FileExport (leaf) with Quantities/Measures/Classifications maps. All use json+yaml struct tags with omitempty on collection fields.
+- **Format handling:** .json → json.MarshalIndent (2-space indent, trailing newline), .yaml/.yml → gopkg.in/yaml.v3. Unsupported extensions return descriptive eris errors.
+- **Metric collection:** Lazy-init approach — only allocate maps when metric values exist. Combined with omitempty tags, output stays clean.
+- **Dependencies added:** gopkg.in/yaml.v3 (direct, added to go.mod).
+- **Test suite:** Left to Lambert. CLI wiring left to Kane. Focus: export logic only.
+

--- a/.squad/agents/kane/history.md
+++ b/.squad/agents/kane/history.md
@@ -58,3 +58,22 @@
 - **Applied to:** `TreemapCmd`, `RadialCmd`, `BubbletreeCmd` — all three have the same structural pattern.
 - **Key files:** `cmd/codeviz/treemap_cmd.go`, `cmd/codeviz/radialtree_cmd.go`, `cmd/codeviz/bubbletree_cmd.go`.
 
+### Export Data CLI Flag — Issue #107 (2026-04-26)
+
+- **Added `--export-data` flag** to `CLI` struct and `Flags` struct in `cmd/codeviz/main.go`, following the `--export-config` pattern.
+- **Wired `export.Export()` call** into all three visualization commands (`TreemapCmd`, `RadialCmd`, `BubbletreeCmd`).
+- **Placement:** After `filterBinaryFiles()` and before render/layout, matching the design spec (after metrics computed, before rendering).
+- **Import:** `github.com/bevan/code-visualizer/internal/export` added to all three command files.
+- **Won't compile yet:** Depends on Dallas's `internal/export/` package (parallel work).
+- **Error message:** Uses `"failed to export data"` consistently across all three commands.
+
+### Issue #107 — CLI Integration Complete (2026-04-26)
+
+- **Added to Flags struct:** ExportData string field (consistent with ExportConfig pattern).
+- **Added to CLI struct:** ExportData string field with Kong tag `help:"Write computed metrics to file (.json or .yaml/.yml)." name:"export-data" optional:""`.
+- **Updated all 3 commands:** treemap_cmd.go, radial_cmd.go, bubbletree_cmd.go each check flags.ExportData after provider.Run() and call export.Export() with requested metrics.
+- **Integration pattern:** Consistent across all commands — collect requested metrics, call export after metric computation, before render.
+- **Build status:** Passes. All three commands wired correctly.
+- **Flag design rationale:** Cross-cutting flag on Flags struct allows any visualization command to export metrics without duplication.
+
+

--- a/.squad/agents/lambert/history.md
+++ b/.squad/agents/lambert/history.md
@@ -111,3 +111,27 @@ Key learnings:
 - Tests 1–3 won't pass until Kane removes size validation from Validate() (that's the fix)
 - Tests 4–6 pass on current code — they exercise applyOverrides and config.Load independently of the Validate fix
 - `go vet ./cmd/codeviz/` confirmed all 6 tests compile cleanly
+
+### 2026-04-26 — export feature tests (issue #107)
+
+Wrote `internal/export/export_test.go` (white-box, `package export`) with 9 test cases covering:
+- **TestExport_JSON**: exports simple tree to JSON, unmarshals and verifies structure (root name, file count, metric values)
+- **TestExport_YAML**: same tree to .yaml, verifies valid YAML output
+- **TestExport_YML**: .yml extension accepted as YAML
+- **TestExport_UnsupportedFormat**: .txt returns an error
+- **TestExport_MetricFiltering**: sets fileSize + lineCount + fileType, requests only fileSize; verifies unrequested metrics are absent from both directory and file exports
+- **TestExport_EmptyDirectory**: empty dir produces valid JSON with no files/directories
+- **TestExport_NestedDirectories**: 3-level deep tree (root → mid → deep), verifies hierarchy preserved
+- **TestExport_BinaryFileFlag**: binary file has isBinary=true, text file has isBinary=false
+- **TestExport_AllMetricTypes**: quantity + measure + classification all present on both directory and file level
+
+Dallas had already delivered `export.go` — all 9 tests pass on first run. Test patterns follow the project standard: `t.Parallel()`, `NewGomegaWithT(t)`, dot-imported gomega, nilaway-safe nil guards before dereferencing, `t.TempDir()` for output files. Used `go.yaml.in/yaml/v3` for YAML unmarshalling (same as config package).
+
+### Issue #107 — Export Test Suite Complete (2026-04-26)
+
+- **File:** `internal/export/export_test.go` with 9 comprehensive tests.
+- **Test coverage:** JSON format, YAML format, unsupported format error, metric filtering (requested list respected), empty directories (omitted via omitempty), nested structures (3 levels deep), binary file flag preservation, all metric types (Quantity int64, Measure float64, Classification string).
+- **Build status:** Pass. All 9 tests pass.
+- **No regressions:** Tests validate Dallas's implementation was correct on first delivery.
+- **Pattern compliance:** Gomega assertions, t.Parallel(), nil-safe guards, temp directories for file I/O, JSON/YAML round-trip validation.
+

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -79,3 +79,24 @@
 - **Key files:** `legend.go` (ReserveLegendSpace), `legend_png.go` (measureLegendH, measureSingleEntryH, drawLegendEntriesH), `legend_svg.go` (writeSVGLegendEntriesH), `treemap_cmd.go` (legendLayoutOffset), `legend_test.go`.
 - **CI:** All tests pass, `go vet` clean. `golangci-lint-custom` only available in CI.
 - **Result:** APPROVED with minor suggestions.
+
+### Issue #107 — Design Review: Export Metrics Feature (2026-04-26)
+
+- **Task:** Architectural decisions for `--export-data` CLI flag to export computed metrics (JSON/YAML).
+- **Data structure:** Recursive `DirectoryExport` tree with flat `FileExport` leaves; metric maps use string keys (human-readable) to simplify JSON/YAML serialization. Preserves paths and binary flags for post-export analysis.
+- **Package placement:** New `internal/export/` package (mirrors existing patterns: render, scan, config). Single `Export()` function independent of CLI, visualization type, and metric registry.
+- **API signature:** `Export(root *model.Directory, requested []metric.Name, outputPath string) error`. Format inferred from file extension (like `render.FormatFromPath`).
+- **Flag design:** `--export-data` added to `Flags` struct (not per-command), consistent with existing `--export-config` pattern. Enables cross-cutting export on any visualization command.
+- **Metric visibility:** No new model methods. Export logic iterates through requested metric names and calls existing getters (`Quantity`, `Measure`, `Classification`). Only metrics actually requested are exported.
+- **Integration point:** Export called after `provider.Run()` (metrics computed) but before render, following the established command flow in treemap_cmd.go.
+- **Team ownership:** Dallas (export implementation), Kane (CLI wiring), Lambert (tests).
+- **Output:** Design decisions written to `.squad/decisions/inbox/ripley-export-data-design.md`.
+
+### Issue #107 — Export Feature Implementation Complete (2026-04-26)
+
+- **Status:** Feature fully implemented and integrated. All team members completed their assigned work.
+- **Dallas (Go Dev):** Implemented `internal/export/` package with recursive tree walking. Export() function handles JSON/YAML format inference, lazy-init metric maps, proper error handling with eris. Dependency added: gopkg.in/yaml.v3.
+- **Kane (CLI Dev):** Wired `--export-data` flag into Flags struct and CLI struct. Updated all 3 command Run() methods (treemap, radial, bubbletree). Export called after provider.Run(), before render. Consistent integration pattern across all commands.
+- **Lambert (QA):** Comprehensive test suite created: 9 tests covering JSON export, YAML export, format error handling, metric filtering, empty directories, nested structures, binary flags, and all metric types. All tests pass. Build green.
+- **Integration:** Feature ready for deployment. Design decisions merged into decisions.md.
+

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -276,6 +276,120 @@ Anytime changes are pushed to address PR review comments, always reply to the re
 
 **Rationale:** User request — reinforces existing team practice of maintaining clear communication on review threads.
 
+### Export Data — Issue #107
+
+**Author:** Ripley  
+**Date:** 2026-04-26  
+**Status:** Implemented
+
+#### Overview
+
+Feature adds `--export-data` CLI flag to save computed metrics to JSON or YAML files after metrics computation but before rendering.
+
+#### 1. Export Data Structure
+
+```go
+type ExportData struct {
+	Directory *DirectoryExport `json:"directory"`
+}
+
+type DirectoryExport struct {
+	Name         string                   `json:"name"`
+	Path         string                   `json:"path"`
+	Files        []*FileExport            `json:"files"`
+	Directories  []*DirectoryExport       `json:"directories"`
+	Quantities   map[string]int64         `json:"quantities"`
+	Measures     map[string]float64       `json:"measures"`
+	Classifications map[string]string     `json:"classifications"`
+}
+
+type FileExport struct {
+	Name            string                 `json:"name"`
+	Path            string                 `json:"path"`
+	Extension       string                 `json:"extension"`
+	IsBinary        bool                   `json:"isBinary"`
+	Quantities      map[string]int64       `json:"quantities"`
+	Measures        map[string]float64     `json:"measures"`
+	Classifications map[string]string      `json:"classifications"`
+}
+```
+
+**Rationale:**
+- Flat metric maps simplify JSON/YAML serialization and make output self-describing
+- String keys preserve human readability instead of using `metric.Name` constants
+- Full paths enable post-export filtering or analysis without tree reconstruction
+- IsBinary flag preserved for debugging verification
+- Structure mirrors model tree (recursive directories + flat files)
+
+#### 2. Package Location
+
+**Decision:** `internal/export/` with single `Export()` function
+
+**Rationale:**
+- Mirrors existing package patterns (render, scan, config)
+- Clear separation of concerns independent of CLI, rendering, and metric computation
+- Allows independent implementation and testing
+- Easy to extend with new formats
+
+#### 3. API Signature
+
+```go
+func Export(root *model.Directory, requested []metric.Name, outputPath string) error
+```
+
+**Design points:**
+- Format inferred from file extension (.json or .yaml/.yml)
+- Takes requested metric names to ensure only computed metrics exported
+- Returns error wrapped with eris for consistency
+- No config dependency; export agnostic to visualization type
+
+#### 4. Flag Placement
+
+**Decision:** `--export-data` added to `Flags` struct (not per-command)
+
+**Rationale:**
+- Consistency with existing `--export-config` pattern
+- Export works on any visualization command (treemap, radial, bubble)
+- Avoids duplication; each command checks `flags.ExportData` after `provider.Run()`
+
+#### 5. Metric Visibility
+
+**Decision:** Use requested metric names passed to `Export()`
+
+**Implementation:** 
+- Each command collects requested metrics (e.g., `collectRequestedMetrics(size, fill, border)`)
+- Passed to `export.Export()` along with root tree
+- Export logic iterates through requested names and extracts values only for those metrics
+- No new model methods required; leverages existing getters
+
+**Rationale:**
+- No model changes needed
+- Explicit control; only metrics actually requested are exported
+- Clean separation; export doesn't need metric registry knowledge
+
+#### 6. Integration Flow
+
+Each command's `Run()` method follows this pattern:
+
+```
+1. Merge config and validate
+2. Scan filesystem
+3. Compute metrics (collect requested list)
+4. [NEW] Export metrics if --export-data flag provided
+5. Render visualization
+```
+
+#### Summary Table
+
+| Aspect | Decision |
+|--------|----------|
+| **Data structure** | Recursive `DirectoryExport` + flat `FileExport` with metric maps |
+| **Package** | `internal/export/` with single `Export()` function |
+| **API** | `Export(root *model.Directory, requested []metric.Name, outputPath string) error` |
+| **Flag** | `--export-data` on `Flags` struct (like `--export-config`) |
+| **Metrics** | Use requested list passed to Export; no new model methods |
+| **Integration** | Call after `provider.Run()`, before render |
+
 ## Governance
 
 - All meaningful changes require team consensus

--- a/cmd/codeviz/bubbletree_cmd.go
+++ b/cmd/codeviz/bubbletree_cmd.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/bevan/code-visualizer/internal/bubbletree"
 	"github.com/bevan/code-visualizer/internal/config"
+	"github.com/bevan/code-visualizer/internal/export"
 	"github.com/bevan/code-visualizer/internal/filter"
 	"github.com/bevan/code-visualizer/internal/metric"
 	"github.com/bevan/code-visualizer/internal/model"
@@ -153,6 +154,12 @@ func (c *BubbletreeCmd) Run(flags *Flags) error {
 	err = c.filterBinaryFiles(cfg, root)
 	if err != nil {
 		return err
+	}
+
+	if flags.ExportData != "" {
+		if err := export.Export(root, requested, flags.ExportData); err != nil {
+			return eris.Wrap(err, "failed to export data")
+		}
 	}
 
 	width := ptrInt(flags.Config.Width, 1920)

--- a/cmd/codeviz/bubbletree_cmd.go
+++ b/cmd/codeviz/bubbletree_cmd.go
@@ -156,10 +156,8 @@ func (c *BubbletreeCmd) Run(flags *Flags) error {
 		return err
 	}
 
-	if flags.ExportData != "" {
-		if err := export.Export(root, requested, flags.ExportData); err != nil {
-			return eris.Wrap(err, "failed to export data")
-		}
+	if err := export.Export(root, requested, flags.ExportData); err != nil {
+		return eris.Wrap(err, "failed to export data")
 	}
 
 	width := ptrInt(flags.Config.Width, 1920)

--- a/cmd/codeviz/main.go
+++ b/cmd/codeviz/main.go
@@ -24,6 +24,7 @@ type CLI struct {
 
 	//nolint:revive // Long help text is more important than minimizing line length, and annotations can't be wrapped
 	ExportConfig string `help:"Write effective configuration to file (.yaml, .yml, or .json)." name:"export-config" optional:""`
+	ExportData   string `help:"Write computed metrics to file (.json or .yaml/.yml)." name:"export-data" optional:""`
 
 	Render       RenderCmd       `cmd:"" help:"Render a visualization."`
 	HelpMetrics  HelpMetricsCmd  `cmd:"" help:"List all available metrics."`
@@ -36,6 +37,7 @@ type Flags struct {
 	Verbose      bool
 	Debug        bool
 	ExportConfig string
+	ExportData   string
 	Config       *config.Config
 	configPath   string // path passed to --config, empty if not explicitly provided
 }
@@ -122,6 +124,7 @@ func main() {
 		Verbose:      cli.Verbose,
 		Debug:        cli.Debug,
 		ExportConfig: cli.ExportConfig,
+		ExportData:   cli.ExportData,
 		Config:       cfg,
 		configPath:   cli.Config,
 	}

--- a/cmd/codeviz/radialtree_cmd.go
+++ b/cmd/codeviz/radialtree_cmd.go
@@ -25,12 +25,12 @@ type RadialCmd struct {
 	TargetPath string `arg:"" help:"Path to directory to scan."`
 	Output     string `help:"Output image file path (png, jpg, jpeg, svg)." required:"true" short:"o"`
 
-	DiscSize metric.Name `default:"" enum:",file-size,file-lines,file-age,file-freshness,author-count" help:"Metric for disc size." short:"d"`
+	DiscSize metric.Name `default:"" enum:",file-size,file-lines,file-age,file-freshness,author-count" help:"Metric for disc size." short:"d"` //nolint:revive // kong struct tags require long lines
 
-	Fill          string `default:"" enum:",file-size,file-lines,file-type,file-age,file-freshness,author-count" help:"Metric for fill colour." optional:"" short:"f"`
-	FillPalette   string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for fill colour." name:"fill-palette" optional:""`
-	Border        string `default:"" enum:",file-size,file-lines,file-type,file-age,file-freshness,author-count" help:"Metric for border colour." optional:"" short:"b"`
-	BorderPalette string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for border colour." name:"border-palette" optional:""`
+	Fill          string `default:"" enum:",file-size,file-lines,file-type,file-age,file-freshness,author-count" help:"Metric for fill colour." optional:"" short:"f"`   //nolint:revive // kong struct tags require long lines
+	FillPalette   string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for fill colour." name:"fill-palette" optional:""`        //nolint:revive // kong struct tags require long lines
+	Border        string `default:"" enum:",file-size,file-lines,file-type,file-age,file-freshness,author-count" help:"Metric for border colour." optional:"" short:"b"` //nolint:revive // kong struct tags require long lines
+	BorderPalette string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for border colour." name:"border-palette" optional:""`    //nolint:revive // kong struct tags require long lines
 
 	Labels string `enum:",all,folders,none" default:"" help:"Labels to display: all, folders, or none."`
 

--- a/cmd/codeviz/radialtree_cmd.go
+++ b/cmd/codeviz/radialtree_cmd.go
@@ -148,10 +148,8 @@ func (c *RadialCmd) Run(flags *Flags) error {
 		return err
 	}
 
-	if flags.ExportData != "" {
-		if err := export.Export(root, requested, flags.ExportData); err != nil {
-			return eris.Wrap(err, "failed to export data")
-		}
+	if err := export.Export(root, requested, flags.ExportData); err != nil {
+		return eris.Wrap(err, "failed to export data")
 	}
 
 	files, dirs := countAll(root)

--- a/cmd/codeviz/radialtree_cmd.go
+++ b/cmd/codeviz/radialtree_cmd.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rotisserie/eris"
 
 	"github.com/bevan/code-visualizer/internal/config"
+	"github.com/bevan/code-visualizer/internal/export"
 	"github.com/bevan/code-visualizer/internal/filter"
 	"github.com/bevan/code-visualizer/internal/metric"
 	"github.com/bevan/code-visualizer/internal/model"
@@ -145,6 +146,12 @@ func (c *RadialCmd) Run(flags *Flags) error {
 	err = c.filterBinaryFiles(cfg, root)
 	if err != nil {
 		return err
+	}
+
+	if flags.ExportData != "" {
+		if err := export.Export(root, requested, flags.ExportData); err != nil {
+			return eris.Wrap(err, "failed to export data")
+		}
 	}
 
 	files, dirs := countAll(root)

--- a/cmd/codeviz/radialtree_cmd.go
+++ b/cmd/codeviz/radialtree_cmd.go
@@ -25,12 +25,12 @@ type RadialCmd struct {
 	TargetPath string `arg:"" help:"Path to directory to scan."`
 	Output     string `help:"Output image file path (png, jpg, jpeg, svg)." required:"true" short:"o"`
 
-	DiscSize metric.Name `default:"" enum:",file-size,file-lines,file-age,file-freshness,author-count" help:"Metric for disc size." short:"d"` //nolint:revive // kong struct tags require long lines
+	DiscSize metric.Name `default:"" enum:",file-size,file-lines,file-age,file-freshness,author-count" help:"Metric for disc size." short:"d"`
 
-	Fill          string `default:"" enum:",file-size,file-lines,file-type,file-age,file-freshness,author-count" help:"Metric for fill colour." optional:"" short:"f"`   //nolint:revive // kong struct tags require long lines
-	FillPalette   string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for fill colour." name:"fill-palette" optional:""`        //nolint:revive // kong struct tags require long lines
-	Border        string `default:"" enum:",file-size,file-lines,file-type,file-age,file-freshness,author-count" help:"Metric for border colour." optional:"" short:"b"` //nolint:revive // kong struct tags require long lines
-	BorderPalette string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for border colour." name:"border-palette" optional:""`    //nolint:revive // kong struct tags require long lines
+	Fill          string `default:"" enum:",file-size,file-lines,file-type,file-age,file-freshness,author-count" help:"Metric for fill colour." optional:"" short:"f"`
+	FillPalette   string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for fill colour." name:"fill-palette" optional:""`
+	Border        string `default:"" enum:",file-size,file-lines,file-type,file-age,file-freshness,author-count" help:"Metric for border colour." optional:"" short:"b"`
+	BorderPalette string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for border colour." name:"border-palette" optional:""`
 
 	Labels string `enum:",all,folders,none" default:"" help:"Labels to display: all, folders, or none."`
 

--- a/cmd/codeviz/treemap_cmd.go
+++ b/cmd/codeviz/treemap_cmd.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rotisserie/eris"
 
 	"github.com/bevan/code-visualizer/internal/config"
+	"github.com/bevan/code-visualizer/internal/export"
 	"github.com/bevan/code-visualizer/internal/filter"
 	"github.com/bevan/code-visualizer/internal/metric"
 	"github.com/bevan/code-visualizer/internal/model"
@@ -190,6 +191,12 @@ func (c *TreemapCmd) Run(flags *Flags) error {
 
 	if err := c.filterBinaryFiles(cfg, root); err != nil {
 		return err
+	}
+
+	if flags.ExportData != "" {
+		if err := export.Export(root, requested, flags.ExportData); err != nil {
+			return eris.Wrap(err, "failed to export data")
+		}
 	}
 
 	width := ptrInt(flags.Config.Width, 1920)

--- a/cmd/codeviz/treemap_cmd.go
+++ b/cmd/codeviz/treemap_cmd.go
@@ -193,10 +193,8 @@ func (c *TreemapCmd) Run(flags *Flags) error {
 		return err
 	}
 
-	if flags.ExportData != "" {
-		if err := export.Export(root, requested, flags.ExportData); err != nil {
-			return eris.Wrap(err, "failed to export data")
-		}
+	if err := export.Export(root, requested, flags.ExportData); err != nil {
+		return eris.Wrap(err, "failed to export data")
 	}
 
 	width := ptrInt(flags.Config.Width, 1920)

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -1,0 +1,212 @@
+// Package export serializes the model tree and computed metrics to JSON or YAML.
+package export
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/rotisserie/eris"
+	"go.yaml.in/yaml/v3"
+
+	"github.com/bevan/code-visualizer/internal/metric"
+	"github.com/bevan/code-visualizer/internal/model"
+)
+
+// ExportData represents the complete model tree with all computed metrics,
+// ready for serialization.
+type ExportData struct {
+	Root *DirectoryExport `json:"root" yaml:"root"`
+}
+
+// DirectoryExport represents a directory node with its files,
+// subdirectories, and metrics.
+type DirectoryExport struct {
+	Name            string             `json:"name"                        yaml:"name"`
+	Path            string             `json:"path"                        yaml:"path"`
+	Files           []*FileExport      `json:"files,omitempty"             yaml:"files,omitempty"`
+	Directories     []*DirectoryExport `json:"directories,omitempty"       yaml:"directories,omitempty"`
+	Quantities      map[string]int64   `json:"quantities,omitempty"        yaml:"quantities,omitempty"`
+	Measures        map[string]float64 `json:"measures,omitempty"          yaml:"measures,omitempty"`
+	Classifications map[string]string  `json:"classifications,omitempty"   yaml:"classifications,omitempty"`
+}
+
+// FileExport represents a file node with its metrics.
+type FileExport struct {
+	Name            string             `json:"name"                        yaml:"name"`
+	Path            string             `json:"path"                        yaml:"path"`
+	Extension       string             `json:"extension"                   yaml:"extension"`
+	IsBinary        bool               `json:"isBinary"                    yaml:"isBinary"`
+	Quantities      map[string]int64   `json:"quantities,omitempty"        yaml:"quantities,omitempty"`
+	Measures        map[string]float64 `json:"measures,omitempty"          yaml:"measures,omitempty"`
+	Classifications map[string]string  `json:"classifications,omitempty"   yaml:"classifications,omitempty"`
+}
+
+// Export serializes the model tree and computed metrics to a file.
+// Format is inferred from the file extension (.json or .yaml/.yml).
+// Only metrics in the requested list are included in the output.
+func Export(
+	root *model.Directory,
+	requested []metric.Name,
+	outputPath string,
+) error {
+	format, err := formatFromPath(outputPath)
+	if err != nil {
+		return err
+	}
+
+	data := ExportData{
+		Root: exportDirectory(root, requested),
+	}
+
+	var content []byte
+
+	switch format {
+	case formatJSON:
+		content, err = json.MarshalIndent(data, "", "  ")
+		if err != nil {
+			return eris.Wrap(err, "failed to marshal JSON")
+		}
+
+		// Append trailing newline for POSIX compliance.
+		content = append(content, '\n')
+	case formatYAML:
+		content, err = yaml.Marshal(data)
+		if err != nil {
+			return eris.Wrap(err, "failed to marshal YAML")
+		}
+	}
+
+	if err := os.WriteFile(outputPath, content, 0o644); err != nil {
+		return eris.Wrap(err, "failed to write export file")
+	}
+
+	return nil
+}
+
+// exportFormat represents a supported export file format.
+type exportFormat int
+
+const (
+	formatJSON exportFormat = iota
+	formatYAML
+)
+
+// formatFromPath infers the export format from the output file extension.
+func formatFromPath(path string) (exportFormat, error) {
+	ext := strings.ToLower(filepath.Ext(path))
+
+	switch ext {
+	case ".json":
+		return formatJSON, nil
+	case ".yaml", ".yml":
+		return formatYAML, nil
+	case "":
+		return 0, eris.New("output path has no file extension; supported formats: json, yaml, yml")
+	default:
+		return 0, eris.Errorf("unsupported export format %q; supported formats: json, yaml, yml", ext)
+	}
+}
+
+// exportDirectory recursively converts a model.Directory into a DirectoryExport.
+func exportDirectory(dir *model.Directory, requested []metric.Name) *DirectoryExport {
+	de := &DirectoryExport{
+		Name: dir.Name,
+		Path: dir.Path,
+	}
+
+	collectDirectoryMetrics(de, dir, requested)
+
+	for _, f := range dir.Files {
+		de.Files = append(de.Files, exportFile(f, requested))
+	}
+
+	for _, sub := range dir.Dirs {
+		de.Directories = append(de.Directories, exportDirectory(sub, requested))
+	}
+
+	return de
+}
+
+// exportFile converts a model.File into a FileExport.
+func exportFile(f *model.File, requested []metric.Name) *FileExport {
+	fe := &FileExport{
+		Name:      f.Name,
+		Path:      f.Path,
+		Extension: f.Extension,
+		IsBinary:  f.IsBinary,
+	}
+
+	collectFileMetrics(fe, f, requested)
+
+	return fe
+}
+
+// collectDirectoryMetrics populates a DirectoryExport's metric maps from the
+// model directory, including only the requested metrics that are present.
+func collectDirectoryMetrics(
+	de *DirectoryExport,
+	dir *model.Directory,
+	requested []metric.Name,
+) {
+	for _, name := range requested {
+		if q, ok := dir.Quantity(name); ok {
+			if de.Quantities == nil {
+				de.Quantities = make(map[string]int64)
+			}
+
+			de.Quantities[string(name)] = q
+		}
+
+		if m, ok := dir.Measure(name); ok {
+			if de.Measures == nil {
+				de.Measures = make(map[string]float64)
+			}
+
+			de.Measures[string(name)] = m
+		}
+
+		if c, ok := dir.Classification(name); ok {
+			if de.Classifications == nil {
+				de.Classifications = make(map[string]string)
+			}
+
+			de.Classifications[string(name)] = c
+		}
+	}
+}
+
+// collectFileMetrics populates a FileExport's metric maps from the model file,
+// including only the requested metrics that are present.
+func collectFileMetrics(
+	fe *FileExport,
+	f *model.File,
+	requested []metric.Name,
+) {
+	for _, name := range requested {
+		if q, ok := f.Quantity(name); ok {
+			if fe.Quantities == nil {
+				fe.Quantities = make(map[string]int64)
+			}
+
+			fe.Quantities[string(name)] = q
+		}
+
+		if m, ok := f.Measure(name); ok {
+			if fe.Measures == nil {
+				fe.Measures = make(map[string]float64)
+			}
+
+			fe.Measures[string(name)] = m
+		}
+
+		if c, ok := f.Classification(name); ok {
+			if fe.Classifications == nil {
+				fe.Classifications = make(map[string]string)
+			}
+
+			fe.Classifications[string(name)] = c
+		}
+	}
+}

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -46,11 +46,16 @@ type FileExport struct {
 // Export serializes the model tree and computed metrics to a file.
 // Format is inferred from the file extension (.json or .yaml/.yml).
 // Only metrics in the requested list are included in the output.
+// If outputPath is empty, Export is a no-op and returns nil.
 func Export(
 	root *model.Directory,
 	requested []metric.Name,
 	outputPath string,
 ) error {
+	if outputPath == "" {
+		return nil
+	}
+
 	format, err := formatFromPath(outputPath)
 	if err != nil {
 		return err
@@ -60,29 +65,39 @@ func Export(
 		Root: exportDirectory(root, requested),
 	}
 
-	var content []byte
-
-	switch format {
-	case formatJSON:
-		content, err = json.MarshalIndent(data, "", "  ")
-		if err != nil {
-			return eris.Wrap(err, "failed to marshal JSON")
-		}
-
-		// Append trailing newline for POSIX compliance.
-		content = append(content, '\n')
-	case formatYAML:
-		content, err = yaml.Marshal(data)
-		if err != nil {
-			return eris.Wrap(err, "failed to marshal YAML")
-		}
+	content, err := marshalExport(data, format)
+	if err != nil {
+		return err
 	}
 
-	if err := os.WriteFile(outputPath, content, 0o644); err != nil {
+	if err := os.WriteFile(outputPath, content, 0o600); err != nil {
 		return eris.Wrap(err, "failed to write export file")
 	}
 
 	return nil
+}
+
+// marshalExport serializes the export data in the specified format.
+func marshalExport(data ExportData, format exportFormat) ([]byte, error) {
+	switch format {
+	case formatJSON:
+		content, err := json.MarshalIndent(data, "", "  ")
+		if err != nil {
+			return nil, eris.Wrap(err, "failed to marshal JSON")
+		}
+
+		// Append trailing newline for POSIX compliance.
+		return append(content, '\n'), nil
+	case formatYAML:
+		content, err := yaml.Marshal(data)
+		if err != nil {
+			return nil, eris.Wrap(err, "failed to marshal YAML")
+		}
+
+		return content, nil
+	default:
+		return nil, eris.Errorf("unsupported export format: %d", format)
+	}
 }
 
 // exportFormat represents a supported export file format.
@@ -152,27 +167,15 @@ func collectDirectoryMetrics(
 ) {
 	for _, name := range requested {
 		if q, ok := dir.Quantity(name); ok {
-			if de.Quantities == nil {
-				de.Quantities = make(map[string]int64)
-			}
-
-			de.Quantities[string(name)] = q
+			de.Quantities = addQuantity(de.Quantities, string(name), q)
 		}
 
 		if m, ok := dir.Measure(name); ok {
-			if de.Measures == nil {
-				de.Measures = make(map[string]float64)
-			}
-
-			de.Measures[string(name)] = m
+			de.Measures = addMeasure(de.Measures, string(name), m)
 		}
 
 		if c, ok := dir.Classification(name); ok {
-			if de.Classifications == nil {
-				de.Classifications = make(map[string]string)
-			}
-
-			de.Classifications[string(name)] = c
+			de.Classifications = addClassification(de.Classifications, string(name), c)
 		}
 	}
 }
@@ -186,27 +189,45 @@ func collectFileMetrics(
 ) {
 	for _, name := range requested {
 		if q, ok := f.Quantity(name); ok {
-			if fe.Quantities == nil {
-				fe.Quantities = make(map[string]int64)
-			}
-
-			fe.Quantities[string(name)] = q
+			fe.Quantities = addQuantity(fe.Quantities, string(name), q)
 		}
 
 		if m, ok := f.Measure(name); ok {
-			if fe.Measures == nil {
-				fe.Measures = make(map[string]float64)
-			}
-
-			fe.Measures[string(name)] = m
+			fe.Measures = addMeasure(fe.Measures, string(name), m)
 		}
 
 		if c, ok := f.Classification(name); ok {
-			if fe.Classifications == nil {
-				fe.Classifications = make(map[string]string)
-			}
-
-			fe.Classifications[string(name)] = c
+			fe.Classifications = addClassification(fe.Classifications, string(name), c)
 		}
 	}
+}
+
+func addQuantity(m map[string]int64, key string, value int64) map[string]int64 {
+	if m == nil {
+		m = make(map[string]int64)
+	}
+
+	m[key] = value
+
+	return m
+}
+
+func addMeasure(m map[string]float64, key string, value float64) map[string]float64 {
+	if m == nil {
+		m = make(map[string]float64)
+	}
+
+	m[key] = value
+
+	return m
+}
+
+func addClassification(m map[string]string, key, value string) map[string]string {
+	if m == nil {
+		m = make(map[string]string)
+	}
+
+	m[key] = value
+
+	return m
 }

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -1,0 +1,424 @@
+package export
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"go.yaml.in/yaml/v3"
+
+	"github.com/bevan/code-visualizer/internal/metric"
+	"github.com/bevan/code-visualizer/internal/model"
+)
+
+// Metric name constants used across tests.
+const (
+	fileSize   metric.Name = "file-size"
+	lineCount  metric.Name = "line-count"
+	complexity metric.Name = "complexity"
+	fileType   metric.Name = "file-type"
+)
+
+// makeFile creates a *model.File with the given name and extension.
+func makeFile(name, ext string, binary bool) *model.File {
+	return &model.File{
+		Path:      name,
+		Name:      name,
+		Extension: ext,
+		IsBinary:  binary,
+	}
+}
+
+// sampleTree builds a small model tree for use in tests:
+//
+//	root/
+//	  main.go   (file-size=120, file-type="go")
+//	  README.md (file-size=45,  file-type="md")
+func sampleTree() *model.Directory {
+	goFile := makeFile("main.go", "go", false)
+	goFile.SetQuantity(fileSize, 120)
+	goFile.SetClassification(fileType, "go")
+
+	mdFile := makeFile("README.md", "md", false)
+	mdFile.SetQuantity(fileSize, 45)
+	mdFile.SetClassification(fileType, "md")
+
+	root := &model.Directory{
+		Name: "root",
+		Path: "root",
+		Files: []*model.File{
+			goFile,
+			mdFile,
+		},
+	}
+	root.SetQuantity(fileSize, 165)
+
+	return root
+}
+
+// TestExport_JSON exports a simple tree to JSON and verifies the output
+// is valid JSON with the expected structure.
+func TestExport_JSON(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := sampleTree()
+	out := filepath.Join(t.TempDir(), "export.json")
+
+	err := Export(root, []metric.Name{fileSize, fileType}, out)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	raw, err := os.ReadFile(out)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var data ExportData
+	err = json.Unmarshal(raw, &data)
+	g.Expect(err).NotTo(HaveOccurred(), "output must be valid JSON")
+
+	g.Expect(data.Root).NotTo(BeNil())
+	g.Expect(data.Root.Name).To(Equal("root"))
+	g.Expect(data.Root.Files).To(HaveLen(2))
+	g.Expect(data.Root.Quantities).To(HaveKeyWithValue("file-size", int64(165)))
+}
+
+// TestExport_YAML exports to a .yaml file and verifies valid YAML output.
+func TestExport_YAML(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := sampleTree()
+	out := filepath.Join(t.TempDir(), "export.yaml")
+
+	err := Export(root, []metric.Name{fileSize, fileType}, out)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	raw, err := os.ReadFile(out)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var data ExportData
+	err = yaml.Unmarshal(raw, &data)
+	g.Expect(err).NotTo(HaveOccurred(), "output must be valid YAML")
+
+	g.Expect(data.Root).NotTo(BeNil())
+	g.Expect(data.Root.Name).To(Equal("root"))
+	g.Expect(data.Root.Files).To(HaveLen(2))
+}
+
+// TestExport_YML verifies that .yml is accepted as a YAML extension.
+func TestExport_YML(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := sampleTree()
+	out := filepath.Join(t.TempDir(), "export.yml")
+
+	err := Export(root, []metric.Name{fileSize}, out)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	raw, err := os.ReadFile(out)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var data ExportData
+	err = yaml.Unmarshal(raw, &data)
+	g.Expect(err).NotTo(HaveOccurred(), ".yml must produce valid YAML")
+
+	g.Expect(data.Root).NotTo(BeNil())
+	g.Expect(data.Root.Name).To(Equal("root"))
+}
+
+// TestExport_UnsupportedFormat verifies that an unsupported extension
+// returns an error.
+func TestExport_UnsupportedFormat(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := sampleTree()
+	out := filepath.Join(t.TempDir(), "export.txt")
+
+	err := Export(root, []metric.Name{fileSize}, out)
+	g.Expect(err).To(HaveOccurred())
+}
+
+// TestExport_MetricFiltering sets multiple metrics on files but requests
+// only a subset. Only requested metrics should appear in the output.
+func TestExport_MetricFiltering(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	f := makeFile("app.go", "go", false)
+	f.SetQuantity(fileSize, 200)
+	f.SetQuantity(lineCount, 50)
+	f.SetClassification(fileType, "go")
+
+	root := &model.Directory{
+		Name:  "project",
+		Path:  "project",
+		Files: []*model.File{f},
+	}
+	root.SetQuantity(fileSize, 200)
+	root.SetQuantity(lineCount, 50)
+
+	out := filepath.Join(t.TempDir(), "filtered.json")
+
+	// Request only fileSize — lineCount and fileType should be absent.
+	err := Export(root, []metric.Name{fileSize}, out)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	raw, err := os.ReadFile(out)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var data ExportData
+	err = json.Unmarshal(raw, &data)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(data.Root).NotTo(BeNil())
+
+	if data.Root == nil {
+		return
+	}
+
+	// Root directory should have fileSize but not lineCount.
+	g.Expect(data.Root.Quantities).To(HaveKeyWithValue("file-size", int64(200)))
+	g.Expect(data.Root.Quantities).NotTo(HaveKey("line-count"))
+
+	g.Expect(data.Root.Files).To(HaveLen(1))
+
+	if len(data.Root.Files) == 0 {
+		return
+	}
+
+	fe := data.Root.Files[0]
+
+	// File should have fileSize but not lineCount or fileType.
+	g.Expect(fe.Quantities).To(HaveKeyWithValue("file-size", int64(200)))
+	g.Expect(fe.Quantities).NotTo(HaveKey("line-count"))
+	g.Expect(fe.Classifications).NotTo(HaveKey("file-type"))
+}
+
+// TestExport_EmptyDirectory exports an empty directory (no files,
+// no subdirectories) and verifies valid output.
+func TestExport_EmptyDirectory(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := &model.Directory{
+		Name: "empty",
+		Path: "empty",
+	}
+
+	out := filepath.Join(t.TempDir(), "empty.json")
+
+	err := Export(root, []metric.Name{fileSize}, out)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	raw, err := os.ReadFile(out)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var data ExportData
+	err = json.Unmarshal(raw, &data)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(data.Root).NotTo(BeNil())
+	g.Expect(data.Root.Name).To(Equal("empty"))
+	g.Expect(data.Root.Files).To(BeEmpty())
+	g.Expect(data.Root.Directories).To(BeEmpty())
+}
+
+// TestExport_NestedDirectories exports a 3-level deep tree and verifies
+// the hierarchy is preserved.
+func TestExport_NestedDirectories(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	leaf := makeFile("util.go", "go", false)
+	leaf.SetQuantity(fileSize, 30)
+
+	deepDir := &model.Directory{
+		Name:  "deep",
+		Path:  "root/mid/deep",
+		Files: []*model.File{leaf},
+	}
+
+	midDir := &model.Directory{
+		Name: "mid",
+		Path: "root/mid",
+		Dirs: []*model.Directory{deepDir},
+	}
+
+	root := &model.Directory{
+		Name: "root",
+		Path: "root",
+		Dirs: []*model.Directory{midDir},
+	}
+
+	out := filepath.Join(t.TempDir(), "nested.json")
+
+	err := Export(root, []metric.Name{fileSize}, out)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	raw, err := os.ReadFile(out)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var data ExportData
+	err = json.Unmarshal(raw, &data)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(data.Root).NotTo(BeNil())
+
+	if data.Root == nil {
+		return
+	}
+
+	// Level 1: root has one subdirectory.
+	g.Expect(data.Root.Name).To(Equal("root"))
+	g.Expect(data.Root.Directories).To(HaveLen(1))
+
+	if len(data.Root.Directories) == 0 {
+		return
+	}
+
+	// Level 2: mid.
+	mid := data.Root.Directories[0]
+	g.Expect(mid.Name).To(Equal("mid"))
+	g.Expect(mid.Directories).To(HaveLen(1))
+
+	if len(mid.Directories) == 0 {
+		return
+	}
+
+	// Level 3: deep contains one file.
+	deep := mid.Directories[0]
+	g.Expect(deep.Name).To(Equal("deep"))
+	g.Expect(deep.Files).To(HaveLen(1))
+}
+
+// TestExport_BinaryFileFlag verifies that the isBinary flag is correctly
+// serialized for binary files.
+func TestExport_BinaryFileFlag(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	binFile := makeFile("image.png", "png", true)
+	binFile.SetQuantity(fileSize, 5000)
+
+	textFile := makeFile("notes.txt", "txt", false)
+	textFile.SetQuantity(fileSize, 100)
+
+	root := &model.Directory{
+		Name: "mixed",
+		Path: "mixed",
+		Files: []*model.File{
+			binFile,
+			textFile,
+		},
+	}
+
+	out := filepath.Join(t.TempDir(), "binary.json")
+
+	err := Export(root, []metric.Name{fileSize}, out)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	raw, err := os.ReadFile(out)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var data ExportData
+	err = json.Unmarshal(raw, &data)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(data.Root).NotTo(BeNil())
+
+	if data.Root == nil {
+		return
+	}
+
+	g.Expect(data.Root.Files).To(HaveLen(2))
+
+	if len(data.Root.Files) < 2 {
+		return
+	}
+
+	// Find the binary and text files (order may vary).
+	var bin, txt *FileExport
+
+	for _, fe := range data.Root.Files {
+		if fe == nil {
+			continue
+		}
+
+		switch fe.Name {
+		case "image.png":
+			bin = fe
+		case "notes.txt":
+			txt = fe
+		}
+	}
+
+	g.Expect(bin).NotTo(BeNil(), "binary file should be present")
+	g.Expect(txt).NotTo(BeNil(), "text file should be present")
+
+	if bin == nil || txt == nil {
+		return
+	}
+
+	g.Expect(bin.IsBinary).To(BeTrue())
+	g.Expect(txt.IsBinary).To(BeFalse())
+}
+
+// TestExport_AllMetricTypes sets quantity, measure, AND classification
+// metrics on a file and verifies all three map types are populated.
+func TestExport_AllMetricTypes(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	f := makeFile("rich.go", "go", false)
+	f.SetQuantity(fileSize, 500)
+	f.SetMeasure(complexity, 7.25)
+	f.SetClassification(fileType, "go")
+
+	root := &model.Directory{
+		Name:  "metrics",
+		Path:  "metrics",
+		Files: []*model.File{f},
+	}
+	root.SetQuantity(fileSize, 500)
+	root.SetMeasure(complexity, 7.25)
+	root.SetClassification(fileType, "source")
+
+	out := filepath.Join(t.TempDir(), "all-metrics.json")
+
+	err := Export(root, []metric.Name{fileSize, complexity, fileType}, out)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	raw, err := os.ReadFile(out)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var data ExportData
+	err = json.Unmarshal(raw, &data)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(data.Root).NotTo(BeNil())
+
+	if data.Root == nil {
+		return
+	}
+
+	// Directory-level metrics.
+	g.Expect(data.Root.Quantities).To(HaveKeyWithValue("file-size", int64(500)))
+	g.Expect(data.Root.Measures).To(HaveKeyWithValue("complexity", 7.25))
+	g.Expect(data.Root.Classifications).To(HaveKeyWithValue("file-type", Equal("source")))
+
+	g.Expect(data.Root.Files).To(HaveLen(1))
+
+	if len(data.Root.Files) == 0 {
+		return
+	}
+
+	fe := data.Root.Files[0]
+
+	// File-level metrics.
+	g.Expect(fe.Quantities).To(HaveKeyWithValue("file-size", int64(500)))
+	g.Expect(fe.Measures).To(HaveKeyWithValue("complexity", 7.25))
+	g.Expect(fe.Classifications).To(HaveKeyWithValue("file-type", Equal("go")))
+}

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+
 	"go.yaml.in/yaml/v3"
 
 	"github.com/bevan/code-visualizer/internal/metric"
@@ -262,6 +263,7 @@ func TestExport_NestedDirectories(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 
 	var data ExportData
+
 	err = json.Unmarshal(raw, &data)
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -324,6 +326,7 @@ func TestExport_BinaryFileFlag(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 
 	var data ExportData
+
 	err = json.Unmarshal(raw, &data)
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -352,6 +355,8 @@ func TestExport_BinaryFileFlag(t *testing.T) {
 			bin = fe
 		case "notes.txt":
 			txt = fe
+		default:
+			// ignore other files
 		}
 	}
 
@@ -395,6 +400,7 @@ func TestExport_AllMetricTypes(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 
 	var data ExportData
+
 	err = json.Unmarshal(raw, &data)
 	g.Expect(err).NotTo(HaveOccurred())
 

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -99,6 +99,7 @@ func TestExport_YAML(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 
 	var data ExportData
+
 	err = yaml.Unmarshal(raw, &data)
 	g.Expect(err).NotTo(HaveOccurred(), "output must be valid YAML")
 
@@ -122,6 +123,7 @@ func TestExport_YML(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 
 	var data ExportData
+
 	err = yaml.Unmarshal(raw, &data)
 	g.Expect(err).NotTo(HaveOccurred(), ".yml must produce valid YAML")
 
@@ -171,6 +173,7 @@ func TestExport_MetricFiltering(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 
 	var data ExportData
+
 	err = json.Unmarshal(raw, &data)
 	g.Expect(err).NotTo(HaveOccurred())
 

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -75,6 +75,7 @@ func TestExport_JSON(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 
 	var data ExportData
+
 	err = json.Unmarshal(raw, &data)
 	g.Expect(err).NotTo(HaveOccurred(), "output must be valid JSON")
 
@@ -221,6 +222,7 @@ func TestExport_EmptyDirectory(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 
 	var data ExportData
+
 	err = json.Unmarshal(raw, &data)
 	g.Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
## Summary

Implements #107 — adds a `--export-data` CLI flag that exports computed metrics to JSON or YAML files. Useful for troubleshooting and importing data into other tools.

## Changes

- **New `internal/export/` package** with `Export()` function that walks the model tree, collects requested metrics, and serializes to JSON (indented) or YAML
- **`--export-data` flag** on all three visualization commands (treemap, radial, bubbletree) — runs after metrics are computed and binary files filtered, before rendering
- **9 tests** covering JSON, YAML (.yaml + .yml), unsupported format errors, metric filtering, empty directories, nested structures, binary file flags, and all metric types

## Usage

```bash
codeviz render treemap ./src -o viz.png -s file-lines --export-data metrics.json
codeviz render radial ./src -o viz.png -d file-size --export-data metrics.yaml
```

## Design Decisions

- Export data structure mirrors the model tree (recursive `DirectoryExport` + flat `FileExport`)
- Only requested metrics are exported (not all available metrics)
- Format inferred from file extension, consistent with `render.FormatFromPath` pattern
- Flag on `Flags` struct (like `--export-config`), not per-command

Closes #107