### PR TITLE
Feature: Combine metric+palette into metricSpec (#118)

### DIFF
--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -15,6 +15,14 @@
 
 <!-- Append learnings below -->
 
+### go-git FileName filter bug — issue #114 (2026-04-27)
+
+- **Root cause:** go-git's `LogOptions{FileName: &path}` includes merge commits that didn't modify the file, inflating the commit set. This made `data.newest` reflect the repo's most recent commit, not the file's last change.
+- **Fix location:** `internal/provider/git/service.go` — added `commitModifiedFile()` and `blobHash()` to verify each commit by comparing blob hashes with the first parent's tree.
+- **Impact:** Affected all three git metrics (file-age, file-freshness, author-count) since they share `fetchCommitData`. file-freshness was most visibly broken because `newest` was always near-now, truncating to 0 days.
+- **Key insight:** `file-age` appeared correct only by coincidence — for files present since the initial commit, `oldest` happened to match the repo's oldest commit.
+- **PR:** #119 (draft), branch `squad/114-fix-file-freshness`.
+
 ### Export package — issue #107 (2026-04-26)
 
 - **New package:** `internal/export/` — serializes model tree + computed metrics to JSON or YAML files.

--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -8,8 +8,29 @@
 
 ## Recent Work
 
-- **PR #39 resolution (2026-04-15)**: Fixed FolderAuthorCountProvider dependencies, mean-file-lines description, git error logging. Extracted folder load helpers. Fixed float-to-days conversion and test error handling. Branch squad/38-extend-provider-capabilities task ci passed and pushed.
-- **PR #98 — Legend fixes (#89, #90)**: Fixed horizontal legend layout to arrange entries side-by-side instead of stacking vertically. Made legend margin carve-out respect orientation at corner positions. Branch squad/89-90-legend-fixes.
+- **Issue #114 — File freshness fix (2026-04-27):** PR #119 (draft) implements TREESAME check for go-git FileName bug.
+- **Issue #107 — Export package (2026-04-26):** Created `internal/export/` with Export() function for JSON/YAML metrics export.
+- **Issue #118 — MetricSpec integration (2026-04-27):** Noted Kane's MetricSpec type changes affecting metric validation.
+- **PR #98 — Legend fixes (#89, #90) (2026-04-18)**: Fixed horizontal legend layout and orientation-aware carve-out. Branch squad/89-90-legend-fixes.
+- **PR #39 resolution (2026-04-15)**: Fixed FolderAuthorCountProvider dependencies, mean-file-lines description, git error logging. Branch squad/38-extend-provider-capabilities.
+
+## Core Context
+
+This is an accumulation of foundational learnings and architecture decisions from early project phases (2026-04-14 through 2026-04-20) that remain relevant for ongoing feature work:
+
+- **Radialtree architecture (2026-04-15):** Package in `internal/radialtree` with `RadialNode` struct (X, Y, DiscRadius, Angle, Label, ShowLabel, IsDirectory, FillColour, BorderColour, Children), `LabelMode` constants (All, FoldersOnly, None), and `Layout()` function. Nodes positioned in rings at increasing depths; disc sizes scaled by metric value; children output files-first, then subdirectories.
+
+- **Bubbletree layout engine (2026-04-19):** Package in `internal/bubbletree` with `BubbleNode` struct (X, Y, Radius, Label, ShowLabel, IsDirectory, FillColour, BorderColour, Path, Children) and `Layout()` function. Uses front-chain circle-packing with Welzl's enclosing-circle algorithm. Bottom-up packing, top-down coordinate assignment. Signature: `Layout(root *model.Directory, width, height int, sizeMetric metric.Name, labels LabelMode) BubbleNode`.
+
+- **Bubbletree rendering (2026-04-19):** PNG/SVG rendering in `internal/render/bubbletree.go` and `internal/render/svg_bubble.go`. Three-pass z-order: directories (transparent fill), files, labels. Directory transparency ~18% alpha. Path field on BubbleNode (populated during layout) enables colour mapping after sorting.
+
+- **Legend rendering (2026-04-18):** Code split across `legend.go` (types, constants), `legend_png.go` (PNG), `legend_svg.go` (SVG), `legend_test.go`. Supports both vertical and horizontal orientations with orientation-aware carve-out at corner positions. Horizontal layout increments X; vertical increments Y. Always verify outer loop handles orientation when adding new rendering features.
+
+- **Folder metrics helpers (2026-04-15):** Five high-level helpers in `internal/metric/metrics.go` (`loadMaxQuantity`, `loadMinQuantity`, `loadSumQuantity`, `loadMeanMeasure`, `loadPositiveMeanMeasure`) encapsulate `WalkDirectories` loop for all folder provider Load() methods. Use integer duration arithmetic (not float hours/days) to avoid precision loss on long durations.
+
+- **Kong + config defaults pattern (2026-04-15):** Never use `default:` tags on Kong fields — Kong silently overrides config file values. Instead, add `""` to enum lists and set actual defaults in `config.New()`. This ensures CLI and config file values can both be respected.
+
+- **Index-based tree correlation bug (2026-04-20):** When two independent trees (BubbleNode + model.Directory) are sorted/reordered differently, index-based pairing fails. Use direct references (paths, pointers) instead. This applies whenever one tree is reordered for optimization (e.g., packing density) but must stay synchronized with colour mapping from another tree.
 
 ## Learnings
 
@@ -39,6 +60,13 @@
 - **Dependency added:** `gopkg.in/yaml.v3` (direct dependency in go.mod).
 - **No tests created** — Lambert owns the test suite. No CLI wiring — Kane handles that.
 
+### Foliage palette — issue #46 (2026-04-18)
+
+- **New palette added:** `Foliage` (`"foliage"`) in `internal/palette/palette.go` — 11-step ordered palette progressing black → brown → orange → yellow → green for plant-health visualisation.
+- **Pattern:** Adding a palette requires changes in four places: const block, `validPalettes` map, `palettes` map, and the `ColourPalette` var definition. Tests need updating in `palette_test.go` for both `IsValid` and the WCAG contrast loop.
+- **WCAG constraint:** All ordered palettes must pass adjacent-step contrast ratio >= 1.0 (checked in `TestWCAGContrastRatio`). The foliage colours were chosen with sufficient luminance steps to satisfy this.
+- **Environment note:** `gofumpt` and `golangci-lint-custom` aren't available in this shell; rely on `task test` for validation.
+
 ### Curved bubble labels — issue #65 (2026-04-20)
 
 - **New file:** `internal/render/bubble_font.go` — shared TrueType font helpers for bubble tree arc labels.
@@ -49,108 +77,4 @@
 - **SVG rendering:** Uses `<defs>` block with `<path>` arcs (top semicircle, left to right), then `<textPath href="#arc-{idx}" startOffset="50%" text-anchor="middle">`. Traversal indices for path IDs, not node paths.
 - **Lint note:** `fixed.Int26_6` is the return type for `font.Face.GlyphAdvance` and `Kern`, not `font.MeasureUnit`. Accumulate in fixed-point then convert to float64 at the end.
 - **Cognitive complexity:** Split arc computation into small helpers (`clampFontToArc`, `measureStringWidth`, `collectAdvances`, `sumAdvances`, `placeGlyphs`) to stay under revive's max-10 limit.
-
-### Foliage palette — issue #46 (2026-04-18)
-
-- **New palette added:** `Foliage` (`"foliage"`) in `internal/palette/palette.go` — 11-step ordered palette progressing black → brown → orange → yellow → green for plant-health visualisation.
-- **Pattern:** Adding a palette requires changes in four places: const block, `validPalettes` map, `palettes` map, and the `ColourPalette` var definition. Tests need updating in `palette_test.go` for both `IsValid` and the WCAG contrast loop.
-- **WCAG constraint:** All ordered palettes must pass adjacent-step contrast ratio >= 1.0 (checked in `TestWCAGContrastRatio`). The foliage colours were chosen with sufficient luminance steps to satisfy this.
-- **Environment note:** `gofumpt` and `golangci-lint-custom` aren't available in this shell; rely on `task test` for validation.
-
-### PR review fixes — radialtree_cmd.go + config (2026-04-15)
-
-- **Kong defaults silently override config**: `default:"all"` on a Kong string field causes Kong to always set the value, so `applyOverrides` always writes over config file values. Fix: remove `default:` tags from Kong fields, add `""` to enum, set defaults in `config.New()` only.
-- **`defaultStr` helper**: Added `func defaultStr(s string) *string { return &s }` to `internal/config/config.go` for use in `New()`.
-- **`resolveLabels` simplification**: After config.New() guarantees `Labels` is always set, the `c.Labels != ""` fallback branch in `resolveLabels` is dead code and was removed.
-- **RenderRadialPNG pointer call site**: Changed `render.RenderRadialPNG(nodes, ...)` → `render.RenderRadialPNG(&nodes, ...)` to align with Parker's upcoming signature change. Build fails until Parker's change lands (expected).
-- **Colour-apply function invariant**: Documented in all four `applyRadial*` functions that `node.Children` must be files-first, then subdirectories — matching `layoutDir` output order.
-
-### radialtree package (2026-04-15)
-
-- **Package path:** `github.com/bevan/code-visualizer/internal/radialtree` — files `node.go` and `layout.go`
-- **RadialNode fields:** `X, Y float64` (pixel offset from canvas centre), `DiscRadius float64` (disc pixel radius), `Angle float64` (radians, 0=east, π/2=down), `Label string`, `ShowLabel bool`, `IsDirectory bool`, `FillColour color.RGBA`, `BorderColour *color.RGBA`, `Children []RadialNode`
-- **Layout() signature:** `Layout(root *model.Directory, canvasSize int, discMetric metric.Name, labels LabelMode) RadialNode`
-- **LabelMode constants:** `LabelAll = "all"`, `LabelFoldersOnly = "folders"`, `LabelNone = "none"`
-- **Algorithm:** ring spacing = (canvasSize/2 - 40) / (maxDepth+1); angular sectors proportional to leaf counts; files placed before subdirs; disc sizes scaled by discMetric quantity/measure value
-- Removed pre-existing `radialtree.go` stub (replaced by `node.go`)
-
-### PR #39 review fixes (2026-04-15)
-
-- **FolderAuthorCountProvider.Dependencies()**: Added `gitprovider.AuthorCount` dependency for correct scheduler ordering. Note: this provider queries git directly (not via file metrics) to compute author union sets — simple count summation wouldn't give correct cross-file deduplication.
-- **mean-file-lines description**: Updated to explicitly say "skips binary files" per the issue spec.
-- **Git debug logging**: Removed the `!errors.Is(err, errUntracked)` guard so untracked-file events are now logged at `slog.Debug` rather than silently swallowed.
-- **Folder load helpers**: Added five higher-level helpers to `metrics.go` (`loadMaxQuantity`, `loadMinQuantity`, `loadSumQuantity`, `loadMeanMeasure`, `loadPositiveMeanMeasure`) that encapsulate the full WalkDirectories loop — all 8 folder Load() methods now delegate to a single helper call.
-- **Float conversion fix**: Changed `int64(age.Hours()/24)` to `int64(age/(24*time.Hour))` to use integer duration arithmetic, avoiding float precision loss on long durations.
-- **Test error handling**: Fixed ignored `os.WriteFile` errors in folder test setup.
-
-### Bubble Tree — Architecture Proposal Ready (2026-04-19)
-
-- **Issue #33:** Ripley completed architecture research for circle-packing bubble tree visualization.
-- **Your role in Phase 1 (Layout engine):** Implement `internal/bubbletree/` package — node type, front-chain circle-packing algorithm, enclosing circle (Welzl's).
-- **BubbleNode struct:** `X, Y float64` (pixel offset from canvas centre), `Radius float64` (circle radius in px), `Label string`, `ShowLabel bool`, `IsDirectory bool`, `FillColour color.RGBA`, `BorderColour *color.RGBA`, `Children []BubbleNode`
-- **LabelMode constants:** `LabelAll = "all"`, `LabelFoldersOnly = "folders"`, `LabelNone = "none"` (parallel to RadialNode)
-- **Layout() signature:** `func Layout(root *model.Directory, width, height int, sizeMetric metric.Name, labels LabelMode) BubbleNode`
-  - Note: takes width+height (like treemap, allows non-square canvas), unlike radial's square canvasSize
-  - Bottom-up recursive packing with front-chain algorithm (Wang et al. 2006)
-  - Leaf sizing: radius ∝ √(metricValue), with minimum floor
-  - Sort children by radius descending (improves packing density)
-  - Front-chain: maintain doubly-linked circular list of outermost circles; place each new circle tangent to best adjacent pair
-  - Enclosing circle: Welzl's algorithm O(n) expected — compute parent radius as enclosing circle + padding
-  - Top-down: assign absolute pixel coordinates, scale to fit width×height
-- **Geometric primitives needed:** Tangent placement, enclosing circle test, circle-circle overlap test (all straightforward)
-- **Padding:** Sibling gap (2–4px), parent inset (4–8px for labels)
-- **Complexity:** O(n²) per level, acceptable for typical codebases (hundreds–low thousands files/directory)
-- **Files to create:** `internal/bubbletree/node.go`, `internal/bubbletree/layout.go`, `internal/bubbletree/layout_test.go` (unit tests: root enclosure, no overlap, radius scaling, nesting depth, label modes, edge cases)
-- **Dependencies:** Already available (model, metric packages)
-
-### Bubble Tree — Phase 1 Layout Engine (2026-04-19)
-
-- **Files created:** `internal/bubbletree/node.go` (BubbleNode type, LabelMode constants) and `internal/bubbletree/layout.go` (Layout function + packing algorithm).
-- **Algorithm implemented:** Front-chain circle packing with Welzl's enclosing circle. Bottom-up recursive packing then top-down coordinate assignment with scaling.
-- **Key constants:** `minFileRadius=2`, `siblingPadding=3`, `parentPadding=6`. Leaf radius = `sqrt(metricValue)` with floor.
-- **Layout signature:** `Layout(root *model.Directory, width, height int, sizeMetric metric.Name, labels LabelMode) BubbleNode` — matches treemap pattern (width+height, not square canvas).
-- **Geometric primitives:** `tangentPositions` (two-circle tangent placement), `computeEnclosing` (Welzl's adapted for circles not points), `anyOverlap` (circle-circle gap test with padding).
-- **Front chain:** Doubly-linked circular list; no pruning (chain only grows). O(n³) per level worst case, acceptable for typical directory sizes.
-- **Welzl adaptation:** `enclosingTwo` handles containment and diametrically-opposite cases. `enclosingThree` uses algebraic elimination (subtract equation pairs → linear in u,v,R → quadratic in R). Falls back to pairwise when degenerate (collinear centres, det≈0).
-- **`goldenAngle` computed at runtime** (`math.Sqrt` is not const-eligible in Go); used in `placeFallback` for even angular distribution when front-chain tangent fails.
-- **Pre-existing `bubbletree_cmd.go`** references `render.RenderBubble` which doesn't exist yet (Phase 2). Full project `go build ./...` fails on that file, but `go build ./internal/bubbletree/...` passes cleanly.
-
-### Bubble Tree — Phases 2+3: PNG & SVG Rendering (2026-04-19)
-
-- **Files created:** `internal/render/bubbletree.go` (PNG/JPG entry point + image rendering) and `internal/render/svg_bubble.go` (SVG rendering).
-- **Signature:** `RenderBubble(root *bubbletree.BubbleNode, width, height int, outputPath string) error` — matches Kane's call site in `bubbletree_cmd.go`.
-- **Three-pass z-order:** (1) Directory circles sorted by radius descending (outermost first, semi-transparent fills at ~18% alpha), (2) File circles with solid fills, (3) Labels drawn last on top.
-- **Coordinate system:** BubbleNode X/Y are absolute pixel coordinates after `Layout()` calls `scaleToFit`. Renderer draws at node coordinates directly (no cx/cy translation).
-- **Directory transparency:** PNG uses `color.RGBA` with `A=0x30` (~18%). SVG uses `fill-opacity="0.19"` on `<circle>` elements.
-- **Labels:** Straight centred text; directory labels positioned inside circle near top edge (Y - Radius + 14px inset). File labels centred on circle. Colour is constant dark `#222222`.
-- **SVG structure:** Flat three-pass approach matching `svg_radial.go` pattern — not nested `<g>` groups. Three passes ensure consistent z-order with PNG.
-- **Shared helpers:** `collectBubblesByType`, `resolveDirFill`, `resolveFileFill`, `resolveBorder` used by both PNG and SVG renderers.
-- **Golden file:** Created `internal/render/testdata/bubble-tree.png` via `-update` flag.
-- **Full build + all tests pass** (`go build ./...` and `go test ./...` clean).
-
-### Bubble Tree — PR #64 colour-mapping bug fix (2026-04-20)
-
-- **Bug:** `layoutDir` sorts children by radius for packing density, which mutates `node.Children` order. The four colour-mapping functions (`applyBubbleFillColours`, `applyCategoricalBubbleFillColours`, `applyBubbleBorderColours`, `applyCategoricalBubbleBorderColours`) used index-based pairing (`fileIdx`/`dirIdx` counters) to match BubbleNode children with `model.Directory` dirs/files. After sorting, indices no longer corresponded — colours were applied to the wrong nodes.
-- **Fix:** Added `Path string` field to `BubbleNode` (populated from `model.Directory.Path` and `model.File.Path` during layout). Replaced all four index-based colour walkers with path-indexed lookup via `indexBubbleNodesByPath` helper. Sort stays — it's good for packing. Path makes ordering irrelevant for colour mapping.
-- **Key pattern:** Use direct references (paths, pointers), not positional indices, when correlating two trees that may be independently reordered.
-- **Test added:** `TestLayoutPathPopulated` verifies that Path is propagated through the full tree.
-
-### Legend rendering fixes — issues #89, #90
-
-- **Legend code structure:** Legend rendering is split across four files: `legend.go` (types, constants, `ReserveLegendSpace`, `legendOrigin`), `legend_png.go` (PNG draw + measure), `legend_svg.go` (SVG write), `legend_test.go`.
-- **Horizontal layout bug:** `drawLegendEntries` and `writeSVGLegendEntries` always stacked entries vertically (incrementing Y). Added `drawLegendEntriesH`/`writeSVGLegendEntriesH` that increment X for horizontal orientation.
-- **Measurement symmetry:** `measureLegendH` was structurally identical to `measureLegendV` (summing heights). Fixed to sum widths and take max height. Added `measureSingleEntryH` to measure one entry including title for reuse by both PNG and SVG draw paths.
-- **Orientation-aware carve-out:** `ReserveLegendSpace` only used position (center-left/right → width, everything else → height). For corner positions, vertical legends now carve width; horizontal legends carve height. Center positions remain fixed.
-- **`legendLayoutOffset` in `treemap_cmd.go`:** Updated to handle the new orientation-based offsets for corner positions — left corners offset by wReduce when vertical, top corners offset by hReduce when horizontal.
-- **Key pattern:** When rendering code has H/V variants for swatches but not for the entry-level layout loop, bugs silently produce correct-looking but suboptimal output. Always verify the outer loop handles orientation too.
-
-### Issue #107 — Export Package Implementation (2026-04-26)
-
-- **New package:** `internal/export/` containing `export.go` with main Export() function.
-- **Public API:** `Export(root *model.Directory, requested []metric.Name, outputPath string) error` — recursive tree walk, format inference from extension.
-- **Data structures:** ExportData wrapper, DirectoryExport (recursive), FileExport (leaf) with Quantities/Measures/Classifications maps. All use json+yaml struct tags with omitempty on collection fields.
-- **Format handling:** .json → json.MarshalIndent (2-space indent, trailing newline), .yaml/.yml → gopkg.in/yaml.v3. Unsupported extensions return descriptive eris errors.
-- **Metric collection:** Lazy-init approach — only allocate maps when metric values exist. Combined with omitempty tags, output stays clean.
-- **Dependencies added:** gopkg.in/yaml.v3 (direct, added to go.mod).
-- **Test suite:** Left to Lambert. CLI wiring left to Kane. Focus: export logic only.
 

--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -15,6 +15,12 @@
 
 <!-- Append learnings below -->
 
+### MetricSpec type — Issue #118 (2026-04-27)
+
+- **CLI integration with Kane:** Kane's new `config.MetricSpec` type bundles metric+palette into single parameters (`--fill metric,palette`). This affects all metric validation in provider work — when checking metric names against `metric.Provider`, extract via `specMetric()` helper.
+- **Config struct impact:** All visualization config structs (`Treemap`, `Radial`, `Bubbletree`) now use `*MetricSpec` for Fill/Border fields instead of separate palette pointers. Check any metric validation code that reads these config fields.
+- **Helper functions:** Use `specMetric(spec)` and `specPalette(spec)` instead of `ptrString()` to safely extract metric/palette values.
+
 ### go-git FileName filter bug — issue #114 (2026-04-27)
 
 - **Root cause:** go-git's `LogOptions{FileName: &path}` includes merge commits that didn't modify the file, inflating the commit set. This made `data.newest` reflect the repo's most recent commit, not the file's last change.

--- a/.squad/agents/kane/history.md
+++ b/.squad/agents/kane/history.md
@@ -76,4 +76,16 @@
 - **Build status:** Passes. All three commands wired correctly.
 - **Flag design rationale:** Cross-cutting flag on Flags struct allows any visualization command to export metrics without duplication.
 
+### MetricSpec — Combined metric+palette CLI parameter (Issue #118, 2026-07-06)
+
+- **New type `config.MetricSpec`** (`internal/config/metric_spec.go`): Bundles metric name and palette name. Parsed from "metric,palette" or just "metric" format.
+- **Kong integration:** Implements `encoding.TextUnmarshaler` — Kong automatically calls `UnmarshalText` for CLI parsing. No custom mapper needed.
+- **Config serialization:** Custom `MarshalYAML`/`UnmarshalYAML` and `MarshalJSON`/`UnmarshalJSON` for config file support.
+- **CLI struct changes:** `Fill` and `Border` fields changed from `string` to `config.MetricSpec`. Removed separate `FillPalette` and `BorderPalette` fields from all three commands.
+- **Config struct changes:** `Treemap`, `Radial`, `Bubbletree` now use `*MetricSpec` for Fill and Border instead of separate `*string` fields.
+- **Helper functions:** `specMetric(s *MetricSpec) string` and `specPalette(s *MetricSpec) string` replace `ptrString` for MetricSpec access.
+- **Validation:** `--border-palette requires --border` check removed (palette is always bundled with metric). Validation uses `validateMetricPalette()` with extracted metric/palette strings.
+- **Lint:** Used `//nolint:recvcheck` on MetricSpec struct because marshal methods need value receivers while unmarshal methods need pointer receivers.
+- **Key files:** `internal/config/metric_spec.go`, `internal/config/metric_spec_test.go`, all three `*_cmd.go` files, config structs.
+- **PR:** #120
 

--- a/.squad/agents/lambert/history.md
+++ b/.squad/agents/lambert/history.md
@@ -10,6 +10,12 @@
 
 <!-- Append learnings below -->
 
+### MetricSpec type — Issue #118 (2026-04-27)
+
+- **Kane's new type:** `config.MetricSpec` bundles metric name + palette into single string (format: "metric,palette" or just "metric"). Implemented with `TextUnmarshaler` for Kong CLI and custom YAML/JSON marshaling.
+- **Test impact:** All CLI and config struct tests that mock Fill/Border metrics need updating to use `config.MetricSpec` instead of `*string`. The type has its own test suite with 22 cases covering parsing, serialization, and marshaling.
+- **Test patterns:** Look for tests creating TreemapCmd, RadialCmd, BubbletreeCmd fixtures with Fill/Border fields — they now take `MetricSpec` values.
+
 ### 2026-04-14 — radialtree layout tests
 
 Wrote `internal/radialtree/layout_test.go` (white-box, `package radialtree`) with 12 test cases covering:
@@ -135,3 +141,20 @@ Dallas had already delivered `export.go` — all 9 tests pass on first run. Test
 - **No regressions:** Tests validate Dallas's implementation was correct on first delivery.
 - **Pattern compliance:** Gomega assertions, t.Parallel(), nil-safe guards, temp directories for file I/O, JSON/YAML round-trip validation.
 
+
+### 2026-04-27 — issue #114 file-freshness always zero
+
+**Root cause:** go-git's `Log` with `FileName` option includes merge commits that didn't actually modify the file. These merge commits have recent timestamps that pollute `commitData.newest`, making `time.Since(newest)` truncate to 0 days for every file. The `oldest` field was less affected because unrelated merge timestamps are always newer than or equal to the real oldest.
+
+**Fix:** Added `commitModifiedFile()` to `internal/provider/git/service.go` — a TREESAME check comparing each commit's blob hash against all parent commits. Merge commits where the file is identical to any parent are filtered out.
+
+**Key files:**
+- `internal/provider/git/service.go` — `fetchCommitData()`, `commitModifiedFile()`, `blobHash()`
+- `internal/provider/git/metrics_test.go` — 5 new/strengthened tests
+
+**Key learning:** go-git's `FileName` log filter has two quirks vs `git log -- <file>`:
+1. Includes merge commits that didn't modify the file (TREESAME merges)
+2. Uses aggressive history simplification that may miss some commits in complex merge topologies
+The TREESAME blob-hash check fixes (1); (2) is a go-git limitation that doesn't affect practical usage.
+
+**PR:** #119

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -493,3 +493,51 @@ Each command's `Run()` method follows this pattern:
 2. Run module tidy so `gopkg.in/yaml.v3` is removed from `go.mod`/`go.sum`
 3. Re-run the targeted export and CLI tests, then let CI confirm the full suite
 
+---
+
+### MetricSpec — Combined metric+palette type
+
+**Author:** Kane
+**Status:** Implemented (PR #120)
+**Issue:** #118
+
+**Decision:** Introduced `config.MetricSpec` type to bundle metric name and palette name into a single value. This replaces the four separate fields (`Fill`, `FillPalette`, `Border`, `BorderPalette`) on both CLI structs and config structs with two `MetricSpec` fields (`Fill`, `Border`).
+
+**CLI format:**
+```
+--fill file-type,categorization --border file-lines,foliage
+```
+Palette is optional — `--fill file-type` uses the provider's default palette.
+
+**Config format:**
+```yaml
+treemap:
+  fill: file-type,categorization
+  border: file-lines,foliage
+```
+
+**Breaking changes:**
+- `--fill-palette` and `--border-palette` CLI flags removed.
+- Config file fields `fillPalette` and `borderPalette` removed (combine into `fill`/`border` values).
+
+**Impact:**
+- **All command structs** (`TreemapCmd`, `RadialCmd`, `BubbletreeCmd`): Updated to use `MetricSpec`.
+- **Config structs** (`Treemap`, `Radial`, `Bubbletree`): `*MetricSpec` replaces separate pointer strings.
+- **Helper functions**: `specMetric()` and `specPalette()` replace `ptrString()` for MetricSpec access.
+- **Existing config files** using old `fillPalette`/`borderPalette` format will need migration.
+
+---
+
+### go-git FileName log includes non-modifying merge commits
+
+**Author:** Lambert
+**Status:** Implemented (PR #119, fixes #114)
+
+**Context:** go-git's `repo.Log(&LogOptions{FileName: &path})` returns merge commits that have the file in their tree but didn't actually change it. This pollutes `commitData.newest` with very recent timestamps, causing `file-freshness` to always be 0.
+
+**Decision:** Added `commitModifiedFile()` TREESAME check to `fetchCommitData()` in `internal/provider/git/service.go`. Each commit's blob hash is compared against all parent commits; if the hash matches any parent, the commit is skipped. This correctly filters merge commits that merely carried the file through.
+
+**Impact:** All three git metrics (file-age, file-freshness, author-count) now correctly exclude non-modifying merge commits. This is most visible for file-freshness but also improves accuracy for file-age and author-count.
+
+**Known limitation:** go-git's history simplification may still miss some commits in complex merge topologies. This hasn't been observed to cause practical issues.
+

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -395,3 +395,101 @@ Each command's `Run()` method follows this pattern:
 - All meaningful changes require team consensus
 - Document architectural decisions here
 - Keep history focused on work, decisions focused on direction
+
+---
+
+### Git providers: use worktree root for relative paths
+
+**Author:** Dallas
+**Date:** 2026-07-21
+**Status:** Implemented
+
+**Context:** All git metric providers (file-age, file-freshness, author-count) were computing file paths relative to the scan root (`root.Path`), but go-git expects paths relative to the git worktree root. This caused zero-value metrics when scanning a subdirectory.
+
+**Decision:** `repoService` now stores the worktree root path (via `Worktree().Filesystem.Root()`) and exposes it as `RepoRoot()`. All path computations use `RepoRoot()` as the base.
+
+**Also:** Factored the triplicated Load() walk-and-compute pattern into a single `loadGitMetric()` helper to prevent this class of bug from recurring if new git providers are added.
+
+---
+
+### Decision: Filter false-positive commits in git metric providers
+
+**Author:** Dallas
+**Date:** 2026-04-27
+**Issue:** #114
+**PR:** #119
+
+**Context:** go-git's `LogOptions{FileName}` filter includes merge commits that didn't modify the target file. This caused `file-freshness` to always return 0 because `data.newest` reflected the repo's most recent commit, not the file's last actual change.
+
+**Decision:** Added `commitModifiedFile()` to `fetchCommitData` in `internal/provider/git/service.go`. Each commit returned by go-git is verified by comparing the file's blob hash against the first parent's tree. Commits where the file hash is unchanged are skipped.
+
+**Impact:**
+- Fixes `file-freshness` (was always 0, now returns correct days-since-last-change).
+- Also improves accuracy of `file-age` and `author-count` — they shared the same inflated commit set, but the impact was less visible.
+- Small performance cost: each commit now does a tree lookup + parent tree lookup. Acceptable for correctness.
+
+---
+
+### Decision: Replace times slice with explicit oldest/newest in commitData
+
+**Author:** Dallas  
+**Date:** 2026-07-21  
+**Status:** Implemented  
+**Scope:** `internal/provider/git/service.go`
+
+**Context:** The `commitData` struct stored commit timestamps in a `times []time.Time` slice, then used positional indexing (`times[0]` for newest, `times[len-1]` for oldest) to compute file-age and file-freshness. This assumed go-git's iteration order (by committer time descending) matched author-time order. It doesn't — author time ≠ committer time for merge commits, rebases, cherry-picks, and PRs.
+
+**Decision:** Replaced `times []time.Time` with two explicit fields: `oldest time.Time` and `newest time.Time`. During `fetchCommitData()` iteration, track min/max with `Before()`/`After()` comparisons. This eliminates any dependency on iteration order.
+
+**Rationale:**
+- Correct by construction — no ordering assumption, just min/max.
+- Simpler — two fields instead of a growing slice. Less memory, no `len()` checks.
+- All existing tests pass unchanged (synthetic repos have correctly ordered timestamps, but the fix is still correct for them).
+
+---
+
+### golangci-lint upgraded to v2.11.4
+
+**Author:** Lambert
+**Date:** 2026-04-26
+**Issue:** #113
+**PR:** #115
+
+**What changed:**
+- golangci-lint and golangci-lint-custom (nilaway) upgraded from v2.8.0 to v2.11.4
+- All `sort.Slice`/`sort.Strings`/`sort.Float64s` replaced with `slices.SortFunc`/`slices.Sort` (new revive `use-slices-sort` rule)
+- `slog.Error(err.Error())` replaced with structured `slog.Error("msg", "err", err)` (gosec G706)
+- `filepath.Clean()` added for user-supplied paths (gosec G703)
+- Nil guard added to `provider/registry.go:get()` for nilaway safety
+
+**Impact on team:**
+- **All code must now use `slices.Sort`/`slices.SortFunc` instead of `sort.Slice`/`sort.Strings`/`sort.Float64s`**. The linter will enforce this.
+- **Use structured slog logging** (`slog.Error("message", "err", err)`) instead of `slog.Error(err.Error())`.
+- **Sanitise user-supplied file paths** with `filepath.Clean()` before use.
+- New revive rules suggested for adoption in issue #116.
+
+**Version references:**
+- `.devcontainer/install-dependencies.sh` line 149
+- `.devcontainer/.custom-gcl.template.yml` line 1
+
+---
+
+### Ripley Review Verdict — PR #108 Export Metrics
+
+**Author:** Ripley
+**Date:** 2026-04-26
+**PR:** #108
+**Issue:** #107
+**Verdict:** REJECT
+
+**Decision:** Standardize YAML usage for export code on the repository's existing package:
+- Use `go.yaml.in/yaml/v3`
+- Do not introduce `gopkg.in/yaml.v3` alongside it
+
+**Why:** The codebase already uses `go.yaml.in/yaml/v3` in config loading/saving and in the new export tests. Adding `gopkg.in/yaml.v3` in `internal/export/export.go` introduces a second YAML library with the same API surface for no functional gain, increases dependency surface, and breaks consistency.
+
+**Required follow-up:**
+1. Change `internal/export/export.go` to import `go.yaml.in/yaml/v3`
+2. Run module tidy so `gopkg.in/yaml.v3` is removed from `go.mod`/`go.sum`
+3. Re-run the targeted export and CLI tests, then let CI confirm the full suite
+

--- a/cmd/codeviz/bubbletree_cmd.go
+++ b/cmd/codeviz/bubbletree_cmd.go
@@ -28,17 +28,8 @@ type BubbletreeCmd struct {
 	//nolint:revive // kong struct tags require long lines
 	Size metric.Name `default:"" enum:",file-size,file-lines,file-age,file-freshness,author-count" help:"Metric for circle size." short:"s"`
 
-	//nolint:revive // kong struct tags require long lines
-	Fill string `default:"" enum:",file-size,file-lines,file-type,file-age,file-freshness,author-count" help:"Metric for fill colour." optional:"" short:"f"`
-
-	//nolint:revive // kong struct tags require long lines
-	FillPalette string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for fill colour." name:"fill-palette" optional:""`
-
-	//nolint:revive // kong struct tags require long lines
-	Border string `default:"" enum:",file-size,file-lines,file-type,file-age,file-freshness,author-count" help:"Metric for border colour." optional:"" short:"b"`
-
-	//nolint:revive // kong struct tags require long lines
-	BorderPalette string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for border colour." name:"border-palette" optional:""`
+	Fill   config.MetricSpec `help:"Fill colour: metric[,palette] (e.g. file-type,categorization)." optional:"" short:"f"` //nolint:revive,nolintlint // kong struct tags require long lines
+	Border config.MetricSpec `help:"Border colour: metric[,palette] (e.g. file-lines,foliage)." optional:"" short:"b"`     //nolint:revive,nolintlint // kong struct tags require long lines
 
 	Labels string `enum:",all,folders,none" default:"" help:"Labels to display: all, folders, or none."`
 
@@ -75,19 +66,11 @@ func (*BubbletreeCmd) validateConfig(cfg *config.Bubbletree) error {
 		return eris.Errorf("size metric must be numeric, got %q (kind: %d)", size, p.Kind())
 	}
 
-	if err := validateMetricPalette(ptrString(cfg.Fill), ptrString(cfg.FillPalette), "fill"); err != nil {
+	if err := validateMetricPalette(specMetric(cfg.Fill), specPalette(cfg.Fill), "fill"); err != nil {
 		return err
 	}
 
-	if err := validateMetricPalette(ptrString(cfg.Border), ptrString(cfg.BorderPalette), "border"); err != nil {
-		return err
-	}
-
-	if ptrString(cfg.BorderPalette) != "" && ptrString(cfg.Border) == "" {
-		return eris.New("--border-palette requires --border to be specified")
-	}
-
-	return nil
+	return validateMetricPalette(specMetric(cfg.Border), specPalette(cfg.Border), "border")
 }
 
 // mergeConfigAndValidate loads the config file, merges CLI overrides on top,
@@ -135,7 +118,7 @@ func (c *BubbletreeCmd) Run(flags *Flags) error {
 		return eris.Wrap(err, "scan failed")
 	}
 
-	requested := collectRequestedMetrics(size, ptrString(cfg.Fill), ptrString(cfg.Border))
+	requested := collectRequestedMetrics(size, cfg.Fill, cfg.Border)
 
 	err = c.checkGitRequirement(requested)
 	if err != nil {
@@ -216,7 +199,7 @@ func (c *BubbletreeCmd) applyColoursAndRender(
 	borderMetric, borderPaletteName := c.applyBorderColours(&nodes, root, cfg)
 
 	legendPos, legendOrient := resolveLegendOptions(ptrString(cfg.Legend), ptrString(cfg.LegendOrientation))
-	borderName := metric.Name(ptrString(cfg.Border))
+	borderName := metric.Name(specMetric(cfg.Border))
 	legend := buildLegendInfo(
 		legendPos, legendOrient, fillMetric, fillPaletteName,
 		borderName, borderPaletteName, size, root,
@@ -251,20 +234,12 @@ func (c *BubbletreeCmd) applyOverrides(cfg *config.Config) {
 		cfg.Bubbletree.Size = &size
 	}
 
-	if c.Fill != "" {
+	if !c.Fill.IsZero() {
 		cfg.Bubbletree.Fill = &c.Fill
 	}
 
-	if c.FillPalette != "" {
-		cfg.Bubbletree.FillPalette = &c.FillPalette
-	}
-
-	if c.Border != "" {
+	if !c.Border.IsZero() {
 		cfg.Bubbletree.Border = &c.Border
-	}
-
-	if c.BorderPalette != "" {
-		cfg.Bubbletree.BorderPalette = &c.BorderPalette
 	}
 
 	if c.Labels != "" {
@@ -357,7 +332,7 @@ func (c *BubbletreeCmd) checkGitRequirement(requested []metric.Name) error {
 }
 
 func (*BubbletreeCmd) resolveFillMetric(cfg *config.Bubbletree) metric.Name {
-	if fill := ptrString(cfg.Fill); fill != "" {
+	if fill := specMetric(cfg.Fill); fill != "" {
 		return metric.Name(fill)
 	}
 
@@ -365,7 +340,7 @@ func (*BubbletreeCmd) resolveFillMetric(cfg *config.Bubbletree) metric.Name {
 }
 
 func (*BubbletreeCmd) resolveFillPalette(cfg *config.Bubbletree, fillMetric metric.Name) palette.PaletteName {
-	if fp := ptrString(cfg.FillPalette); fp != "" {
+	if fp := specPalette(cfg.Fill); fp != "" {
 		return palette.PaletteName(fp)
 	}
 
@@ -440,15 +415,15 @@ func (*BubbletreeCmd) applyBorderColours(
 	root *model.Directory,
 	cfg *config.Bubbletree,
 ) (metric.Name, palette.PaletteName) {
-	border := ptrString(cfg.Border)
+	border := specMetric(cfg.Border)
 	if border == "" {
 		return "", ""
 	}
 
 	borderMetric := metric.Name(border)
 
-	borderPaletteName := palette.PaletteName(ptrString(cfg.BorderPalette))
-	if ptrString(cfg.BorderPalette) == "" {
+	borderPaletteName := palette.PaletteName(specPalette(cfg.Border))
+	if specPalette(cfg.Border) == "" {
 		if p, ok := provider.Get(borderMetric); ok {
 			borderPaletteName = p.DefaultPalette()
 		} else {

--- a/cmd/codeviz/bubbletree_cmd.go
+++ b/cmd/codeviz/bubbletree_cmd.go
@@ -66,11 +66,15 @@ func (*BubbletreeCmd) validateConfig(cfg *config.Bubbletree) error {
 		return eris.Errorf("size metric must be numeric, got %q (kind: %d)", size, p.Kind())
 	}
 
-	if err := validateMetricPalette(specMetric(cfg.Fill), specPalette(cfg.Fill), "fill"); err != nil {
-		return err
+	if err := cfg.Fill.Validate("fill"); err != nil {
+		return eris.Wrap(err, "invalid fill spec")
 	}
 
-	return validateMetricPalette(specMetric(cfg.Border), specPalette(cfg.Border), "border")
+	if err := cfg.Border.Validate("border"); err != nil {
+		return eris.Wrap(err, "invalid border spec")
+	}
+
+	return nil
 }
 
 // mergeConfigAndValidate loads the config file, merges CLI overrides on top,
@@ -199,7 +203,7 @@ func (c *BubbletreeCmd) applyColoursAndRender(
 	borderMetric, borderPaletteName := c.applyBorderColours(&nodes, root, cfg)
 
 	legendPos, legendOrient := resolveLegendOptions(ptrString(cfg.Legend), ptrString(cfg.LegendOrientation))
-	borderName := metric.Name(specMetric(cfg.Border))
+	borderName := specMetric(cfg.Border)
 	legend := buildLegendInfo(
 		legendPos, legendOrient, fillMetric, fillPaletteName,
 		borderName, borderPaletteName, size, root,
@@ -333,7 +337,7 @@ func (c *BubbletreeCmd) checkGitRequirement(requested []metric.Name) error {
 
 func (*BubbletreeCmd) resolveFillMetric(cfg *config.Bubbletree) metric.Name {
 	if fill := specMetric(cfg.Fill); fill != "" {
-		return metric.Name(fill)
+		return fill
 	}
 
 	return metric.Name(ptrString(cfg.Size))
@@ -341,7 +345,7 @@ func (*BubbletreeCmd) resolveFillMetric(cfg *config.Bubbletree) metric.Name {
 
 func (*BubbletreeCmd) resolveFillPalette(cfg *config.Bubbletree, fillMetric metric.Name) palette.PaletteName {
 	if fp := specPalette(cfg.Fill); fp != "" {
-		return palette.PaletteName(fp)
+		return fp
 	}
 
 	if p, ok := provider.Get(fillMetric); ok {
@@ -420,11 +424,9 @@ func (*BubbletreeCmd) applyBorderColours(
 		return "", ""
 	}
 
-	borderMetric := metric.Name(border)
-
-	borderPaletteName := palette.PaletteName(specPalette(cfg.Border))
-	if specPalette(cfg.Border) == "" {
-		if p, ok := provider.Get(borderMetric); ok {
+	borderPaletteName := specPalette(cfg.Border)
+	if borderPaletteName == "" {
+		if p, ok := provider.Get(border); ok {
 			borderPaletteName = p.DefaultPalette()
 		} else {
 			borderPaletteName = palette.Neutral
@@ -433,24 +435,24 @@ func (*BubbletreeCmd) applyBorderColours(
 
 	borderPalette := palette.GetPalette(borderPaletteName)
 
-	p, ok := provider.Get(borderMetric)
+	p, ok := provider.Get(border)
 	if !ok {
-		return borderMetric, borderPaletteName
+		return border, borderPaletteName
 	}
 
 	if p.Kind() == metric.Quantity || p.Kind() == metric.Measure {
-		values := collectNumericValues(root, borderMetric)
+		values := collectNumericValues(root, border)
 		if len(values) > 0 {
 			buckets := metric.ComputeBuckets(values, len(borderPalette.Colours))
-			applyBubbleBorderColours(nodes, root, borderMetric, buckets, borderPalette)
+			applyBubbleBorderColours(nodes, root, border, buckets, borderPalette)
 		}
 	} else {
-		types := collectDistinctTypes(root, borderMetric)
+		types := collectDistinctTypes(root, border)
 		mapper := palette.NewCategoricalMapper(types, borderPalette)
-		applyCategoricalBubbleBorderColours(nodes, root, borderMetric, mapper)
+		applyCategoricalBubbleBorderColours(nodes, root, border, mapper)
 	}
 
-	return borderMetric, borderPaletteName
+	return border, borderPaletteName
 }
 
 // indexBubbleNodesByPath recursively walks the BubbleNode tree and indexes

--- a/cmd/codeviz/main_test.go
+++ b/cmd/codeviz/main_test.go
@@ -337,7 +337,7 @@ func TestTreemapCmd_ValidateConfig_ConfigSuppliesFillAndPalette(t *testing.T) {
 	cfgPath := filepath.Join(dir, "config.yaml")
 	g.Expect(os.WriteFile(
 		cfgPath,
-		[]byte("treemap:\n  size: file-size\n  fill: file-lines\n  fillPalette: temperature\n"),
+		[]byte("treemap:\n  size: file-size\n  fill: file-lines,temperature\n"),
 		0o600,
 	)).To(Succeed())
 
@@ -352,26 +352,13 @@ func TestTreemapCmd_ValidateConfig_ConfigSuppliesFillAndPalette(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 }
 
-func TestTreemapCmd_ValidateConfig_BorderPaletteWithoutBorder(t *testing.T) {
-	t.Parallel()
-	g := NewGomegaWithT(t)
-
-	cfg := config.New()
-	cfg.Treemap.Size = new("file-size")
-	cfg.Treemap.BorderPalette = new("temperature") // no Border set
-
-	cmd := &TreemapCmd{}
-	err := cmd.validateConfig(cfg.Treemap)
-	g.Expect(err).To(MatchError(ContainSubstring("--border-palette requires --border")))
-}
-
 func TestTreemapCmd_ValidateConfig_InvalidFillMetric(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
 	cfg := config.New()
 	cfg.Treemap.Size = new("file-size")
-	cfg.Treemap.Fill = new("not-a-real-metric")
+	cfg.Treemap.Fill = &config.MetricSpec{Metric: "not-a-real-metric"}
 
 	cmd := &TreemapCmd{}
 	err := cmd.validateConfig(cfg.Treemap)
@@ -384,8 +371,7 @@ func TestTreemapCmd_ValidateConfig_InvalidFillPalette(t *testing.T) {
 
 	cfg := config.New()
 	cfg.Treemap.Size = new("file-size")
-	cfg.Treemap.Fill = new("file-lines")
-	cfg.Treemap.FillPalette = new("not-a-real-palette")
+	cfg.Treemap.Fill = &config.MetricSpec{Metric: "file-lines", Palette: "not-a-real-palette"}
 
 	cmd := &TreemapCmd{}
 	err := cmd.validateConfig(cfg.Treemap)

--- a/cmd/codeviz/radialtree_cmd.go
+++ b/cmd/codeviz/radialtree_cmd.go
@@ -27,10 +27,8 @@ type RadialCmd struct {
 
 	DiscSize metric.Name `default:"" enum:",file-size,file-lines,file-age,file-freshness,author-count" help:"Metric for disc size." short:"d"` //nolint:revive // kong struct tags require long lines
 
-	Fill          string `default:"" enum:",file-size,file-lines,file-type,file-age,file-freshness,author-count" help:"Metric for fill colour." optional:"" short:"f"`   //nolint:revive // kong struct tags require long lines
-	FillPalette   string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for fill colour." name:"fill-palette" optional:""`        //nolint:revive // kong struct tags require long lines
-	Border        string `default:"" enum:",file-size,file-lines,file-type,file-age,file-freshness,author-count" help:"Metric for border colour." optional:"" short:"b"` //nolint:revive // kong struct tags require long lines
-	BorderPalette string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for border colour." name:"border-palette" optional:""`    //nolint:revive // kong struct tags require long lines
+	Fill   config.MetricSpec `help:"Fill colour: metric[,palette] (e.g. file-type,categorization)." optional:"" short:"f"` //nolint:revive,nolintlint // kong struct tags require long lines
+	Border config.MetricSpec `help:"Border colour: metric[,palette] (e.g. file-lines,foliage)." optional:"" short:"b"`     //nolint:revive,nolintlint // kong struct tags require long lines
 
 	Labels string `enum:",all,folders,none" default:"" help:"Labels to display: all, folders, or none."`
 
@@ -67,19 +65,11 @@ func (*RadialCmd) validateConfig(cfg *config.Radial) error {
 		return eris.Errorf("disc-size metric must be numeric, got %q (kind: %d)", discSize, p.Kind())
 	}
 
-	if err := validateMetricPalette(ptrString(cfg.Fill), ptrString(cfg.FillPalette), "fill"); err != nil {
+	if err := validateMetricPalette(specMetric(cfg.Fill), specPalette(cfg.Fill), "fill"); err != nil {
 		return err
 	}
 
-	if err := validateMetricPalette(ptrString(cfg.Border), ptrString(cfg.BorderPalette), "border"); err != nil {
-		return err
-	}
-
-	if ptrString(cfg.BorderPalette) != "" && ptrString(cfg.Border) == "" {
-		return eris.New("--border-palette requires --border to be specified")
-	}
-
-	return nil
+	return validateMetricPalette(specMetric(cfg.Border), specPalette(cfg.Border), "border")
 }
 
 // mergeConfigAndValidate loads the config file, merges CLI overrides on top,
@@ -127,7 +117,7 @@ func (c *RadialCmd) Run(flags *Flags) error {
 		return eris.Wrap(err, "scan failed")
 	}
 
-	requested := collectRequestedMetrics(discSize, ptrString(cfg.Fill), ptrString(cfg.Border))
+	requested := collectRequestedMetrics(discSize, cfg.Fill, cfg.Border)
 
 	err = c.checkGitRequirement(requested)
 	if err != nil {
@@ -207,7 +197,7 @@ func (c *RadialCmd) applyColoursAndRender(
 	borderMetric, borderPaletteName := c.applyBorderColours(&nodes, root, cfg)
 
 	legendPos, legendOrient := resolveLegendOptions(ptrString(cfg.Legend), ptrString(cfg.LegendOrientation))
-	borderName := metric.Name(ptrString(cfg.Border))
+	borderName := metric.Name(specMetric(cfg.Border))
 	legend := buildLegendInfo(
 		legendPos, legendOrient, fillMetric, fillPaletteName,
 		borderName, borderPaletteName, discSize, root,
@@ -242,20 +232,12 @@ func (c *RadialCmd) applyOverrides(cfg *config.Config) {
 		cfg.Radial.DiscSize = &discSize
 	}
 
-	if c.Fill != "" {
+	if !c.Fill.IsZero() {
 		cfg.Radial.Fill = &c.Fill
 	}
 
-	if c.FillPalette != "" {
-		cfg.Radial.FillPalette = &c.FillPalette
-	}
-
-	if c.Border != "" {
+	if !c.Border.IsZero() {
 		cfg.Radial.Border = &c.Border
-	}
-
-	if c.BorderPalette != "" {
-		cfg.Radial.BorderPalette = &c.BorderPalette
 	}
 
 	if c.Labels != "" {
@@ -348,7 +330,7 @@ func (c *RadialCmd) checkGitRequirement(requested []metric.Name) error {
 }
 
 func (*RadialCmd) resolveFillMetric(cfg *config.Radial) metric.Name {
-	if fill := ptrString(cfg.Fill); fill != "" {
+	if fill := specMetric(cfg.Fill); fill != "" {
 		return metric.Name(fill)
 	}
 
@@ -356,7 +338,7 @@ func (*RadialCmd) resolveFillMetric(cfg *config.Radial) metric.Name {
 }
 
 func (*RadialCmd) resolveFillPalette(cfg *config.Radial, fillMetric metric.Name) palette.PaletteName {
-	if fp := ptrString(cfg.FillPalette); fp != "" {
+	if fp := specPalette(cfg.Fill); fp != "" {
 		return palette.PaletteName(fp)
 	}
 
@@ -431,15 +413,15 @@ func (*RadialCmd) applyBorderColours(
 	root *model.Directory,
 	cfg *config.Radial,
 ) (metric.Name, palette.PaletteName) {
-	border := ptrString(cfg.Border)
+	border := specMetric(cfg.Border)
 	if border == "" {
 		return "", ""
 	}
 
 	borderMetric := metric.Name(border)
 
-	borderPaletteName := palette.PaletteName(ptrString(cfg.BorderPalette))
-	if ptrString(cfg.BorderPalette) == "" {
+	borderPaletteName := palette.PaletteName(specPalette(cfg.Border))
+	if specPalette(cfg.Border) == "" {
 		if p, ok := provider.Get(borderMetric); ok {
 			borderPaletteName = p.DefaultPalette()
 		} else {

--- a/cmd/codeviz/radialtree_cmd.go
+++ b/cmd/codeviz/radialtree_cmd.go
@@ -65,11 +65,15 @@ func (*RadialCmd) validateConfig(cfg *config.Radial) error {
 		return eris.Errorf("disc-size metric must be numeric, got %q (kind: %d)", discSize, p.Kind())
 	}
 
-	if err := validateMetricPalette(specMetric(cfg.Fill), specPalette(cfg.Fill), "fill"); err != nil {
-		return err
+	if err := cfg.Fill.Validate("fill"); err != nil {
+		return eris.Wrap(err, "invalid fill spec")
 	}
 
-	return validateMetricPalette(specMetric(cfg.Border), specPalette(cfg.Border), "border")
+	if err := cfg.Border.Validate("border"); err != nil {
+		return eris.Wrap(err, "invalid border spec")
+	}
+
+	return nil
 }
 
 // mergeConfigAndValidate loads the config file, merges CLI overrides on top,
@@ -197,7 +201,7 @@ func (c *RadialCmd) applyColoursAndRender(
 	borderMetric, borderPaletteName := c.applyBorderColours(&nodes, root, cfg)
 
 	legendPos, legendOrient := resolveLegendOptions(ptrString(cfg.Legend), ptrString(cfg.LegendOrientation))
-	borderName := metric.Name(specMetric(cfg.Border))
+	borderName := specMetric(cfg.Border)
 	legend := buildLegendInfo(
 		legendPos, legendOrient, fillMetric, fillPaletteName,
 		borderName, borderPaletteName, discSize, root,
@@ -331,7 +335,7 @@ func (c *RadialCmd) checkGitRequirement(requested []metric.Name) error {
 
 func (*RadialCmd) resolveFillMetric(cfg *config.Radial) metric.Name {
 	if fill := specMetric(cfg.Fill); fill != "" {
-		return metric.Name(fill)
+		return fill
 	}
 
 	return metric.Name(ptrString(cfg.DiscSize))
@@ -339,7 +343,7 @@ func (*RadialCmd) resolveFillMetric(cfg *config.Radial) metric.Name {
 
 func (*RadialCmd) resolveFillPalette(cfg *config.Radial, fillMetric metric.Name) palette.PaletteName {
 	if fp := specPalette(cfg.Fill); fp != "" {
-		return palette.PaletteName(fp)
+		return fp
 	}
 
 	if p, ok := provider.Get(fillMetric); ok {
@@ -418,11 +422,9 @@ func (*RadialCmd) applyBorderColours(
 		return "", ""
 	}
 
-	borderMetric := metric.Name(border)
-
-	borderPaletteName := palette.PaletteName(specPalette(cfg.Border))
-	if specPalette(cfg.Border) == "" {
-		if p, ok := provider.Get(borderMetric); ok {
+	borderPaletteName := specPalette(cfg.Border)
+	if borderPaletteName == "" {
+		if p, ok := provider.Get(border); ok {
 			borderPaletteName = p.DefaultPalette()
 		} else {
 			borderPaletteName = palette.Neutral
@@ -431,24 +433,24 @@ func (*RadialCmd) applyBorderColours(
 
 	borderPalette := palette.GetPalette(borderPaletteName)
 
-	p, ok := provider.Get(borderMetric)
+	p, ok := provider.Get(border)
 	if !ok {
-		return borderMetric, borderPaletteName
+		return border, borderPaletteName
 	}
 
 	if p.Kind() == metric.Quantity || p.Kind() == metric.Measure {
-		values := collectNumericValues(root, borderMetric)
+		values := collectNumericValues(root, border)
 		if len(values) > 0 {
 			buckets := metric.ComputeBuckets(values, len(borderPalette.Colours))
-			applyRadialBorderColours(nodes, root, borderMetric, buckets, borderPalette)
+			applyRadialBorderColours(nodes, root, border, buckets, borderPalette)
 		}
 	} else {
-		types := collectDistinctTypes(root, borderMetric)
+		types := collectDistinctTypes(root, border)
 		mapper := palette.NewCategoricalMapper(types, borderPalette)
-		applyCategoricalRadialBorderColours(nodes, root, borderMetric, mapper)
+		applyCategoricalRadialBorderColours(nodes, root, border, mapper)
 	}
 
-	return borderMetric, borderPaletteName
+	return border, borderPaletteName
 }
 
 // applyRadialFillColours assigns fill colours to the RadialNode tree.

--- a/cmd/codeviz/treemap_cmd.go
+++ b/cmd/codeviz/treemap_cmd.go
@@ -66,25 +66,12 @@ func (*TreemapCmd) validateConfig(cfg *config.Treemap) error {
 		return eris.Errorf("size metric must be numeric, got %q (kind: %d)", size, p.Kind())
 	}
 
-	if err := validateMetricPalette(specMetric(cfg.Fill), specPalette(cfg.Fill), "fill"); err != nil {
-		return err
+	if err := cfg.Fill.Validate("fill"); err != nil {
+		return eris.Wrap(err, "invalid fill spec")
 	}
 
-	return validateMetricPalette(specMetric(cfg.Border), specPalette(cfg.Border), "border")
-}
-
-func validateMetricPalette(metricStr, paletteStr, label string) error {
-	if metricStr != "" {
-		if _, ok := provider.Get(metric.Name(metricStr)); !ok {
-			return eris.Errorf("invalid %s metric %q; available metrics: %s", label, metricStr, formatMetricNames())
-		}
-	}
-
-	if paletteStr != "" {
-		p := palette.PaletteName(paletteStr)
-		if !p.IsValid() {
-			return eris.Errorf("invalid %s palette %q", label, paletteStr)
-		}
+	if err := cfg.Border.Validate("border"); err != nil {
+		return eris.Wrap(err, "invalid border spec")
 	}
 
 	return nil
@@ -107,10 +94,9 @@ func collectRequestedMetrics(size metric.Name, fill, border *config.MetricSpec) 
 
 	for _, spec := range []*config.MetricSpec{fill, border} {
 		if spec != nil && spec.Metric != "" {
-			n := metric.Name(spec.Metric)
-			if !seen[n] {
-				seen[n] = true
-				names = append(names, n)
+			if !seen[spec.Metric] {
+				seen[spec.Metric] = true
+				names = append(names, spec.Metric)
 			}
 		}
 	}
@@ -119,7 +105,7 @@ func collectRequestedMetrics(size metric.Name, fill, border *config.MetricSpec) 
 }
 
 // specMetric returns the metric name from a *MetricSpec, or "" if nil.
-func specMetric(s *config.MetricSpec) string {
+func specMetric(s *config.MetricSpec) metric.Name {
 	if s == nil {
 		return ""
 	}
@@ -128,7 +114,7 @@ func specMetric(s *config.MetricSpec) string {
 }
 
 // specPalette returns the palette name from a *MetricSpec, or "" if nil.
-func specPalette(s *config.MetricSpec) string {
+func specPalette(s *config.MetricSpec) palette.PaletteName {
 	if s == nil {
 		return ""
 	}
@@ -279,17 +265,15 @@ func resolveBorderPaletteName(cfg *config.Treemap) (metric.Name, palette.Palette
 		return "", ""
 	}
 
-	borderMetric := metric.Name(border)
-
 	if bp := specPalette(cfg.Border); bp != "" {
-		return borderMetric, palette.PaletteName(bp)
+		return border, bp
 	}
 
-	if p, ok := provider.Get(borderMetric); ok {
-		return borderMetric, p.DefaultPalette()
+	if p, ok := provider.Get(border); ok {
+		return border, p.DefaultPalette()
 	}
 
-	return borderMetric, palette.Neutral
+	return border, palette.Neutral
 }
 
 func (c *TreemapCmd) renderAndLog(
@@ -482,7 +466,7 @@ func (c *TreemapCmd) validatePaths() error {
 
 func (*TreemapCmd) resolveFillMetric(cfg *config.Treemap) metric.Name {
 	if fill := specMetric(cfg.Fill); fill != "" {
-		return metric.Name(fill)
+		return fill
 	}
 
 	return metric.Name(ptrString(cfg.Size))
@@ -490,7 +474,7 @@ func (*TreemapCmd) resolveFillMetric(cfg *config.Treemap) metric.Name {
 
 func (*TreemapCmd) resolveFillPalette(cfg *config.Treemap, fillMetric metric.Name) palette.PaletteName {
 	if fp := specPalette(cfg.Fill); fp != "" {
-		return palette.PaletteName(fp)
+		return fp
 	}
 
 	if p, ok := provider.Get(fillMetric); ok {
@@ -560,11 +544,9 @@ func (*TreemapCmd) applyBorderColours(
 		return "", ""
 	}
 
-	borderMetric := metric.Name(border)
-
-	borderPaletteName := palette.PaletteName(specPalette(cfg.Border))
-	if specPalette(cfg.Border) == "" {
-		if p, ok := provider.Get(borderMetric); ok {
+	borderPaletteName := specPalette(cfg.Border)
+	if borderPaletteName == "" {
+		if p, ok := provider.Get(border); ok {
 			borderPaletteName = p.DefaultPalette()
 		} else {
 			borderPaletteName = palette.Neutral
@@ -573,24 +555,24 @@ func (*TreemapCmd) applyBorderColours(
 
 	borderPalette := palette.GetPalette(borderPaletteName)
 
-	p, ok := provider.Get(borderMetric)
+	p, ok := provider.Get(border)
 	if !ok {
-		return borderMetric, borderPaletteName
+		return border, borderPaletteName
 	}
 
 	if p.Kind() == metric.Quantity || p.Kind() == metric.Measure {
-		values := collectNumericValues(root, borderMetric)
+		values := collectNumericValues(root, border)
 		if len(values) > 0 {
 			buckets := metric.ComputeBuckets(values, len(borderPalette.Colours))
-			applyNumericBorderColours(rects, root, borderMetric, buckets, borderPalette)
+			applyNumericBorderColours(rects, root, border, buckets, borderPalette)
 		}
 	} else {
-		types := collectDistinctTypes(root, borderMetric)
+		types := collectDistinctTypes(root, border)
 		mapper := palette.NewCategoricalMapper(types, borderPalette)
-		applyCategoricalBorderColours(rects, root, borderMetric, mapper)
+		applyCategoricalBorderColours(rects, root, border, mapper)
 	}
 
-	return borderMetric, borderPaletteName
+	return border, borderPaletteName
 }
 
 func extractNumeric(f *model.File, m metric.Name) float64 {

--- a/cmd/codeviz/treemap_cmd.go
+++ b/cmd/codeviz/treemap_cmd.go
@@ -30,10 +30,8 @@ type TreemapCmd struct {
 
 	Size metric.Name `default:"" enum:",file-size,file-lines,file-age,file-freshness,author-count" help:"Metric for rectangle area." short:"s"` //nolint:revive,nolintlint // kong struct tags require long lines
 
-	Fill          string `default:"" enum:",file-size,file-lines,file-type,file-age,file-freshness,author-count" help:"Metric for fill colour." optional:"" short:"f"`   //nolint:revive,nolintlint // kong struct tags require long lines
-	FillPalette   string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for fill colour." name:"fill-palette" optional:""`        //nolint:revive,nolintlint // kong struct tags require long lines
-	Border        string `default:"" enum:",file-size,file-lines,file-type,file-age,file-freshness,author-count" help:"Metric for border colour." optional:"" short:"b"` //nolint:revive // kong struct tags require long lines
-	BorderPalette string `default:"" enum:",categorization,temperature,good-bad,neutral,foliage" help:"Palette for border colour." name:"border-palette" optional:""`    //nolint:revive // kong struct tags require long lines
+	Fill   config.MetricSpec `help:"Fill colour: metric[,palette] (e.g. file-type,categorization)." optional:"" short:"f"` //nolint:revive,nolintlint // kong struct tags require long lines
+	Border config.MetricSpec `help:"Border colour: metric[,palette] (e.g. file-lines,foliage)." optional:"" short:"b"`     //nolint:revive,nolintlint // kong struct tags require long lines
 
 	Legend            string `default:"" enum:",top-left,top-center,top-right,center-right,bottom-right,bottom-center,bottom-left,center-left,none" help:"Legend position (default: bottom-right)." optional:""` //nolint:revive // kong struct tags require long lines
 	LegendOrientation string `default:"" enum:",vertical,horizontal" help:"Legend orientation (auto-detected from position if omitted)." name:"legend-orientation" optional:""`                                  //nolint:revive // kong struct tags require long lines
@@ -68,19 +66,11 @@ func (*TreemapCmd) validateConfig(cfg *config.Treemap) error {
 		return eris.Errorf("size metric must be numeric, got %q (kind: %d)", size, p.Kind())
 	}
 
-	if err := validateMetricPalette(ptrString(cfg.Fill), ptrString(cfg.FillPalette), "fill"); err != nil {
+	if err := validateMetricPalette(specMetric(cfg.Fill), specPalette(cfg.Fill), "fill"); err != nil {
 		return err
 	}
 
-	if err := validateMetricPalette(ptrString(cfg.Border), ptrString(cfg.BorderPalette), "border"); err != nil {
-		return err
-	}
-
-	if ptrString(cfg.BorderPalette) != "" && ptrString(cfg.Border) == "" {
-		return eris.New("--border-palette requires --border to be specified")
-	}
-
-	return nil
+	return validateMetricPalette(specMetric(cfg.Border), specPalette(cfg.Border), "border")
 }
 
 func validateMetricPalette(metricStr, paletteStr, label string) error {
@@ -111,13 +101,13 @@ func formatMetricNames() string {
 	return strings.Join(strs, ", ")
 }
 
-func collectRequestedMetrics(size metric.Name, fill, border string) []metric.Name {
+func collectRequestedMetrics(size metric.Name, fill, border *config.MetricSpec) []metric.Name {
 	seen := map[metric.Name]bool{size: true}
 	names := []metric.Name{size}
 
-	for _, s := range []string{fill, border} {
-		if s != "" {
-			n := metric.Name(s)
+	for _, spec := range []*config.MetricSpec{fill, border} {
+		if spec != nil && spec.Metric != "" {
+			n := metric.Name(spec.Metric)
 			if !seen[n] {
 				seen[n] = true
 				names = append(names, n)
@@ -126,6 +116,24 @@ func collectRequestedMetrics(size metric.Name, fill, border string) []metric.Nam
 	}
 
 	return names
+}
+
+// specMetric returns the metric name from a *MetricSpec, or "" if nil.
+func specMetric(s *config.MetricSpec) string {
+	if s == nil {
+		return ""
+	}
+
+	return s.Metric
+}
+
+// specPalette returns the palette name from a *MetricSpec, or "" if nil.
+func specPalette(s *config.MetricSpec) string {
+	if s == nil {
+		return ""
+	}
+
+	return s.Palette
 }
 
 // mergeConfigAndValidate loads the config file, merges CLI overrides on top,
@@ -174,7 +182,7 @@ func (c *TreemapCmd) Run(flags *Flags) error {
 	}
 
 	// Collect all requested metrics and run providers
-	requested := collectRequestedMetrics(size, ptrString(cfg.Fill), ptrString(cfg.Border))
+	requested := collectRequestedMetrics(size, cfg.Fill, cfg.Border)
 
 	// Check git requirement before running providers
 	if err := c.checkGitRequirement(requested); err != nil {
@@ -266,14 +274,14 @@ func cornerLegendOffset(info *render.LegendInfo, wReduce, hReduce float64) (dx, 
 // palette, using provider defaults when no explicit palette is configured.
 // Shared by legend building and colour application to ensure consistency.
 func resolveBorderPaletteName(cfg *config.Treemap) (metric.Name, palette.PaletteName) {
-	border := ptrString(cfg.Border)
+	border := specMetric(cfg.Border)
 	if border == "" {
 		return "", ""
 	}
 
 	borderMetric := metric.Name(border)
 
-	if bp := ptrString(cfg.BorderPalette); bp != "" {
+	if bp := specPalette(cfg.Border); bp != "" {
 		return borderMetric, palette.PaletteName(bp)
 	}
 
@@ -401,20 +409,12 @@ func (c *TreemapCmd) applyOverrides(cfg *config.Config) {
 		cfg.Treemap.Size = &size
 	}
 
-	if c.Fill != "" {
+	if !c.Fill.IsZero() {
 		cfg.Treemap.Fill = &c.Fill
 	}
 
-	if c.FillPalette != "" {
-		cfg.Treemap.FillPalette = &c.FillPalette
-	}
-
-	if c.Border != "" {
+	if !c.Border.IsZero() {
 		cfg.Treemap.Border = &c.Border
-	}
-
-	if c.BorderPalette != "" {
-		cfg.Treemap.BorderPalette = &c.BorderPalette
 	}
 
 	if c.Legend != "" {
@@ -481,7 +481,7 @@ func (c *TreemapCmd) validatePaths() error {
 }
 
 func (*TreemapCmd) resolveFillMetric(cfg *config.Treemap) metric.Name {
-	if fill := ptrString(cfg.Fill); fill != "" {
+	if fill := specMetric(cfg.Fill); fill != "" {
 		return metric.Name(fill)
 	}
 
@@ -489,7 +489,7 @@ func (*TreemapCmd) resolveFillMetric(cfg *config.Treemap) metric.Name {
 }
 
 func (*TreemapCmd) resolveFillPalette(cfg *config.Treemap, fillMetric metric.Name) palette.PaletteName {
-	if fp := ptrString(cfg.FillPalette); fp != "" {
+	if fp := specPalette(cfg.Fill); fp != "" {
 		return palette.PaletteName(fp)
 	}
 
@@ -555,15 +555,15 @@ func (*TreemapCmd) applyBorderColours(
 	root *model.Directory,
 	cfg *config.Treemap,
 ) (metric.Name, palette.PaletteName) {
-	border := ptrString(cfg.Border)
+	border := specMetric(cfg.Border)
 	if border == "" {
 		return "", ""
 	}
 
 	borderMetric := metric.Name(border)
 
-	borderPaletteName := palette.PaletteName(ptrString(cfg.BorderPalette))
-	if ptrString(cfg.BorderPalette) == "" {
+	borderPaletteName := palette.PaletteName(specPalette(cfg.Border))
+	if specPalette(cfg.Border) == "" {
 		if p, ok := provider.Get(borderMetric); ok {
 			borderPaletteName = p.DefaultPalette()
 		} else {

--- a/internal/config/bubbletree.go
+++ b/internal/config/bubbletree.go
@@ -4,12 +4,10 @@ package config
 // All fields are pointers: nil means the field was not configured, non-nil
 // means it was explicitly set (by a config file or by a CLI flag override).
 type Bubbletree struct {
-	Size              *string `yaml:"size,omitempty"              json:"size,omitempty"`
-	Fill              *string `yaml:"fill,omitempty"              json:"fill,omitempty"`
-	FillPalette       *string `yaml:"fillPalette,omitempty"       json:"fillPalette,omitempty"`
-	Border            *string `yaml:"border,omitempty"            json:"border,omitempty"`
-	BorderPalette     *string `yaml:"borderPalette,omitempty"     json:"borderPalette,omitempty"`
-	Labels            *string `yaml:"labels,omitempty"            json:"labels,omitempty"`
-	Legend            *string `yaml:"legend,omitempty"            json:"legend,omitempty"`
-	LegendOrientation *string `yaml:"legendOrientation,omitempty" json:"legendOrientation,omitempty"`
+	Size              *string     `yaml:"size,omitempty"              json:"size,omitempty"`
+	Fill              *MetricSpec `yaml:"fill,omitempty"              json:"fill,omitempty"`
+	Border            *MetricSpec `yaml:"border,omitempty"            json:"border,omitempty"`
+	Labels            *string     `yaml:"labels,omitempty"            json:"labels,omitempty"`
+	Legend            *string     `yaml:"legend,omitempty"            json:"legend,omitempty"`
+	LegendOrientation *string     `yaml:"legendOrientation,omitempty" json:"legendOrientation,omitempty"`
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,6 +8,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/bevan/code-visualizer/internal/filter"
+	"github.com/bevan/code-visualizer/internal/metric"
+	"github.com/bevan/code-visualizer/internal/palette"
 )
 
 // New tests
@@ -154,8 +156,8 @@ func TestLoad_JSONConfig_OverridesFill(t *testing.T) {
 	// Assert
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(cfg.Treemap.Fill).NotTo(BeNil())
-	g.Expect(cfg.Treemap.Fill.Metric).To(Equal("file-type"))
-	g.Expect(cfg.Treemap.Fill.Palette).To(Equal("categorization"))
+	g.Expect(cfg.Treemap.Fill.Metric).To(Equal(metric.Name("file-type")))
+	g.Expect(cfg.Treemap.Fill.Palette).To(Equal(palette.PaletteName("categorization")))
 }
 
 func TestLoad_InvalidYAML_ReturnsError(t *testing.T) {
@@ -258,7 +260,7 @@ func TestSave_ThenLoad_RoundTrips(t *testing.T) {
 	path := filepath.Join(dir, "config.yaml")
 
 	original := New()
-	original.Treemap.Fill = &MetricSpec{Metric: "file-type"}
+	original.Treemap.Fill = &MetricSpec{Metric: metric.Name("file-type")}
 
 	// Act: save then load into fresh config
 	g.Expect(original.Save(path)).To(Succeed())
@@ -270,7 +272,7 @@ func TestSave_ThenLoad_RoundTrips(t *testing.T) {
 	g.Expect(*loaded.Width).To(Equal(1920))
 	g.Expect(*loaded.Height).To(Equal(1080))
 	g.Expect(loaded.Treemap.Fill).NotTo(BeNil())
-	g.Expect(loaded.Treemap.Fill.Metric).To(Equal("file-type"))
+	g.Expect(loaded.Treemap.Fill.Metric).To(Equal(metric.Name("file-type")))
 }
 
 func TestSave_OmitsNilFields(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -57,9 +57,7 @@ func TestNew_OptionalFieldsNil(t *testing.T) {
 
 	// Assert
 	g.Expect(cfg.Treemap.Fill).To(BeNil())
-	g.Expect(cfg.Treemap.FillPalette).To(BeNil())
 	g.Expect(cfg.Treemap.Border).To(BeNil())
-	g.Expect(cfg.Treemap.BorderPalette).To(BeNil())
 }
 
 // Load tests
@@ -145,7 +143,7 @@ func TestLoad_JSONConfig_OverridesFill(t *testing.T) {
 	// Arrange
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.json")
-	content := `{"treemap":{"fill":"file-type","fillPalette":"categorization"}}`
+	content := `{"treemap":{"fill":"file-type,categorization"}}`
 	g.Expect(os.WriteFile(path, []byte(content), 0o600)).To(Succeed())
 
 	cfg := New()
@@ -156,9 +154,8 @@ func TestLoad_JSONConfig_OverridesFill(t *testing.T) {
 	// Assert
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(cfg.Treemap.Fill).NotTo(BeNil())
-	g.Expect(*cfg.Treemap.Fill).To(Equal("file-type"))
-	g.Expect(cfg.Treemap.FillPalette).NotTo(BeNil())
-	g.Expect(*cfg.Treemap.FillPalette).To(Equal("categorization"))
+	g.Expect(cfg.Treemap.Fill.Metric).To(Equal("file-type"))
+	g.Expect(cfg.Treemap.Fill.Palette).To(Equal("categorization"))
 }
 
 func TestLoad_InvalidYAML_ReturnsError(t *testing.T) {
@@ -260,9 +257,8 @@ func TestSave_ThenLoad_RoundTrips(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
 
-	fill := "file-type"
 	original := New()
-	original.Treemap.Fill = &fill
+	original.Treemap.Fill = &MetricSpec{Metric: "file-type"}
 
 	// Act: save then load into fresh config
 	g.Expect(original.Save(path)).To(Succeed())
@@ -274,7 +270,7 @@ func TestSave_ThenLoad_RoundTrips(t *testing.T) {
 	g.Expect(*loaded.Width).To(Equal(1920))
 	g.Expect(*loaded.Height).To(Equal(1080))
 	g.Expect(loaded.Treemap.Fill).NotTo(BeNil())
-	g.Expect(*loaded.Treemap.Fill).To(Equal("file-type"))
+	g.Expect(loaded.Treemap.Fill.Metric).To(Equal("file-type"))
 }
 
 func TestSave_OmitsNilFields(t *testing.T) {

--- a/internal/config/metric_spec.go
+++ b/internal/config/metric_spec.go
@@ -1,0 +1,101 @@
+package config
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/rotisserie/eris"
+	"go.yaml.in/yaml/v3"
+)
+
+// MetricSpec combines a metric name and an optional palette name into a single
+// value. It implements encoding.TextUnmarshaler so Kong can parse "metric,palette"
+// from the command line, and custom YAML/JSON marshaling for config files.
+//
+// Format: "metric" or "metric,palette".
+type MetricSpec struct { //nolint:recvcheck // marshal methods need value receivers, unmarshal need pointer
+	Metric  string
+	Palette string
+}
+
+// IsZero reports whether the MetricSpec is empty (no metric specified).
+func (m MetricSpec) IsZero() bool {
+	return m.Metric == ""
+}
+
+// String returns the canonical text form: "metric,palette" or just "metric".
+func (m MetricSpec) String() string {
+	if m.Palette != "" {
+		return m.Metric + "," + m.Palette
+	}
+
+	return m.Metric
+}
+
+// UnmarshalText parses "metric,palette" or "metric" from text.
+// Implements encoding.TextUnmarshaler for Kong CLI integration.
+func (m *MetricSpec) UnmarshalText(text []byte) error {
+	s := strings.TrimSpace(string(text))
+	if s == "" {
+		*m = MetricSpec{}
+
+		return nil
+	}
+
+	parts := strings.SplitN(s, ",", 2)
+	m.Metric = strings.TrimSpace(parts[0])
+
+	if m.Metric == "" {
+		return eris.New("metric name must not be empty in metric spec")
+	}
+
+	if len(parts) == 2 {
+		m.Palette = strings.TrimSpace(parts[1])
+
+		if m.Palette == "" {
+			return eris.Errorf("palette name must not be empty after comma in %q", s)
+		}
+	}
+
+	return nil
+}
+
+// MarshalText produces the canonical "metric,palette" or "metric" form.
+// Implements encoding.TextMarshaler.
+func (m MetricSpec) MarshalText() ([]byte, error) {
+	return []byte(m.String()), nil
+}
+
+// MarshalYAML produces a scalar string for YAML output.
+func (m MetricSpec) MarshalYAML() (any, error) {
+	return m.String(), nil
+}
+
+// UnmarshalYAML reads a MetricSpec from a YAML scalar string.
+func (m *MetricSpec) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.ScalarNode {
+		return eris.New("metric spec must be a string")
+	}
+
+	return m.UnmarshalText([]byte(value.Value))
+}
+
+// MarshalJSON produces a JSON string.
+func (m MetricSpec) MarshalJSON() ([]byte, error) {
+	data, err := json.Marshal(m.String())
+	if err != nil {
+		return nil, eris.Wrap(err, "failed to marshal metric spec to JSON")
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON reads a MetricSpec from a JSON string.
+func (m *MetricSpec) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return eris.Wrap(err, "metric spec must be a JSON string")
+	}
+
+	return m.UnmarshalText([]byte(s))
+}

--- a/internal/config/metric_spec.go
+++ b/internal/config/metric_spec.go
@@ -18,8 +18,8 @@ import (
 //
 // Format: "metric" or "metric,palette".
 type MetricSpec struct { //nolint:recvcheck // marshal methods need value receivers, unmarshal need pointer
-	Metric  metric.Name
-	Palette palette.PaletteName
+	Metric  metric.Name         `json:"metric" yaml:"metric"`
+	Palette palette.PaletteName `json:"palette,omitempty" yaml:"palette,omitempty"`
 }
 
 // IsZero reports whether the MetricSpec is empty (no metric specified).
@@ -106,23 +106,37 @@ func (m MetricSpec) MarshalText() ([]byte, error) {
 	return []byte(m.String()), nil
 }
 
-// MarshalYAML produces a scalar string for YAML output.
+// MarshalYAML produces a YAML mapping with metric and palette fields.
 func (m MetricSpec) MarshalYAML() (any, error) {
-	return m.String(), nil
+	type plain MetricSpec // strips methods to avoid recursion via TextMarshaler
+
+	return plain(m), nil
 }
 
-// UnmarshalYAML reads a MetricSpec from a YAML scalar string.
+// UnmarshalYAML reads a MetricSpec from a YAML mapping with metric and palette fields.
+// Also accepts a scalar string for backward compatibility (delegating to UnmarshalText).
 func (m *MetricSpec) UnmarshalYAML(value *yaml.Node) error {
-	if value.Kind != yaml.ScalarNode {
-		return eris.New("metric spec must be a string")
+	if value.Kind == yaml.ScalarNode {
+		return m.UnmarshalText([]byte(value.Value))
 	}
 
-	return m.UnmarshalText([]byte(value.Value))
+	type plain MetricSpec // strips methods to avoid recursion via TextUnmarshaler
+
+	var p plain
+	if err := value.Decode(&p); err != nil {
+		return eris.Wrap(err, "failed to decode metric spec from YAML")
+	}
+
+	*m = MetricSpec(p)
+
+	return nil
 }
 
-// MarshalJSON produces a JSON string.
+// MarshalJSON produces a JSON object with metric and palette fields.
 func (m MetricSpec) MarshalJSON() ([]byte, error) {
-	data, err := json.Marshal(m.String())
+	type plain MetricSpec // strips methods to avoid recursion via TextMarshaler
+
+	data, err := json.Marshal(plain(m))
 	if err != nil {
 		return nil, eris.Wrap(err, "failed to marshal metric spec to JSON")
 	}
@@ -130,12 +144,23 @@ func (m MetricSpec) MarshalJSON() ([]byte, error) {
 	return data, nil
 }
 
-// UnmarshalJSON reads a MetricSpec from a JSON string.
+// UnmarshalJSON reads a MetricSpec from a JSON object with metric and palette fields.
+// Also accepts a JSON string for backward compatibility (delegating to UnmarshalText).
 func (m *MetricSpec) UnmarshalJSON(data []byte) error {
+	// Try string first for backward compatibility.
 	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
-		return eris.Wrap(err, "metric spec must be a JSON string")
+	if json.Unmarshal(data, &s) == nil {
+		return m.UnmarshalText([]byte(s))
 	}
 
-	return m.UnmarshalText([]byte(s))
+	type plain MetricSpec // strips methods to avoid recursion via TextUnmarshaler
+
+	var p plain
+	if err := json.Unmarshal(data, &p); err != nil {
+		return eris.Wrap(err, "failed to decode metric spec from JSON")
+	}
+
+	*m = MetricSpec(p)
+
+	return nil
 }

--- a/internal/config/metric_spec.go
+++ b/internal/config/metric_spec.go
@@ -6,6 +6,10 @@ import (
 
 	"github.com/rotisserie/eris"
 	"go.yaml.in/yaml/v3"
+
+	"github.com/bevan/code-visualizer/internal/metric"
+	"github.com/bevan/code-visualizer/internal/palette"
+	"github.com/bevan/code-visualizer/internal/provider"
 )
 
 // MetricSpec combines a metric name and an optional palette name into a single
@@ -14,8 +18,8 @@ import (
 //
 // Format: "metric" or "metric,palette".
 type MetricSpec struct { //nolint:recvcheck // marshal methods need value receivers, unmarshal need pointer
-	Metric  string
-	Palette string
+	Metric  metric.Name
+	Palette palette.PaletteName
 }
 
 // IsZero reports whether the MetricSpec is empty (no metric specified).
@@ -26,10 +30,10 @@ func (m MetricSpec) IsZero() bool {
 // String returns the canonical text form: "metric,palette" or just "metric".
 func (m MetricSpec) String() string {
 	if m.Palette != "" {
-		return m.Metric + "," + m.Palette
+		return string(m.Metric) + "," + string(m.Palette)
 	}
 
-	return m.Metric
+	return string(m.Metric)
 }
 
 // UnmarshalText parses "metric,palette" or "metric" from text.
@@ -42,18 +46,54 @@ func (m *MetricSpec) UnmarshalText(text []byte) error {
 		return nil
 	}
 
-	parts := strings.SplitN(s, ",", 2)
-	m.Metric = strings.TrimSpace(parts[0])
+	metricPart, rest, hasSep := strings.Cut(s, ",")
+	m.Metric = metric.Name(strings.TrimSpace(metricPart))
 
 	if m.Metric == "" {
 		return eris.New("metric name must not be empty in metric spec")
 	}
 
-	if len(parts) == 2 {
-		m.Palette = strings.TrimSpace(parts[1])
+	if hasSep {
+		palettePart, extra, hasExtra := strings.Cut(rest, ",")
+		m.Palette = palette.PaletteName(strings.TrimSpace(palettePart))
 
 		if m.Palette == "" {
 			return eris.Errorf("palette name must not be empty after comma in %q", s)
+		}
+
+		if hasExtra {
+			return eris.Errorf("unexpected extra content %q after palette in %q", strings.TrimSpace(extra), s)
+		}
+	}
+
+	return nil
+}
+
+// Validate checks that the metric name (if set) is a known metric and that
+// the palette name (if set) is a valid palette. The label describes the field
+// being validated (e.g. "fill" or "border") for error messages.
+// A nil receiver is valid (no metric specified).
+func (m *MetricSpec) Validate(label string) error {
+	if m == nil {
+		return nil
+	}
+
+	if m.Metric != "" {
+		if _, ok := provider.Get(m.Metric); !ok {
+			names := provider.Names()
+			strs := make([]string, len(names))
+
+			for i, n := range names {
+				strs[i] = string(n)
+			}
+
+			return eris.Errorf("invalid %s metric %q; available metrics: %s", label, m.Metric, strings.Join(strs, ", "))
+		}
+	}
+
+	if m.Palette != "" {
+		if !m.Palette.IsValid() {
+			return eris.Errorf("invalid %s palette %q", label, m.Palette)
 		}
 	}
 

--- a/internal/config/metric_spec_test.go
+++ b/internal/config/metric_spec_test.go
@@ -1,0 +1,252 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// UnmarshalText tests
+
+func TestMetricSpec_UnmarshalText_MetricOnly(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	var ms MetricSpec
+
+	err := ms.UnmarshalText([]byte("file-size"))
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ms.Metric).To(Equal("file-size"))
+	g.Expect(ms.Palette).To(BeEmpty())
+}
+
+func TestMetricSpec_UnmarshalText_MetricAndPalette(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	var ms MetricSpec
+
+	err := ms.UnmarshalText([]byte("file-type,categorization"))
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ms.Metric).To(Equal("file-type"))
+	g.Expect(ms.Palette).To(Equal("categorization"))
+}
+
+func TestMetricSpec_UnmarshalText_EmptyString(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	var ms MetricSpec
+
+	err := ms.UnmarshalText([]byte(""))
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ms.IsZero()).To(BeTrue())
+}
+
+func TestMetricSpec_UnmarshalText_WhitespaceOnly(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	var ms MetricSpec
+
+	err := ms.UnmarshalText([]byte("  "))
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ms.IsZero()).To(BeTrue())
+}
+
+func TestMetricSpec_UnmarshalText_TrimsWhitespace(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	var ms MetricSpec
+
+	err := ms.UnmarshalText([]byte(" file-lines , foliage "))
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ms.Metric).To(Equal("file-lines"))
+	g.Expect(ms.Palette).To(Equal("foliage"))
+}
+
+func TestMetricSpec_UnmarshalText_EmptyMetric_ReturnsError(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	var ms MetricSpec
+
+	err := ms.UnmarshalText([]byte(",categorization"))
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(MatchError(ContainSubstring("metric name must not be empty")))
+}
+
+func TestMetricSpec_UnmarshalText_EmptyPalette_ReturnsError(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	var ms MetricSpec
+
+	err := ms.UnmarshalText([]byte("file-type,"))
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(MatchError(ContainSubstring("palette name must not be empty after comma")))
+}
+
+func TestMetricSpec_UnmarshalText_ExtraCommas_TreatedAsPartOfPalette(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	// SplitN(s, ",", 2) means only the first comma separates metric from palette.
+	// Extra commas remain part of the palette name (and will be caught by validation later).
+	var ms MetricSpec
+
+	err := ms.UnmarshalText([]byte("file-type,a,b"))
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ms.Metric).To(Equal("file-type"))
+	g.Expect(ms.Palette).To(Equal("a,b"))
+}
+
+// String tests
+
+func TestMetricSpec_String_MetricOnly(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	ms := MetricSpec{Metric: "file-size"}
+	g.Expect(ms.String()).To(Equal("file-size"))
+}
+
+func TestMetricSpec_String_MetricAndPalette(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	ms := MetricSpec{Metric: "file-type", Palette: "categorization"}
+	g.Expect(ms.String()).To(Equal("file-type,categorization"))
+}
+
+func TestMetricSpec_String_Zero(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	ms := MetricSpec{}
+	g.Expect(ms.String()).To(BeEmpty())
+}
+
+// IsZero tests
+
+func TestMetricSpec_IsZero_True(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+	g.Expect(MetricSpec{}.IsZero()).To(BeTrue())
+}
+
+func TestMetricSpec_IsZero_False(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+	g.Expect(MetricSpec{Metric: "file-size"}.IsZero()).To(BeFalse())
+}
+
+// YAML round-trip tests
+
+func TestMetricSpec_YAML_RoundTrip_MetricOnly(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	original := MetricSpec{Metric: "file-lines"}
+
+	data, err := yaml.Marshal(original)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(string(data)).To(ContainSubstring("file-lines"))
+
+	var loaded MetricSpec
+	g.Expect(yaml.Unmarshal(data, &loaded)).To(Succeed())
+	g.Expect(loaded).To(Equal(original))
+}
+
+func TestMetricSpec_YAML_RoundTrip_MetricAndPalette(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	original := MetricSpec{Metric: "file-type", Palette: "categorization"}
+
+	data, err := yaml.Marshal(original)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(string(data)).To(ContainSubstring("file-type,categorization"))
+
+	var loaded MetricSpec
+	g.Expect(yaml.Unmarshal(data, &loaded)).To(Succeed())
+	g.Expect(loaded).To(Equal(original))
+}
+
+// JSON round-trip tests
+
+func TestMetricSpec_JSON_RoundTrip_MetricOnly(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	original := MetricSpec{Metric: "file-lines"}
+
+	data, err := json.Marshal(original)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(string(data)).To(Equal(`"file-lines"`))
+
+	var loaded MetricSpec
+	g.Expect(json.Unmarshal(data, &loaded)).To(Succeed())
+	g.Expect(loaded).To(Equal(original))
+}
+
+func TestMetricSpec_JSON_RoundTrip_MetricAndPalette(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	original := MetricSpec{Metric: "file-type", Palette: "categorization"}
+
+	data, err := json.Marshal(original)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(string(data)).To(Equal(`"file-type,categorization"`))
+
+	var loaded MetricSpec
+	g.Expect(json.Unmarshal(data, &loaded)).To(Succeed())
+	g.Expect(loaded).To(Equal(original))
+}
+
+// Pointer YAML test (config files use *MetricSpec)
+
+func TestMetricSpec_YAML_Pointer_OmitsNil(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	type wrapper struct {
+		Fill *MetricSpec `yaml:"fill,omitempty"`
+	}
+
+	data, err := yaml.Marshal(wrapper{})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(string(data)).To(Equal("{}\n"))
+}
+
+func TestMetricSpec_YAML_Pointer_RoundTrips(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	type wrapper struct {
+		Fill *MetricSpec `yaml:"fill,omitempty"`
+	}
+
+	original := wrapper{Fill: &MetricSpec{Metric: "file-type", Palette: "categorization"}}
+
+	data, err := yaml.Marshal(original)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var loaded wrapper
+	g.Expect(yaml.Unmarshal(data, &loaded)).To(Succeed())
+	g.Expect(loaded.Fill).NotTo(BeNil())
+	g.Expect(*loaded.Fill).To(Equal(*original.Fill))
+}

--- a/internal/config/metric_spec_test.go
+++ b/internal/config/metric_spec_test.go
@@ -164,7 +164,8 @@ func TestMetricSpec_YAML_RoundTrip_MetricOnly(t *testing.T) {
 
 	data, err := yaml.Marshal(original)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(string(data)).To(ContainSubstring("file-lines"))
+	g.Expect(string(data)).To(ContainSubstring("metric: file-lines"))
+	g.Expect(string(data)).NotTo(ContainSubstring("palette"))
 
 	var loaded MetricSpec
 	g.Expect(yaml.Unmarshal(data, &loaded)).To(Succeed())
@@ -179,7 +180,8 @@ func TestMetricSpec_YAML_RoundTrip_MetricAndPalette(t *testing.T) {
 
 	data, err := yaml.Marshal(original)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(string(data)).To(ContainSubstring("file-type,categorization"))
+	g.Expect(string(data)).To(ContainSubstring("metric: file-type"))
+	g.Expect(string(data)).To(ContainSubstring("palette: categorization"))
 
 	var loaded MetricSpec
 	g.Expect(yaml.Unmarshal(data, &loaded)).To(Succeed())
@@ -196,7 +198,7 @@ func TestMetricSpec_JSON_RoundTrip_MetricOnly(t *testing.T) {
 
 	data, err := json.Marshal(original)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(string(data)).To(Equal(`"file-lines"`))
+	g.Expect(string(data)).To(Equal(`{"metric":"file-lines"}`))
 
 	var loaded MetricSpec
 	g.Expect(json.Unmarshal(data, &loaded)).To(Succeed())
@@ -211,7 +213,7 @@ func TestMetricSpec_JSON_RoundTrip_MetricAndPalette(t *testing.T) {
 
 	data, err := json.Marshal(original)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(string(data)).To(Equal(`"file-type,categorization"`))
+	g.Expect(string(data)).To(Equal(`{"metric":"file-type","palette":"categorization"}`))
 
 	var loaded MetricSpec
 	g.Expect(json.Unmarshal(data, &loaded)).To(Succeed())
@@ -250,9 +252,49 @@ func TestMetricSpec_YAML_Pointer_RoundTrips(t *testing.T) {
 
 	data, err := yaml.Marshal(original)
 	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(string(data)).To(ContainSubstring("metric: file-type"))
+	g.Expect(string(data)).To(ContainSubstring("palette: categorization"))
 
 	var loaded wrapper
 	g.Expect(yaml.Unmarshal(data, &loaded)).To(Succeed())
 	g.Expect(loaded.Fill).NotTo(BeNil())
 	g.Expect(*loaded.Fill).To(Equal(*original.Fill))
+}
+
+// Zero/omitempty tests
+
+func TestMetricSpec_YAML_OmitsEmptyPalette(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	ms := MetricSpec{Metric: metric.Name("file-size")}
+
+	data, err := yaml.Marshal(ms)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(string(data)).To(ContainSubstring("metric: file-size"))
+	g.Expect(string(data)).NotTo(ContainSubstring("palette"))
+}
+
+func TestMetricSpec_JSON_OmitsEmptyPalette(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	ms := MetricSpec{Metric: metric.Name("file-size")}
+
+	data, err := json.Marshal(ms)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(string(data)).To(Equal(`{"metric":"file-size"}`))
+	g.Expect(string(data)).NotTo(ContainSubstring("palette"))
+}
+
+// YAML scalar fallback test (backward compatibility)
+
+func TestMetricSpec_YAML_UnmarshalScalar_Fallback(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	var ms MetricSpec
+	g.Expect(yaml.Unmarshal([]byte(`"file-type,categorization"`), &ms)).To(Succeed())
+	g.Expect(ms.Metric).To(Equal(metric.Name("file-type")))
+	g.Expect(ms.Palette).To(Equal(palette.PaletteName("categorization")))
 }

--- a/internal/config/metric_spec_test.go
+++ b/internal/config/metric_spec_test.go
@@ -7,6 +7,9 @@ import (
 	. "github.com/onsi/gomega"
 
 	"go.yaml.in/yaml/v3"
+
+	"github.com/bevan/code-visualizer/internal/metric"
+	"github.com/bevan/code-visualizer/internal/palette"
 )
 
 // UnmarshalText tests
@@ -20,7 +23,7 @@ func TestMetricSpec_UnmarshalText_MetricOnly(t *testing.T) {
 	err := ms.UnmarshalText([]byte("file-size"))
 
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(ms.Metric).To(Equal("file-size"))
+	g.Expect(ms.Metric).To(Equal(metric.Name("file-size")))
 	g.Expect(ms.Palette).To(BeEmpty())
 }
 
@@ -33,8 +36,8 @@ func TestMetricSpec_UnmarshalText_MetricAndPalette(t *testing.T) {
 	err := ms.UnmarshalText([]byte("file-type,categorization"))
 
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(ms.Metric).To(Equal("file-type"))
-	g.Expect(ms.Palette).To(Equal("categorization"))
+	g.Expect(ms.Metric).To(Equal(metric.Name("file-type")))
+	g.Expect(ms.Palette).To(Equal(palette.PaletteName("categorization")))
 }
 
 func TestMetricSpec_UnmarshalText_EmptyString(t *testing.T) {
@@ -70,8 +73,8 @@ func TestMetricSpec_UnmarshalText_TrimsWhitespace(t *testing.T) {
 	err := ms.UnmarshalText([]byte(" file-lines , foliage "))
 
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(ms.Metric).To(Equal("file-lines"))
-	g.Expect(ms.Palette).To(Equal("foliage"))
+	g.Expect(ms.Metric).To(Equal(metric.Name("file-lines")))
+	g.Expect(ms.Palette).To(Equal(palette.PaletteName("foliage")))
 }
 
 func TestMetricSpec_UnmarshalText_EmptyMetric_ReturnsError(t *testing.T) {
@@ -98,19 +101,17 @@ func TestMetricSpec_UnmarshalText_EmptyPalette_ReturnsError(t *testing.T) {
 	g.Expect(err).To(MatchError(ContainSubstring("palette name must not be empty after comma")))
 }
 
-func TestMetricSpec_UnmarshalText_ExtraCommas_TreatedAsPartOfPalette(t *testing.T) {
+func TestMetricSpec_UnmarshalText_ExtraCommas_ReturnsError(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	// SplitN(s, ",", 2) means only the first comma separates metric from palette.
-	// Extra commas remain part of the palette name (and will be caught by validation later).
+	// strings.Cut twice means a third comma-delimited part is rejected.
 	var ms MetricSpec
 
 	err := ms.UnmarshalText([]byte("file-type,a,b"))
 
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(ms.Metric).To(Equal("file-type"))
-	g.Expect(ms.Palette).To(Equal("a,b"))
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(MatchError(ContainSubstring("unexpected extra content")))
 }
 
 // String tests
@@ -119,7 +120,7 @@ func TestMetricSpec_String_MetricOnly(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	ms := MetricSpec{Metric: "file-size"}
+	ms := MetricSpec{Metric: metric.Name("file-size")}
 	g.Expect(ms.String()).To(Equal("file-size"))
 }
 
@@ -127,7 +128,7 @@ func TestMetricSpec_String_MetricAndPalette(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	ms := MetricSpec{Metric: "file-type", Palette: "categorization"}
+	ms := MetricSpec{Metric: metric.Name("file-type"), Palette: palette.PaletteName("categorization")}
 	g.Expect(ms.String()).To(Equal("file-type,categorization"))
 }
 
@@ -150,7 +151,7 @@ func TestMetricSpec_IsZero_True(t *testing.T) {
 func TestMetricSpec_IsZero_False(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
-	g.Expect(MetricSpec{Metric: "file-size"}.IsZero()).To(BeFalse())
+	g.Expect(MetricSpec{Metric: metric.Name("file-size")}.IsZero()).To(BeFalse())
 }
 
 // YAML round-trip tests
@@ -159,7 +160,7 @@ func TestMetricSpec_YAML_RoundTrip_MetricOnly(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	original := MetricSpec{Metric: "file-lines"}
+	original := MetricSpec{Metric: metric.Name("file-lines")}
 
 	data, err := yaml.Marshal(original)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -174,7 +175,7 @@ func TestMetricSpec_YAML_RoundTrip_MetricAndPalette(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	original := MetricSpec{Metric: "file-type", Palette: "categorization"}
+	original := MetricSpec{Metric: metric.Name("file-type"), Palette: palette.PaletteName("categorization")}
 
 	data, err := yaml.Marshal(original)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -191,7 +192,7 @@ func TestMetricSpec_JSON_RoundTrip_MetricOnly(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	original := MetricSpec{Metric: "file-lines"}
+	original := MetricSpec{Metric: metric.Name("file-lines")}
 
 	data, err := json.Marshal(original)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -206,7 +207,7 @@ func TestMetricSpec_JSON_RoundTrip_MetricAndPalette(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	original := MetricSpec{Metric: "file-type", Palette: "categorization"}
+	original := MetricSpec{Metric: metric.Name("file-type"), Palette: palette.PaletteName("categorization")}
 
 	data, err := json.Marshal(original)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -240,7 +241,12 @@ func TestMetricSpec_YAML_Pointer_RoundTrips(t *testing.T) {
 		Fill *MetricSpec `yaml:"fill,omitempty"`
 	}
 
-	original := wrapper{Fill: &MetricSpec{Metric: "file-type", Palette: "categorization"}}
+	original := wrapper{
+		Fill: &MetricSpec{
+			Metric:  metric.Name("file-type"),
+			Palette: palette.PaletteName("categorization"),
+		},
+	}
 
 	data, err := yaml.Marshal(original)
 	g.Expect(err).NotTo(HaveOccurred())

--- a/internal/config/radialtree.go
+++ b/internal/config/radialtree.go
@@ -3,12 +3,10 @@ package config
 // Radial holds persistent configuration for radial tree visualizations.
 // All fields are pointers: nil means not configured, non-nil means explicitly set.
 type Radial struct {
-	DiscSize          *string `yaml:"discSize,omitempty"          json:"discSize,omitempty"`
-	Fill              *string `yaml:"fill,omitempty"              json:"fill,omitempty"`
-	FillPalette       *string `yaml:"fillPalette,omitempty"       json:"fillPalette,omitempty"`
-	Border            *string `yaml:"border,omitempty"            json:"border,omitempty"`
-	BorderPalette     *string `yaml:"borderPalette,omitempty"     json:"borderPalette,omitempty"`
-	Labels            *string `yaml:"labels,omitempty"            json:"labels,omitempty"`
-	Legend            *string `yaml:"legend,omitempty"            json:"legend,omitempty"`
-	LegendOrientation *string `yaml:"legendOrientation,omitempty" json:"legendOrientation,omitempty"`
+	DiscSize          *string     `yaml:"discSize,omitempty"          json:"discSize,omitempty"`
+	Fill              *MetricSpec `yaml:"fill,omitempty"              json:"fill,omitempty"`
+	Border            *MetricSpec `yaml:"border,omitempty"            json:"border,omitempty"`
+	Labels            *string     `yaml:"labels,omitempty"            json:"labels,omitempty"`
+	Legend            *string     `yaml:"legend,omitempty"            json:"legend,omitempty"`
+	LegendOrientation *string     `yaml:"legendOrientation,omitempty" json:"legendOrientation,omitempty"`
 }

--- a/internal/config/treemap.go
+++ b/internal/config/treemap.go
@@ -4,11 +4,9 @@ package config
 // All fields are pointers: nil means the field was not configured, non-nil
 // means it was explicitly set (by a config file or by a CLI flag override).
 type Treemap struct {
-	Size              *string `yaml:"size,omitempty"              json:"size,omitempty"`
-	Fill              *string `yaml:"fill,omitempty"              json:"fill,omitempty"`
-	FillPalette       *string `yaml:"fillPalette,omitempty"       json:"fillPalette,omitempty"`
-	Border            *string `yaml:"border,omitempty"            json:"border,omitempty"`
-	BorderPalette     *string `yaml:"borderPalette,omitempty"     json:"borderPalette,omitempty"`
-	Legend            *string `yaml:"legend,omitempty"            json:"legend,omitempty"`
-	LegendOrientation *string `yaml:"legendOrientation,omitempty" json:"legendOrientation,omitempty"`
+	Size              *string     `yaml:"size,omitempty"              json:"size,omitempty"`
+	Fill              *MetricSpec `yaml:"fill,omitempty"              json:"fill,omitempty"`
+	Border            *MetricSpec `yaml:"border,omitempty"            json:"border,omitempty"`
+	Legend            *string     `yaml:"legend,omitempty"            json:"legend,omitempty"`
+	LegendOrientation *string     `yaml:"legendOrientation,omitempty" json:"legendOrientation,omitempty"`
 }

--- a/internal/provider/git/metrics_test.go
+++ b/internal/provider/git/metrics_test.go
@@ -145,10 +145,18 @@ func TestFileFreshnessProvider(t *testing.T) {
 	err := p.Load(root)
 	g.Expect(err).NotTo(HaveOccurred())
 
+	// old.go was committed at 2024-01-01 and never modified — should have freshness > 0
+	freshOld, ok := root.Files[0].Quantity(FileFreshness)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(freshOld).To(BeNumerically(">", 0), "old.go last modified 2024-01-01 should have freshness > 0")
+
 	// new.go was just committed — should be very fresh (small number)
 	freshNew, ok := root.Files[1].Quantity(FileFreshness)
 	g.Expect(ok).To(BeTrue())
 	g.Expect(freshNew).To(BeNumerically(">=", 0))
+
+	// old.go should be staler than new.go (higher freshness = more days since last change)
+	g.Expect(freshOld).To(BeNumerically(">", freshNew))
 }
 
 func TestAuthorCountProvider(t *testing.T) {
@@ -357,4 +365,142 @@ func TestAuthorCountProvider_SubdirectoryScanning(t *testing.T) {
 	count, ok := root.Files[0].Quantity(AuthorCount)
 	g.Expect(ok).To(BeTrue(), "author-count metric should be set for file in subdirectory")
 	g.Expect(count).To(Equal(int64(1)), "code.go should have 1 author (Alice)")
+}
+
+// setupMergeRepo creates a git repo where a merge commit touches both files
+// in the tree but only actually modifies one of them. This reproduces the
+// bug where go-git's FileName log filter includes merge commits that didn't
+// change the file, polluting the "newest" timestamp.
+func setupMergeRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+
+		cmd := exec.Command(args[0], args[1:]...) //nolint:gosec // test helper
+		cmd.Dir = dir
+
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=Alice",
+			"GIT_AUTHOR_EMAIL=alice@example.com",
+			"GIT_COMMITTER_NAME=Alice",
+			"GIT_COMMITTER_EMAIL=alice@example.com",
+		)
+
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("command %v failed: %s\n%s", args, err, out)
+		}
+	}
+
+	// Create initial commit with two files, backdated.
+	run("git", "init")
+	run("git", "config", "user.name", "Alice")
+	run("git", "config", "user.email", "alice@example.com")
+
+	_ = os.WriteFile(filepath.Join(dir, "stable.go"), []byte("package stable\n"), 0o600)
+	_ = os.WriteFile(filepath.Join(dir, "active.go"), []byte("package active\n"), 0o600)
+
+	run("git", "add", ".")
+	run("git", "commit", "-m", "initial commit", "--date=2024-01-01T00:00:00+00:00")
+
+	// Create a feature branch that modifies only active.go.
+	run("git", "checkout", "-b", "feature")
+	_ = os.WriteFile(filepath.Join(dir, "active.go"), []byte("package active\n// feature\n"), 0o600)
+	run("git", "add", "active.go")
+	run("git", "commit", "-m", "feature change", "--date=2025-12-01T00:00:00+00:00")
+
+	// Merge back to main — creates a merge commit that includes stable.go
+	// in its tree but doesn't modify it.
+	run("git", "checkout", "master")
+	run("git", "merge", "feature", "--no-ff", "-m", "merge feature")
+
+	return dir
+}
+
+// TestFileFreshness_MergeCommitDoesNotPollute verifies that a merge commit
+// touching stable.go's tree entry (but not its content) doesn't update the
+// freshness timestamp for stable.go. This was the root cause of #114.
+func TestFileFreshness_MergeCommitDoesNotPollute(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir := setupMergeRepo(t)
+	root := buildTree(dir, "stable.go", "active.go")
+
+	resetService()
+
+	p := &FileFreshnessProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// stable.go was only committed at 2024-01-01 and never actually modified
+	// after that. Its freshness (days since last real change) should be > 300.
+	freshStable, ok := root.Files[0].Quantity(FileFreshness)
+	g.Expect(ok).To(BeTrue(), "file-freshness should be set for stable.go")
+	g.Expect(freshStable).To(BeNumerically(">", 300),
+		"stable.go last modified 2024-01-01 should have high freshness (days since change)")
+
+	// active.go was modified at 2025-12-01 — should have a moderate freshness.
+	freshActive, ok := root.Files[1].Quantity(FileFreshness)
+	g.Expect(ok).To(BeTrue(), "file-freshness should be set for active.go")
+	g.Expect(freshActive).To(BeNumerically(">", 0),
+		"active.go last modified 2025-12-01 should have freshness > 0")
+
+	// stable.go must be staler than active.go.
+	g.Expect(freshStable).To(BeNumerically(">", freshActive),
+		"stable.go should be staler than active.go")
+}
+
+// TestFileAge_MergeCommitDoesNotPollute verifies that a merge commit doesn't
+// shift the oldest timestamp for files it didn't modify.
+func TestFileAge_MergeCommitDoesNotPollute(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir := setupMergeRepo(t)
+	root := buildTree(dir, "stable.go", "active.go")
+
+	resetService()
+
+	p := &FileAgeProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Both files were created at 2024-01-01 — same age.
+	ageStable, ok := root.Files[0].Quantity(FileAge)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(ageStable).To(BeNumerically(">", 300))
+
+	ageActive, ok := root.Files[1].Quantity(FileAge)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(ageActive).To(BeNumerically(">", 300))
+}
+
+// TestAuthorCount_MergeCommitDoesNotPollute verifies that the merge commit
+// author is not counted for files the merge didn't actually modify.
+func TestAuthorCount_MergeCommitDoesNotPollute(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir := setupMergeRepo(t)
+	root := buildTree(dir, "stable.go", "active.go")
+
+	resetService()
+
+	p := &AuthorCountProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// stable.go was only committed by Alice — the merge didn't change it.
+	count, ok := root.Files[0].Quantity(AuthorCount)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(count).To(Equal(int64(1)), "stable.go should have 1 author")
+
+	// active.go was committed by Alice initially — the feature branch commit
+	// was also by Alice (our test setup uses Alice for all commits).
+	countActive, ok := root.Files[1].Quantity(AuthorCount)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(countActive).To(Equal(int64(1)), "active.go should have 1 author (all commits by Alice)")
 }

--- a/internal/provider/git/metrics_test.go
+++ b/internal/provider/git/metrics_test.go
@@ -367,10 +367,11 @@ func TestAuthorCountProvider_SubdirectoryScanning(t *testing.T) {
 	g.Expect(count).To(Equal(int64(1)), "code.go should have 1 author (Alice)")
 }
 
-// setupMergeRepo creates a git repo where a merge commit touches both files
-// in the tree but only actually modifies one of them. This reproduces the
-// bug where go-git's FileName log filter includes merge commits that didn't
-// change the file, polluting the "newest" timestamp.
+// setupMergeRepo creates a git repo where main has two files, stable.go
+// is modified once on main, and a feature branch modifies only active.go
+// before being merged back. The modification of stable.go on main gives
+// go-git a clear commit that's NOT TREESAME for stable.go, ensuring the
+// commit is returned even with history simplification.
 func setupMergeRepo(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -394,8 +395,8 @@ func setupMergeRepo(t *testing.T) string {
 		}
 	}
 
-	// Create initial commit with two files, backdated.
-	run("git", "init")
+	// Commit 1: create both files (backdated).
+	run("git", "init", "-b", "main")
 	run("git", "config", "user.name", "Alice")
 	run("git", "config", "user.email", "alice@example.com")
 
@@ -405,15 +406,23 @@ func setupMergeRepo(t *testing.T) string {
 	run("git", "add", ".")
 	run("git", "commit", "-m", "initial commit", "--date=2024-01-01T00:00:00+00:00")
 
+	// Commit 2 (on main): modify stable.go at a known date.
+	_ = os.WriteFile(filepath.Join(dir, "stable.go"), []byte("package stable\n// updated\n"), 0o600)
+
+	run("git", "add", "stable.go")
+	run("git", "commit", "-m", "update stable", "--date=2024-06-01T00:00:00+00:00")
+
 	// Create a feature branch that modifies only active.go.
 	run("git", "checkout", "-b", "feature")
+
 	_ = os.WriteFile(filepath.Join(dir, "active.go"), []byte("package active\n// feature\n"), 0o600)
+
 	run("git", "add", "active.go")
 	run("git", "commit", "-m", "feature change", "--date=2025-12-01T00:00:00+00:00")
 
 	// Merge back to main — creates a merge commit that includes stable.go
 	// in its tree but doesn't modify it.
-	run("git", "checkout", "master")
+	run("git", "checkout", "main")
 	run("git", "merge", "feature", "--no-ff", "-m", "merge feature")
 
 	return dir
@@ -435,12 +444,13 @@ func TestFileFreshness_MergeCommitDoesNotPollute(t *testing.T) {
 	err := p.Load(root)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	// stable.go was only committed at 2024-01-01 and never actually modified
-	// after that. Its freshness (days since last real change) should be > 300.
+	// stable.go was last truly modified at 2024-06-01. Its freshness (days
+	// since last real change) should be > 300. Without the fix, the merge
+	// commit's timestamp (today) would pollute this to ~0.
 	freshStable, ok := root.Files[0].Quantity(FileFreshness)
 	g.Expect(ok).To(BeTrue(), "file-freshness should be set for stable.go")
 	g.Expect(freshStable).To(BeNumerically(">", 300),
-		"stable.go last modified 2024-01-01 should have high freshness (days since change)")
+		"stable.go last modified 2024-06-01 should have high freshness (days since change)")
 
 	// active.go was modified at 2025-12-01 — should have a moderate freshness.
 	freshActive, ok := root.Files[1].Quantity(FileFreshness)
@@ -503,4 +513,31 @@ func TestAuthorCount_MergeCommitDoesNotPollute(t *testing.T) {
 	countActive, ok := root.Files[1].Quantity(AuthorCount)
 	g.Expect(ok).To(BeTrue())
 	g.Expect(countActive).To(Equal(int64(1)), "active.go should have 1 author (all commits by Alice)")
+}
+
+// TestFileFreshnessEqualsAgeForSingleCommit verifies that for a file with
+// exactly one commit, file-freshness equals file-age (both measure days since
+// the same single commit).
+func TestFileFreshnessEqualsAgeForSingleCommit(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir := setupSubdirRepo(t) // code.go committed once at 2024-01-01
+	root := buildTree(dir, "code.go")
+
+	resetService()
+
+	ageP := &FileAgeProvider{}
+	g.Expect(ageP.Load(root)).To(Succeed())
+
+	freshP := &FileFreshnessProvider{}
+	g.Expect(freshP.Load(root)).To(Succeed())
+
+	age, ageOk := root.Files[0].Quantity(FileAge)
+	freshness, freshOk := root.Files[0].Quantity(FileFreshness)
+
+	g.Expect(ageOk).To(BeTrue())
+	g.Expect(freshOk).To(BeTrue())
+	g.Expect(age).To(Equal(freshness),
+		"single-commit file should have identical age and freshness")
 }

--- a/internal/provider/git/service.go
+++ b/internal/provider/git/service.go
@@ -214,9 +214,11 @@ func (s *repoService) fetchCommitData(relPath string) (*commitData, error) {
 
 // commitModifiedFile returns true if the commit actually changed the file at
 // relPath, as opposed to merely having it in the tree (which happens with merge
-// commits). A commit modified the file if:
-//   - it is a root commit (no parents), or
-//   - the file's blob hash differs from at least one parent.
+// commits). A commit modified the file only if it is NOT TREESAME to any parent,
+// matching git's history simplification semantics. Specifically:
+//   - root commits (no parents) are always considered as modifying the file,
+//   - a commit is TREESAME to a parent when the file's blob hash is identical,
+//   - a commit is "modified" only when it differs from ALL parents.
 func commitModifiedFile(c *object.Commit, relPath string) bool {
 	fileHash, err := blobHash(c, relPath)
 	if err != nil {
@@ -227,18 +229,14 @@ func commitModifiedFile(c *object.Commit, relPath string) bool {
 	defer parents.Close()
 
 	hasParent := false
+	treesameToAny := false
 
-	err = parents.ForEach(func(parent *object.Commit) error {
+	_ = parents.ForEach(func(parent *object.Commit) error {
 		hasParent = true
 
 		parentHash, hashErr := blobHash(parent, relPath)
-		if hashErr != nil {
-			// File missing in parent → commit added it.
-			return errFileModified
-		}
-
-		if parentHash != fileHash {
-			return errFileModified
+		if hashErr == nil && parentHash == fileHash {
+			treesameToAny = true
 		}
 
 		return nil
@@ -248,10 +246,8 @@ func commitModifiedFile(c *object.Commit, relPath string) bool {
 		return true // root commit — file was introduced
 	}
 
-	return errors.Is(err, errFileModified)
+	return !treesameToAny
 }
-
-var errFileModified = errors.New("file modified")
 
 // blobHash returns the blob hash of the file at relPath within the commit's tree.
 func blobHash(c *object.Commit, relPath string) (plumbing.Hash, error) {

--- a/internal/provider/git/service.go
+++ b/internal/provider/git/service.go
@@ -8,6 +8,7 @@ import (
 
 	gogit "github.com/go-git/go-git/v5"
 
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/rotisserie/eris"
 	"golang.org/x/sync/singleflight"
@@ -184,6 +185,13 @@ func (s *repoService) fetchCommitData(relPath string) (*commitData, error) {
 	}
 
 	err = log.ForEach(func(c *object.Commit) error {
+		// go-git's FileName filter includes merge commits that didn't
+		// actually modify the file. Skip those to avoid polluting
+		// the newest timestamp with unrelated commit dates.
+		if !commitModifiedFile(c, relPath) {
+			return nil
+		}
+
 		when := c.Author.When
 		if data.oldest.IsZero() || when.Before(data.oldest) {
 			data.oldest = when
@@ -202,4 +210,60 @@ func (s *repoService) fetchCommitData(relPath string) (*commitData, error) {
 	}
 
 	return data, nil
+}
+
+// commitModifiedFile returns true if the commit actually changed the file at
+// relPath, as opposed to merely having it in the tree (which happens with merge
+// commits). A commit modified the file if:
+//   - it is a root commit (no parents), or
+//   - the file's blob hash differs from at least one parent.
+func commitModifiedFile(c *object.Commit, relPath string) bool {
+	fileHash, err := blobHash(c, relPath)
+	if err != nil {
+		return true // conservative: include on error
+	}
+
+	parents := c.Parents()
+	defer parents.Close()
+
+	hasParent := false
+
+	err = parents.ForEach(func(parent *object.Commit) error {
+		hasParent = true
+
+		parentHash, hashErr := blobHash(parent, relPath)
+		if hashErr != nil {
+			// File missing in parent → commit added it.
+			return errFileModified
+		}
+
+		if parentHash != fileHash {
+			return errFileModified
+		}
+
+		return nil
+	})
+
+	if !hasParent {
+		return true // root commit — file was introduced
+	}
+
+	return errors.Is(err, errFileModified)
+}
+
+var errFileModified = errors.New("file modified")
+
+// blobHash returns the blob hash of the file at relPath within the commit's tree.
+func blobHash(c *object.Commit, relPath string) (plumbing.Hash, error) {
+	tree, err := c.Tree()
+	if err != nil {
+		return plumbing.ZeroHash, err //nolint:wrapcheck // internal helper
+	}
+
+	entry, err := tree.File(relPath)
+	if err != nil {
+		return plumbing.ZeroHash, err //nolint:wrapcheck // internal helper
+	}
+
+	return entry.Hash, nil
 }


### PR DESCRIPTION
Fixes #118

## Summary

Introduces `config.MetricSpec` type that bundles a metric name and palette name into a single CLI parameter. This simplifies the command line:

**Before:**
```
--fill file-type --fill-palette categorization --border file-lines --border-palette foliage
```

**After:**
```
--fill file-type,categorization --border file-lines,foliage
```

## Changes

- **New `MetricSpec` type** (`internal/config/metric_spec.go`): Captures both metric and palette. Implements `encoding.TextUnmarshaler` for Kong CLI parsing, plus YAML/JSON marshal/unmarshal for config files.
- **Updated CLI structs**: `TreemapCmd`, `RadialCmd`, `BubbletreeCmd` now use `MetricSpec` for `--fill` and `--border` flags instead of separate metric + palette parameters.
- **Updated config structs**: `Treemap`, `Radial`, `Bubbletree` use `*MetricSpec` for Fill and Border, replacing separate `Fill`/`FillPalette`/`Border`/`BorderPalette` pointer strings.
- **Removed flags**: `--fill-palette` and `--border-palette` are no longer separate flags.

## Config file format change

Config files now use the combined format:
```yaml
treemap:
  fill: file-type,categorization
  border: file-lines,foliage
```

Metric-only (no explicit palette) still works — the provider default palette is used:
```yaml
treemap:
  fill: file-type
```

## Breaking changes

- `--fill-palette` and `--border-palette` CLI flags removed (use `--fill metric,palette` instead).
- Config file fields `fillPalette` and `borderPalette` removed (combine into `fill` and `border` values).
- The `--border-palette requires --border` validation is no longer needed (palette is always bundled with its metric).

## Tests

22 new tests for MetricSpec (parsing, round-trips, edge cases, YAML/JSON). All existing tests updated and passing.