### PR TITLE
Improve file filtering

### DIFF
--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -29,7 +29,7 @@ type Rule struct {
 // Default (no match) is include.
 func IsIncluded(relativePath string, rules []Rule) bool {
 	for _, r := range rules {
-		matched, err := doublestar.Match(r.Pattern, relativePath)
+		matched, err := matchPattern(r.Pattern, relativePath)
 		if err != nil {
 			// Invalid pattern → skip this rule
 			continue
@@ -41,6 +41,24 @@ func IsIncluded(relativePath string, rules []Rule) bool {
 	}
 
 	return true
+}
+
+func matchPattern(pattern, relativePath string) (bool, error) {
+	matched, err := doublestar.Match(pattern, relativePath)
+	if err != nil {
+		return false, err
+	}
+
+	if matched {
+		return matched, nil
+	}
+
+	if strings.HasPrefix(pattern, "/") || strings.HasPrefix(pattern, "**/") {
+		return false, nil
+	}
+
+	// For unanchored patterns, also match at any depth (gitignore-like behavior).
+	return doublestar.Match("**/"+pattern, relativePath)
 }
 
 // MarshalText implements encoding.TextMarshaler.

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -46,7 +46,7 @@ func IsIncluded(relativePath string, rules []Rule) bool {
 func matchPattern(pattern, relativePath string) (bool, error) {
 	matched, err := doublestar.Match(pattern, relativePath)
 	if err != nil {
-		return false, eris.Wrapf(err, "Failed to match pattern %q against path %q", pattern, relativePath)
+		return false, eris.Wrap(err, "Failed to match pattern")
 	}
 
 	if matched {
@@ -60,7 +60,7 @@ func matchPattern(pattern, relativePath string) (bool, error) {
 	// For unanchored patterns, also match at any depth (gitignore-like behavior).
 	matched, err = doublestar.Match("**/"+pattern, relativePath)
 	if err != nil {
-		return false, eris.Wrapf(err, "Failed to match pattern %q against path %q", pattern, relativePath)
+		return false, eris.Wrap(err, "failed to match pattern")
 	}
 
 	return matched, nil

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -46,7 +46,7 @@ func IsIncluded(relativePath string, rules []Rule) bool {
 func matchPattern(pattern, relativePath string) (bool, error) {
 	matched, err := doublestar.Match(pattern, relativePath)
 	if err != nil {
-		return false, err
+		return false, eris.Wrapf(err, "Failed to match pattern %q against path %q", pattern, relativePath)
 	}
 
 	if matched {
@@ -58,7 +58,12 @@ func matchPattern(pattern, relativePath string) (bool, error) {
 	}
 
 	// For unanchored patterns, also match at any depth (gitignore-like behavior).
-	return doublestar.Match("**/"+pattern, relativePath)
+	matched, err = doublestar.Match("**/"+pattern, relativePath)
+	if err != nil {
+		return false, eris.Wrapf(err, "Failed to match pattern %q against path %q", pattern, relativePath)
+	}
+
+	return matched, nil
 }
 
 // MarshalText implements encoding.TextMarshaler.

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -81,6 +81,27 @@ func TestIsIncluded_DoublestarPattern(t *testing.T) {
 	g.Expect(IsIncluded("debug.log", rules)).To(BeFalse())
 }
 
+func TestIsIncluded_SlashlessPatternMatchesNestedPath(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	rules := []Rule{{Pattern: ".*", Mode: Exclude}}
+
+	g.Expect(IsIncluded("docs/.cache", rules)).To(BeFalse())
+	g.Expect(IsIncluded("docs/notes.md", rules)).To(BeTrue())
+}
+
+func TestIsIncluded_SuperpowersPatternMatchesNestedDirectory(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	rules := []Rule{{Pattern: "superpowers/**", Mode: Exclude}}
+
+	g.Expect(IsIncluded("docs/superpowers", rules)).To(BeFalse())
+	g.Expect(IsIncluded("docs/superpowers/specs/design.md", rules)).To(BeFalse())
+	g.Expect(IsIncluded("docs/specs/design.md", rules)).To(BeTrue())
+}
+
 func TestIsIncluded_InvalidPattern_TreatedAsNoMatch(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)


### PR DESCRIPTION
This pull request enhances the pattern matching logic in the `internal/filter` package to better mimic gitignore-style behavior and adds new tests to ensure correct handling of patterns, especially for nested paths and directories.