### PR TITLE
fix: resolve file-age always zero when scanning subdirectory

### DIFF
--- a/internal/provider/git/metrics.go
+++ b/internal/provider/git/metrics.go
@@ -30,32 +30,7 @@ func (*FileAgeProvider) Dependencies() []metric.Name         { return nil }
 func (*FileAgeProvider) DefaultPalette() palette.PaletteName { return palette.Temperature }
 
 func (*FileAgeProvider) Load(root *model.Directory) error {
-	s, err := getService(root.Path)
-	if err != nil {
-		return eris.Wrap(err, "file-age requires a git repository")
-	}
-
-	model.WalkFiles(root, func(f *model.File) {
-		relPath, err := filepath.Rel(root.Path, f.Path)
-		if err != nil {
-			slog.Warn("could not compute relative path", "path", f.Path, "error", err)
-
-			return
-		}
-
-		age, err := s.fileAge(relPath)
-		if err != nil {
-			if !errors.Is(err, errUntracked) {
-				slog.Debug("could not get file age", "path", relPath, "error", err)
-			}
-
-			return
-		}
-
-		f.SetQuantity(FileAge, age)
-	})
-
-	return nil
+	return loadGitMetric(root, FileAge, "file-age", (*repoService).fileAge)
 }
 
 // FileFreshnessProvider reports time since most recent commit in days.
@@ -70,32 +45,7 @@ func (*FileFreshnessProvider) Dependencies() []metric.Name         { return nil 
 func (*FileFreshnessProvider) DefaultPalette() palette.PaletteName { return palette.Temperature }
 
 func (*FileFreshnessProvider) Load(root *model.Directory) error {
-	s, err := getService(root.Path)
-	if err != nil {
-		return eris.Wrap(err, "file-freshness requires a git repository")
-	}
-
-	model.WalkFiles(root, func(f *model.File) {
-		relPath, err := filepath.Rel(root.Path, f.Path)
-		if err != nil {
-			slog.Warn("could not compute relative path", "path", f.Path, "error", err)
-
-			return
-		}
-
-		freshness, err := s.fileFreshness(relPath)
-		if err != nil {
-			if !errors.Is(err, errUntracked) {
-				slog.Debug("could not get file freshness", "path", relPath, "error", err)
-			}
-
-			return
-		}
-
-		f.SetQuantity(FileFreshness, freshness)
-	})
-
-	return nil
+	return loadGitMetric(root, FileFreshness, "file-freshness", (*repoService).fileFreshness)
 }
 
 // IsGitMetric reports whether name is a metric that requires a git repository.
@@ -120,29 +70,41 @@ func (*AuthorCountProvider) Dependencies() []metric.Name         { return nil }
 func (*AuthorCountProvider) DefaultPalette() palette.PaletteName { return palette.GoodBad }
 
 func (*AuthorCountProvider) Load(root *model.Directory) error {
+	return loadGitMetric(root, AuthorCount, "author-count", (*repoService).authorCount)
+}
+
+// loadGitMetric is the shared implementation for all git-based metric providers.
+// It opens the repo service, walks all files, computes paths relative to the git
+// worktree root (not the scan root), and sets the metric via the supplied fn.
+func loadGitMetric(
+	root *model.Directory,
+	name metric.Name,
+	desc string,
+	fn func(*repoService, string) (int64, error),
+) error {
 	s, err := getService(root.Path)
 	if err != nil {
-		return eris.Wrap(err, "author-count requires a git repository")
+		return eris.Wrapf(err, "%s requires a git repository", desc)
 	}
 
 	model.WalkFiles(root, func(f *model.File) {
-		relPath, err := filepath.Rel(root.Path, f.Path)
+		relPath, err := filepath.Rel(s.RepoRoot(), f.Path)
 		if err != nil {
 			slog.Warn("could not compute relative path", "path", f.Path, "error", err)
 
 			return
 		}
 
-		count, err := s.authorCount(relPath)
+		val, err := fn(s, relPath)
 		if err != nil {
 			if !errors.Is(err, errUntracked) {
-				slog.Debug("could not get author count", "path", relPath, "error", err)
+				slog.Debug("could not get "+desc, "path", relPath, "error", err)
 			}
 
 			return
 		}
 
-		f.SetQuantity(AuthorCount, count)
+		f.SetQuantity(name, val)
 	})
 
 	return nil

--- a/internal/provider/git/metrics_test.go
+++ b/internal/provider/git/metrics_test.go
@@ -262,3 +262,99 @@ func TestAuthorCountProviderMetadata(t *testing.T) {
 	g.Expect(p.DefaultPalette()).NotTo(BeEmpty())
 	g.Expect(p.Dependencies()).To(BeNil())
 }
+
+// setupSubdirRepo creates a git repo with a file inside a subdirectory,
+// committed at a fixed old date. It returns the subdirectory path.
+func setupSubdirRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+
+		cmd := exec.Command(args[0], args[1:]...) //nolint:gosec // test helper
+		cmd.Dir = dir
+
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=Alice",
+			"GIT_AUTHOR_EMAIL=alice@example.com",
+			"GIT_COMMITTER_NAME=Alice",
+			"GIT_COMMITTER_EMAIL=alice@example.com",
+		)
+
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("command %v failed: %s\n%s", args, err, out)
+		}
+	}
+
+	run("git", "init")
+	run("git", "config", "user.name", "Alice")
+	run("git", "config", "user.email", "alice@example.com")
+
+	sub := filepath.Join(dir, "subdir")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir: %s", err)
+	}
+
+	_ = os.WriteFile(filepath.Join(sub, "code.go"), []byte("package code\n"), 0o600)
+
+	run("git", "add", ".")
+	run("git", "commit", "-m", "initial commit", "--date=2024-01-01T00:00:00+00:00")
+
+	return sub
+}
+
+func TestFileAgeProvider_SubdirectoryScanning(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	subdir := setupSubdirRepo(t)
+	root := buildTree(subdir, "code.go")
+
+	resetService()
+
+	p := &FileAgeProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	age, ok := root.Files[0].Quantity(FileAge)
+	g.Expect(ok).To(BeTrue(), "file-age metric should be set for file in subdirectory")
+	g.Expect(age).To(BeNumerically(">", 0), "file committed 2024-01-01 should have age > 0")
+}
+
+func TestFileFreshnessProvider_SubdirectoryScanning(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	subdir := setupSubdirRepo(t)
+	root := buildTree(subdir, "code.go")
+
+	resetService()
+
+	p := &FileFreshnessProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	freshness, ok := root.Files[0].Quantity(FileFreshness)
+	g.Expect(ok).To(BeTrue(), "file-freshness metric should be set for file in subdirectory")
+	g.Expect(freshness).To(BeNumerically(">", 0), "file committed 2024-01-01 should have freshness > 0")
+}
+
+func TestAuthorCountProvider_SubdirectoryScanning(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	subdir := setupSubdirRepo(t)
+	root := buildTree(subdir, "code.go")
+
+	resetService()
+
+	p := &AuthorCountProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	count, ok := root.Files[0].Quantity(AuthorCount)
+	g.Expect(ok).To(BeTrue(), "author-count metric should be set for file in subdirectory")
+	g.Expect(count).To(Equal(int64(1)), "code.go should have 1 author (Alice)")
+}

--- a/internal/provider/git/service.go
+++ b/internal/provider/git/service.go
@@ -21,9 +21,15 @@ type commitData struct {
 
 type repoService struct {
 	repo        *gogit.Repository
+	rootPath    string // git worktree root (absolute path)
 	commitGroup singleflight.Group
 	commitMu    sync.RWMutex
 	commitCache map[string]*commitData
+}
+
+// RepoRoot returns the absolute path to the git worktree root.
+func (s *repoService) RepoRoot() string {
+	return s.rootPath
 }
 
 var (
@@ -52,8 +58,21 @@ func getService(repoPath string) (*repoService, error) {
 		return nil, err
 	}
 
+	rootPath := repoPath
+
+	wt, err := repo.Worktree()
+	if err == nil {
+		rootPath = wt.Filesystem.Root()
+	} else if !errors.Is(err, gogit.ErrIsBareRepository) {
+		err = eris.Wrap(err, "failed to get git worktree")
+		services[repoPath] = &serviceResult{nil, err}
+
+		return nil, err
+	}
+
 	svc := &repoService{
 		repo:        repo,
+		rootPath:    rootPath,
 		commitCache: make(map[string]*commitData),
 	}
 	services[repoPath] = &serviceResult{svc, nil}


### PR DESCRIPTION
## Summary

Fixes #109 — all git-based metrics (file-age, file-freshness, author-count) reported zero when scanning a subdirectory of the git repository.

## Root Cause

`filepath.Rel(root.Path, f.Path)` computed paths relative to the **scan root**, but `go-git`'s `repo.Log(FileName)` expects paths relative to the **git worktree root**. When the scan root is a subdirectory (e.g. `codeviz render treemap ./cmd`), all git log queries returned zero commits.

## Fix

- Store the git worktree root path in `repoService` (via `Worktree().Filesystem.Root()`)
- Compute relative paths from the repo root instead of the scan root
- Refactor three identical `Load()` method bodies into a shared `loadGitMetric()` helper (DRY improvement)
- Add 3 regression tests verifying subdirectory scanning works for all three providers

## Files Changed

| File | Change |
|------|--------|
| `internal/provider/git/service.go` | Add `rootPath` field + `RepoRoot()` method + worktree init |
| `internal/provider/git/metrics.go` | Refactor to shared `loadGitMetric()` using `svc.RepoRoot()` |
| `internal/provider/git/metrics_test.go` | Add `setupSubdirRepo` + 3 subdirectory scanning tests |
