### PR TITLE
Fix: file-freshness metric always zero (#114)

### DIFF
--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -15,6 +15,14 @@
 
 <!-- Append learnings below -->
 
+### go-git FileName filter bug — issue #114 (2026-04-27)
+
+- **Root cause:** go-git's `LogOptions{FileName: &path}` includes merge commits that didn't modify the file, inflating the commit set. This made `data.newest` reflect the repo's most recent commit, not the file's last change.
+- **Fix location:** `internal/provider/git/service.go` — added `commitModifiedFile()` and `blobHash()` to verify each commit by comparing blob hashes with the first parent's tree.
+- **Impact:** Affected all three git metrics (file-age, file-freshness, author-count) since they share `fetchCommitData`. file-freshness was most visibly broken because `newest` was always near-now, truncating to 0 days.
+- **Key insight:** `file-age` appeared correct only by coincidence — for files present since the initial commit, `oldest` happened to match the repo's oldest commit.
+- **PR:** #119 (draft), branch `squad/114-fix-file-freshness`.
+
 ### Export package — issue #107 (2026-04-26)
 
 - **New package:** `internal/export/` — serializes model tree + computed metrics to JSON or YAML files.

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -395,3 +395,101 @@ Each command's `Run()` method follows this pattern:
 - All meaningful changes require team consensus
 - Document architectural decisions here
 - Keep history focused on work, decisions focused on direction
+
+---
+
+### Git providers: use worktree root for relative paths
+
+**Author:** Dallas
+**Date:** 2026-07-21
+**Status:** Implemented
+
+**Context:** All git metric providers (file-age, file-freshness, author-count) were computing file paths relative to the scan root (`root.Path`), but go-git expects paths relative to the git worktree root. This caused zero-value metrics when scanning a subdirectory.
+
+**Decision:** `repoService` now stores the worktree root path (via `Worktree().Filesystem.Root()`) and exposes it as `RepoRoot()`. All path computations use `RepoRoot()` as the base.
+
+**Also:** Factored the triplicated Load() walk-and-compute pattern into a single `loadGitMetric()` helper to prevent this class of bug from recurring if new git providers are added.
+
+---
+
+### Decision: Filter false-positive commits in git metric providers
+
+**Author:** Dallas
+**Date:** 2026-04-27
+**Issue:** #114
+**PR:** #119
+
+**Context:** go-git's `LogOptions{FileName}` filter includes merge commits that didn't modify the target file. This caused `file-freshness` to always return 0 because `data.newest` reflected the repo's most recent commit, not the file's last actual change.
+
+**Decision:** Added `commitModifiedFile()` to `fetchCommitData` in `internal/provider/git/service.go`. Each commit returned by go-git is verified by comparing the file's blob hash against the first parent's tree. Commits where the file hash is unchanged are skipped.
+
+**Impact:**
+- Fixes `file-freshness` (was always 0, now returns correct days-since-last-change).
+- Also improves accuracy of `file-age` and `author-count` — they shared the same inflated commit set, but the impact was less visible.
+- Small performance cost: each commit now does a tree lookup + parent tree lookup. Acceptable for correctness.
+
+---
+
+### Decision: Replace times slice with explicit oldest/newest in commitData
+
+**Author:** Dallas  
+**Date:** 2026-07-21  
+**Status:** Implemented  
+**Scope:** `internal/provider/git/service.go`
+
+**Context:** The `commitData` struct stored commit timestamps in a `times []time.Time` slice, then used positional indexing (`times[0]` for newest, `times[len-1]` for oldest) to compute file-age and file-freshness. This assumed go-git's iteration order (by committer time descending) matched author-time order. It doesn't — author time ≠ committer time for merge commits, rebases, cherry-picks, and PRs.
+
+**Decision:** Replaced `times []time.Time` with two explicit fields: `oldest time.Time` and `newest time.Time`. During `fetchCommitData()` iteration, track min/max with `Before()`/`After()` comparisons. This eliminates any dependency on iteration order.
+
+**Rationale:**
+- Correct by construction — no ordering assumption, just min/max.
+- Simpler — two fields instead of a growing slice. Less memory, no `len()` checks.
+- All existing tests pass unchanged (synthetic repos have correctly ordered timestamps, but the fix is still correct for them).
+
+---
+
+### golangci-lint upgraded to v2.11.4
+
+**Author:** Lambert
+**Date:** 2026-04-26
+**Issue:** #113
+**PR:** #115
+
+**What changed:**
+- golangci-lint and golangci-lint-custom (nilaway) upgraded from v2.8.0 to v2.11.4
+- All `sort.Slice`/`sort.Strings`/`sort.Float64s` replaced with `slices.SortFunc`/`slices.Sort` (new revive `use-slices-sort` rule)
+- `slog.Error(err.Error())` replaced with structured `slog.Error("msg", "err", err)` (gosec G706)
+- `filepath.Clean()` added for user-supplied paths (gosec G703)
+- Nil guard added to `provider/registry.go:get()` for nilaway safety
+
+**Impact on team:**
+- **All code must now use `slices.Sort`/`slices.SortFunc` instead of `sort.Slice`/`sort.Strings`/`sort.Float64s`**. The linter will enforce this.
+- **Use structured slog logging** (`slog.Error("message", "err", err)`) instead of `slog.Error(err.Error())`.
+- **Sanitise user-supplied file paths** with `filepath.Clean()` before use.
+- New revive rules suggested for adoption in issue #116.
+
+**Version references:**
+- `.devcontainer/install-dependencies.sh` line 149
+- `.devcontainer/.custom-gcl.template.yml` line 1
+
+---
+
+### Ripley Review Verdict — PR #108 Export Metrics
+
+**Author:** Ripley
+**Date:** 2026-04-26
+**PR:** #108
+**Issue:** #107
+**Verdict:** REJECT
+
+**Decision:** Standardize YAML usage for export code on the repository's existing package:
+- Use `go.yaml.in/yaml/v3`
+- Do not introduce `gopkg.in/yaml.v3` alongside it
+
+**Why:** The codebase already uses `go.yaml.in/yaml/v3` in config loading/saving and in the new export tests. Adding `gopkg.in/yaml.v3` in `internal/export/export.go` introduces a second YAML library with the same API surface for no functional gain, increases dependency surface, and breaks consistency.
+
+**Required follow-up:**
+1. Change `internal/export/export.go` to import `go.yaml.in/yaml/v3`
+2. Run module tidy so `gopkg.in/yaml.v3` is removed from `go.mod`/`go.sum`
+3. Re-run the targeted export and CLI tests, then let CI confirm the full suite
+

--- a/internal/provider/git/metrics_test.go
+++ b/internal/provider/git/metrics_test.go
@@ -145,10 +145,18 @@ func TestFileFreshnessProvider(t *testing.T) {
 	err := p.Load(root)
 	g.Expect(err).NotTo(HaveOccurred())
 
+	// old.go was committed at 2024-01-01 and never modified — should have freshness > 0
+	freshOld, ok := root.Files[0].Quantity(FileFreshness)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(freshOld).To(BeNumerically(">", 0), "old.go last modified 2024-01-01 should have freshness > 0")
+
 	// new.go was just committed — should be very fresh (small number)
 	freshNew, ok := root.Files[1].Quantity(FileFreshness)
 	g.Expect(ok).To(BeTrue())
 	g.Expect(freshNew).To(BeNumerically(">=", 0))
+
+	// old.go should be staler than new.go (higher freshness = more days since last change)
+	g.Expect(freshOld).To(BeNumerically(">", freshNew))
 }
 
 func TestAuthorCountProvider(t *testing.T) {
@@ -357,4 +365,142 @@ func TestAuthorCountProvider_SubdirectoryScanning(t *testing.T) {
 	count, ok := root.Files[0].Quantity(AuthorCount)
 	g.Expect(ok).To(BeTrue(), "author-count metric should be set for file in subdirectory")
 	g.Expect(count).To(Equal(int64(1)), "code.go should have 1 author (Alice)")
+}
+
+// setupMergeRepo creates a git repo where a merge commit touches both files
+// in the tree but only actually modifies one of them. This reproduces the
+// bug where go-git's FileName log filter includes merge commits that didn't
+// change the file, polluting the "newest" timestamp.
+func setupMergeRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+
+		cmd := exec.Command(args[0], args[1:]...) //nolint:gosec // test helper
+		cmd.Dir = dir
+
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=Alice",
+			"GIT_AUTHOR_EMAIL=alice@example.com",
+			"GIT_COMMITTER_NAME=Alice",
+			"GIT_COMMITTER_EMAIL=alice@example.com",
+		)
+
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("command %v failed: %s\n%s", args, err, out)
+		}
+	}
+
+	// Create initial commit with two files, backdated.
+	run("git", "init")
+	run("git", "config", "user.name", "Alice")
+	run("git", "config", "user.email", "alice@example.com")
+
+	_ = os.WriteFile(filepath.Join(dir, "stable.go"), []byte("package stable\n"), 0o600)
+	_ = os.WriteFile(filepath.Join(dir, "active.go"), []byte("package active\n"), 0o600)
+
+	run("git", "add", ".")
+	run("git", "commit", "-m", "initial commit", "--date=2024-01-01T00:00:00+00:00")
+
+	// Create a feature branch that modifies only active.go.
+	run("git", "checkout", "-b", "feature")
+	_ = os.WriteFile(filepath.Join(dir, "active.go"), []byte("package active\n// feature\n"), 0o600)
+	run("git", "add", "active.go")
+	run("git", "commit", "-m", "feature change", "--date=2025-12-01T00:00:00+00:00")
+
+	// Merge back to main — creates a merge commit that includes stable.go
+	// in its tree but doesn't modify it.
+	run("git", "checkout", "master")
+	run("git", "merge", "feature", "--no-ff", "-m", "merge feature")
+
+	return dir
+}
+
+// TestFileFreshness_MergeCommitDoesNotPollute verifies that a merge commit
+// touching stable.go's tree entry (but not its content) doesn't update the
+// freshness timestamp for stable.go. This was the root cause of #114.
+func TestFileFreshness_MergeCommitDoesNotPollute(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir := setupMergeRepo(t)
+	root := buildTree(dir, "stable.go", "active.go")
+
+	resetService()
+
+	p := &FileFreshnessProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// stable.go was only committed at 2024-01-01 and never actually modified
+	// after that. Its freshness (days since last real change) should be > 300.
+	freshStable, ok := root.Files[0].Quantity(FileFreshness)
+	g.Expect(ok).To(BeTrue(), "file-freshness should be set for stable.go")
+	g.Expect(freshStable).To(BeNumerically(">", 300),
+		"stable.go last modified 2024-01-01 should have high freshness (days since change)")
+
+	// active.go was modified at 2025-12-01 — should have a moderate freshness.
+	freshActive, ok := root.Files[1].Quantity(FileFreshness)
+	g.Expect(ok).To(BeTrue(), "file-freshness should be set for active.go")
+	g.Expect(freshActive).To(BeNumerically(">", 0),
+		"active.go last modified 2025-12-01 should have freshness > 0")
+
+	// stable.go must be staler than active.go.
+	g.Expect(freshStable).To(BeNumerically(">", freshActive),
+		"stable.go should be staler than active.go")
+}
+
+// TestFileAge_MergeCommitDoesNotPollute verifies that a merge commit doesn't
+// shift the oldest timestamp for files it didn't modify.
+func TestFileAge_MergeCommitDoesNotPollute(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir := setupMergeRepo(t)
+	root := buildTree(dir, "stable.go", "active.go")
+
+	resetService()
+
+	p := &FileAgeProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Both files were created at 2024-01-01 — same age.
+	ageStable, ok := root.Files[0].Quantity(FileAge)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(ageStable).To(BeNumerically(">", 300))
+
+	ageActive, ok := root.Files[1].Quantity(FileAge)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(ageActive).To(BeNumerically(">", 300))
+}
+
+// TestAuthorCount_MergeCommitDoesNotPollute verifies that the merge commit
+// author is not counted for files the merge didn't actually modify.
+func TestAuthorCount_MergeCommitDoesNotPollute(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir := setupMergeRepo(t)
+	root := buildTree(dir, "stable.go", "active.go")
+
+	resetService()
+
+	p := &AuthorCountProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// stable.go was only committed by Alice — the merge didn't change it.
+	count, ok := root.Files[0].Quantity(AuthorCount)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(count).To(Equal(int64(1)), "stable.go should have 1 author")
+
+	// active.go was committed by Alice initially — the feature branch commit
+	// was also by Alice (our test setup uses Alice for all commits).
+	countActive, ok := root.Files[1].Quantity(AuthorCount)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(countActive).To(Equal(int64(1)), "active.go should have 1 author (all commits by Alice)")
 }

--- a/internal/provider/git/metrics_test.go
+++ b/internal/provider/git/metrics_test.go
@@ -367,10 +367,11 @@ func TestAuthorCountProvider_SubdirectoryScanning(t *testing.T) {
 	g.Expect(count).To(Equal(int64(1)), "code.go should have 1 author (Alice)")
 }
 
-// setupMergeRepo creates a git repo where a merge commit touches both files
-// in the tree but only actually modifies one of them. This reproduces the
-// bug where go-git's FileName log filter includes merge commits that didn't
-// change the file, polluting the "newest" timestamp.
+// setupMergeRepo creates a git repo where main has two files, stable.go
+// is modified once on main, and a feature branch modifies only active.go
+// before being merged back. The modification of stable.go on main gives
+// go-git a clear commit that's NOT TREESAME for stable.go, ensuring the
+// commit is returned even with history simplification.
 func setupMergeRepo(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -394,8 +395,8 @@ func setupMergeRepo(t *testing.T) string {
 		}
 	}
 
-	// Create initial commit with two files, backdated.
-	run("git", "init")
+	// Commit 1: create both files (backdated).
+	run("git", "init", "-b", "main")
 	run("git", "config", "user.name", "Alice")
 	run("git", "config", "user.email", "alice@example.com")
 
@@ -405,15 +406,23 @@ func setupMergeRepo(t *testing.T) string {
 	run("git", "add", ".")
 	run("git", "commit", "-m", "initial commit", "--date=2024-01-01T00:00:00+00:00")
 
+	// Commit 2 (on main): modify stable.go at a known date.
+	_ = os.WriteFile(filepath.Join(dir, "stable.go"), []byte("package stable\n// updated\n"), 0o600)
+
+	run("git", "add", "stable.go")
+	run("git", "commit", "-m", "update stable", "--date=2024-06-01T00:00:00+00:00")
+
 	// Create a feature branch that modifies only active.go.
 	run("git", "checkout", "-b", "feature")
+
 	_ = os.WriteFile(filepath.Join(dir, "active.go"), []byte("package active\n// feature\n"), 0o600)
+
 	run("git", "add", "active.go")
 	run("git", "commit", "-m", "feature change", "--date=2025-12-01T00:00:00+00:00")
 
 	// Merge back to main — creates a merge commit that includes stable.go
 	// in its tree but doesn't modify it.
-	run("git", "checkout", "master")
+	run("git", "checkout", "main")
 	run("git", "merge", "feature", "--no-ff", "-m", "merge feature")
 
 	return dir
@@ -435,12 +444,13 @@ func TestFileFreshness_MergeCommitDoesNotPollute(t *testing.T) {
 	err := p.Load(root)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	// stable.go was only committed at 2024-01-01 and never actually modified
-	// after that. Its freshness (days since last real change) should be > 300.
+	// stable.go was last truly modified at 2024-06-01. Its freshness (days
+	// since last real change) should be > 300. Without the fix, the merge
+	// commit's timestamp (today) would pollute this to ~0.
 	freshStable, ok := root.Files[0].Quantity(FileFreshness)
 	g.Expect(ok).To(BeTrue(), "file-freshness should be set for stable.go")
 	g.Expect(freshStable).To(BeNumerically(">", 300),
-		"stable.go last modified 2024-01-01 should have high freshness (days since change)")
+		"stable.go last modified 2024-06-01 should have high freshness (days since change)")
 
 	// active.go was modified at 2025-12-01 — should have a moderate freshness.
 	freshActive, ok := root.Files[1].Quantity(FileFreshness)
@@ -503,4 +513,31 @@ func TestAuthorCount_MergeCommitDoesNotPollute(t *testing.T) {
 	countActive, ok := root.Files[1].Quantity(AuthorCount)
 	g.Expect(ok).To(BeTrue())
 	g.Expect(countActive).To(Equal(int64(1)), "active.go should have 1 author (all commits by Alice)")
+}
+
+// TestFileFreshnessEqualsAgeForSingleCommit verifies that for a file with
+// exactly one commit, file-freshness equals file-age (both measure days since
+// the same single commit).
+func TestFileFreshnessEqualsAgeForSingleCommit(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir := setupSubdirRepo(t) // code.go committed once at 2024-01-01
+	root := buildTree(dir, "code.go")
+
+	resetService()
+
+	ageP := &FileAgeProvider{}
+	g.Expect(ageP.Load(root)).To(Succeed())
+
+	freshP := &FileFreshnessProvider{}
+	g.Expect(freshP.Load(root)).To(Succeed())
+
+	age, ageOk := root.Files[0].Quantity(FileAge)
+	freshness, freshOk := root.Files[0].Quantity(FileFreshness)
+
+	g.Expect(ageOk).To(BeTrue())
+	g.Expect(freshOk).To(BeTrue())
+	g.Expect(age).To(Equal(freshness),
+		"single-commit file should have identical age and freshness")
 }

--- a/internal/provider/git/service.go
+++ b/internal/provider/git/service.go
@@ -214,9 +214,11 @@ func (s *repoService) fetchCommitData(relPath string) (*commitData, error) {
 
 // commitModifiedFile returns true if the commit actually changed the file at
 // relPath, as opposed to merely having it in the tree (which happens with merge
-// commits). A commit modified the file if:
-//   - it is a root commit (no parents), or
-//   - the file's blob hash differs from at least one parent.
+// commits). A commit modified the file only if it is NOT TREESAME to any parent,
+// matching git's history simplification semantics. Specifically:
+//   - root commits (no parents) are always considered as modifying the file,
+//   - a commit is TREESAME to a parent when the file's blob hash is identical,
+//   - a commit is "modified" only when it differs from ALL parents.
 func commitModifiedFile(c *object.Commit, relPath string) bool {
 	fileHash, err := blobHash(c, relPath)
 	if err != nil {
@@ -227,18 +229,14 @@ func commitModifiedFile(c *object.Commit, relPath string) bool {
 	defer parents.Close()
 
 	hasParent := false
+	treesameToAny := false
 
-	err = parents.ForEach(func(parent *object.Commit) error {
+	_ = parents.ForEach(func(parent *object.Commit) error {
 		hasParent = true
 
 		parentHash, hashErr := blobHash(parent, relPath)
-		if hashErr != nil {
-			// File missing in parent → commit added it.
-			return errFileModified
-		}
-
-		if parentHash != fileHash {
-			return errFileModified
+		if hashErr == nil && parentHash == fileHash {
+			treesameToAny = true
 		}
 
 		return nil
@@ -248,10 +246,8 @@ func commitModifiedFile(c *object.Commit, relPath string) bool {
 		return true // root commit — file was introduced
 	}
 
-	return errors.Is(err, errFileModified)
+	return !treesameToAny
 }
-
-var errFileModified = errors.New("file modified")
 
 // blobHash returns the blob hash of the file at relPath within the commit's tree.
 func blobHash(c *object.Commit, relPath string) (plumbing.Hash, error) {

--- a/internal/provider/git/service.go
+++ b/internal/provider/git/service.go
@@ -8,6 +8,7 @@ import (
 
 	gogit "github.com/go-git/go-git/v5"
 
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/rotisserie/eris"
 	"golang.org/x/sync/singleflight"
@@ -184,6 +185,13 @@ func (s *repoService) fetchCommitData(relPath string) (*commitData, error) {
 	}
 
 	err = log.ForEach(func(c *object.Commit) error {
+		// go-git's FileName filter includes merge commits that didn't
+		// actually modify the file. Skip those to avoid polluting
+		// the newest timestamp with unrelated commit dates.
+		if !commitModifiedFile(c, relPath) {
+			return nil
+		}
+
 		when := c.Author.When
 		if data.oldest.IsZero() || when.Before(data.oldest) {
 			data.oldest = when
@@ -202,4 +210,60 @@ func (s *repoService) fetchCommitData(relPath string) (*commitData, error) {
 	}
 
 	return data, nil
+}
+
+// commitModifiedFile returns true if the commit actually changed the file at
+// relPath, as opposed to merely having it in the tree (which happens with merge
+// commits). A commit modified the file if:
+//   - it is a root commit (no parents), or
+//   - the file's blob hash differs from at least one parent.
+func commitModifiedFile(c *object.Commit, relPath string) bool {
+	fileHash, err := blobHash(c, relPath)
+	if err != nil {
+		return true // conservative: include on error
+	}
+
+	parents := c.Parents()
+	defer parents.Close()
+
+	hasParent := false
+
+	err = parents.ForEach(func(parent *object.Commit) error {
+		hasParent = true
+
+		parentHash, hashErr := blobHash(parent, relPath)
+		if hashErr != nil {
+			// File missing in parent → commit added it.
+			return errFileModified
+		}
+
+		if parentHash != fileHash {
+			return errFileModified
+		}
+
+		return nil
+	})
+
+	if !hasParent {
+		return true // root commit — file was introduced
+	}
+
+	return errors.Is(err, errFileModified)
+}
+
+var errFileModified = errors.New("file modified")
+
+// blobHash returns the blob hash of the file at relPath within the commit's tree.
+func blobHash(c *object.Commit, relPath string) (plumbing.Hash, error) {
+	tree, err := c.Tree()
+	if err != nil {
+		return plumbing.ZeroHash, err //nolint:wrapcheck // internal helper
+	}
+
+	entry, err := tree.File(relPath)
+	if err != nil {
+		return plumbing.ZeroHash, err //nolint:wrapcheck // internal helper
+	}
+
+	return entry.Hash, nil
 }


### PR DESCRIPTION
Fixes #114

## Root Cause

go-git's `Log` with `FileName` option includes merge commits that didn't actually modify the file. These merge commits carry recent timestamps that pollute `commitData.newest`, causing `time.Since(newest)` to always be less than 24 hours and truncate to 0 days.

This affected all three git metrics (file-age, file-freshness, author-count), but file-freshness was most visibly impacted because `data.newest` is far more sensitive to recent noise than `data.oldest`.

## Fix

Added `commitModifiedFile()` — a TREESAME check that compares each commit's file blob hash against all parent commits. Commits where the file is identical to any parent (i.e., merge commits that merely carried the file through) are skipped.

## Tests

- Strengthened `TestFileFreshnessProvider` to assert old files have non-zero freshness
- Added `TestFileFreshness_MergeCommitDoesNotPollute` — verifies merge commits don't inflate freshness
- Added `TestFileAge_MergeCommitDoesNotPollute`
- Added `TestAuthorCount_MergeCommitDoesNotPollute`
- Added `TestFileFreshnessEqualsAgeForSingleCommit` — verifies age == freshness for single-commit files

All existing tests continue to pass. `task test` and `task lint` clean.