### PR TITLE
[Repo Assist] fix(filesystem): correctly count lines in UTF-16 encoded text files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/image v0.39.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/text v0.36.0
 )
 
 require (
@@ -39,6 +40,5 @@ require (
 	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
-	golang.org/x/text v0.36.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/internal/provider/filesystem/metrics.go
+++ b/internal/provider/filesystem/metrics.go
@@ -9,6 +9,8 @@ import (
 	"log/slog"
 	"os"
 
+	"golang.org/x/text/encoding/unicode"
+
 	"github.com/rotisserie/eris"
 
 	"github.com/bevan/code-visualizer/internal/metric"
@@ -91,6 +93,15 @@ var errBinaryFile = errors.New("file appears to be binary")
 // detect binary content. This matches the heuristic used by Git.
 const binaryProbeSize = 8000
 
+// utf16Encoding indicates the UTF-16 byte-order of a file, if any.
+type utf16Encoding int
+
+const (
+	notUTF16 utf16Encoding = iota
+	utf16LE
+	utf16BE
+)
+
 func countLines(path string) (int64, error) {
 	file, err := os.Open(path)
 	if err != nil {
@@ -98,13 +109,21 @@ func countLines(path string) (int64, error) {
 	}
 	defer file.Close()
 
-	if isBinary, err := probeBinary(file); err != nil {
+	isBinary, enc, err := probeBinary(file)
+	if err != nil {
 		return 0, err
 	} else if isBinary {
 		return 0, errBinaryFile
 	}
 
-	scanner := bufio.NewScanner(file)
+	var r io.Reader = file
+	if enc != notUTF16 {
+		// Wrap in UTF-16 decoder so that newlines are decoded correctly.
+		// UseBOM reads the BOM to determine endianness, overriding the default.
+		r = unicode.UTF16(unicode.LittleEndian, unicode.UseBOM).NewDecoder().Reader(file)
+	}
+
+	scanner := bufio.NewScanner(r)
 
 	var count int64
 	for scanner.Scan() {
@@ -123,51 +142,58 @@ func countLines(path string) (int64, error) {
 }
 
 // probeBinary reads the first binaryProbeSize bytes of f and reports whether
-// the content looks like a binary file. It uses a null-byte heuristic (same
-// approach as Git) but skips the check for files that start with a UTF-16 BOM,
-// since UTF-16 text legitimately contains null bytes.
+// the content looks like a binary file, and the UTF-16 encoding if any.
+// It uses a null-byte heuristic (same approach as Git) but skips the check
+// for files that start with a UTF-16 BOM, since UTF-16 text legitimately
+// contains null bytes.
 //
 // On return the file is seeked back to the start, ready for line counting.
-func probeBinary(f *os.File) (bool, error) {
+func probeBinary(f *os.File) (isBinary bool, enc utf16Encoding, err error) {
 	header := make([]byte, binaryProbeSize)
 
-	n, err := f.Read(header)
-	if err != nil && !errors.Is(err, io.EOF) {
-		return false, eris.Wrap(err, "reading file header for binary probe")
+	n, readErr := f.Read(header)
+	if readErr != nil && !errors.Is(readErr, io.EOF) {
+		return false, notUTF16, eris.Wrap(readErr, "reading file header for binary probe")
 	}
 
-	if _, err := f.Seek(0, io.SeekStart); err != nil {
-		return false, eris.Wrap(err, "seeking back to start after binary probe")
+	if _, seekErr := f.Seek(0, io.SeekStart); seekErr != nil {
+		return false, notUTF16, eris.Wrap(seekErr, "seeking back to start after binary probe")
 	}
 
 	if n == 0 {
-		return false, nil
+		return false, notUTF16, nil
 	}
 
 	buf := header[:n]
 
-	if hasUTF16BOM(buf) {
-		return false, nil
+	enc = detectUTF16Encoding(buf)
+	if enc != notUTF16 {
+		return false, enc, nil
 	}
 
-	return bytes.IndexByte(buf, 0) >= 0, nil
+	return bytes.IndexByte(buf, 0) >= 0, notUTF16, nil
 }
 
-// hasUTF16BOM reports whether buf starts with a UTF-16 byte-order mark.
-func hasUTF16BOM(buf []byte) bool {
+// detectUTF16Encoding reports the UTF-16 byte-order of buf based on its BOM,
+// or notUTF16 if no UTF-16 BOM is detected.
+func detectUTF16Encoding(buf []byte) utf16Encoding {
 	if len(buf) < 2 {
-		return false
+		return notUTF16
 	}
 
 	// UTF-16 LE: FF FE (but not FF FE 00 00, which is UTF-32 LE)
 	if buf[0] == 0xFF && buf[1] == 0xFE {
 		if len(buf) >= 4 && buf[2] == 0x00 && buf[3] == 0x00 {
-			return false // UTF-32 LE — not text we can handle
+			return notUTF16 // UTF-32 LE — not text we can handle
 		}
 
-		return true
+		return utf16LE
 	}
 
 	// UTF-16 BE: FE FF
-	return buf[0] == 0xFE && buf[1] == 0xFF
+	if buf[0] == 0xFE && buf[1] == 0xFF {
+		return utf16BE
+	}
+
+	return notUTF16
 }

--- a/internal/provider/filesystem/metrics.go
+++ b/internal/provider/filesystem/metrics.go
@@ -9,9 +9,8 @@ import (
 	"log/slog"
 	"os"
 
-	"golang.org/x/text/encoding/unicode"
-
 	"github.com/rotisserie/eris"
+	"golang.org/x/text/encoding/unicode"
 
 	"github.com/bevan/code-visualizer/internal/metric"
 	"github.com/bevan/code-visualizer/internal/model"

--- a/internal/provider/filesystem/metrics_test.go
+++ b/internal/provider/filesystem/metrics_test.go
@@ -150,54 +150,45 @@ func TestFileLinesProviderDetectsBinaryByNullByte(t *testing.T) {
 	g.Expect(f.IsBinary).To(BeTrue())
 }
 
-func TestFileLinesProviderCountsUTF16LELines(t *testing.T) {
+func TestFileLinesProviderCountsUTF16Lines(t *testing.T) {
 	t.Parallel()
-	g := NewGomegaWithT(t)
 
-	dir := t.TempDir()
+	tests := []struct {
+		name    string
+		content []byte
+	}{
+		{
+			name:    "little-endian",
+			content: []byte{0xFF, 0xFE, 0x61, 0x00, 0x0A, 0x00, 0x62, 0x00, 0x0A, 0x00},
+		},
+		{
+			name:    "big-endian",
+			content: []byte{0xFE, 0xFF, 0x00, 0x61, 0x00, 0x0A, 0x00, 0x62, 0x00, 0x0A},
+		},
+	}
 
-	// UTF-16 LE BOM (FF FE) followed by "a\nb\n" encoded in UTF-16 LE:
-	// 'a'=61 00, '\n'=0A 00, 'b'=62 00, '\n'=0A 00  →  2 lines
-	content := []byte{0xFF, 0xFE, 0x61, 0x00, 0x0A, 0x00, 0x62, 0x00, 0x0A, 0x00}
-	_ = os.WriteFile(filepath.Join(dir, "code.cs"), content, 0o600)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
 
-	f := &model.File{Path: filepath.Join(dir, "code.cs"), Name: "code.cs"}
-	root := &model.Directory{Path: dir, Name: "root", Files: []*model.File{f}}
+			dir := t.TempDir()
+			_ = os.WriteFile(filepath.Join(dir, "code.cs"), tt.content, 0o600)
 
-	p := FileLinesProvider{}
-	err := p.Load(root)
-	g.Expect(err).NotTo(HaveOccurred())
+			f := &model.File{Path: filepath.Join(dir, "code.cs"), Name: "code.cs"}
+			root := &model.Directory{Path: dir, Name: "root", Files: []*model.File{f}}
 
-	g.Expect(f.IsBinary).To(BeFalse())
+			p := FileLinesProvider{}
+			err := p.Load(root)
+			g.Expect(err).NotTo(HaveOccurred())
 
-	v, ok := f.Quantity(FileLines)
-	g.Expect(ok).To(BeTrue())
-	g.Expect(v).To(Equal(int64(2)))
-}
+			g.Expect(f.IsBinary).To(BeFalse())
 
-func TestFileLinesProviderCountsUTF16BELines(t *testing.T) {
-	t.Parallel()
-	g := NewGomegaWithT(t)
-
-	dir := t.TempDir()
-
-	// UTF-16 BE BOM (FE FF) followed by "a\nb\n" encoded in UTF-16 BE:
-	// 'a'=00 61, '\n'=00 0A, 'b'=00 62, '\n'=00 0A  →  2 lines
-	content := []byte{0xFE, 0xFF, 0x00, 0x61, 0x00, 0x0A, 0x00, 0x62, 0x00, 0x0A}
-	_ = os.WriteFile(filepath.Join(dir, "code.cs"), content, 0o600)
-
-	f := &model.File{Path: filepath.Join(dir, "code.cs"), Name: "code.cs"}
-	root := &model.Directory{Path: dir, Name: "root", Files: []*model.File{f}}
-
-	p := FileLinesProvider{}
-	err := p.Load(root)
-	g.Expect(err).NotTo(HaveOccurred())
-
-	g.Expect(f.IsBinary).To(BeFalse())
-
-	v, ok := f.Quantity(FileLines)
-	g.Expect(ok).To(BeTrue())
-	g.Expect(v).To(Equal(int64(2)))
+			v, ok := f.Quantity(FileLines)
+			g.Expect(ok).To(BeTrue())
+			g.Expect(v).To(Equal(int64(2)))
+		})
+	}
 }
 
 func TestFileLinesProviderHandlesEmptyFile(t *testing.T) {

--- a/internal/provider/filesystem/metrics_test.go
+++ b/internal/provider/filesystem/metrics_test.go
@@ -150,13 +150,14 @@ func TestFileLinesProviderDetectsBinaryByNullByte(t *testing.T) {
 	g.Expect(f.IsBinary).To(BeTrue())
 }
 
-func TestFileLinesProviderAllowsUTF16LEWithBOM(t *testing.T) {
+func TestFileLinesProviderCountsUTF16LELines(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
 	dir := t.TempDir()
 
-	// UTF-16 LE BOM (FF FE) followed by ASCII 'a' in UTF-16 LE (61 00) + newline (0A 00)
+	// UTF-16 LE BOM (FF FE) followed by "a\nb\n" encoded in UTF-16 LE:
+	// 'a'=61 00, '\n'=0A 00, 'b'=62 00, '\n'=0A 00  →  2 lines
 	content := []byte{0xFF, 0xFE, 0x61, 0x00, 0x0A, 0x00, 0x62, 0x00, 0x0A, 0x00}
 	_ = os.WriteFile(filepath.Join(dir, "code.cs"), content, 0o600)
 
@@ -168,15 +169,20 @@ func TestFileLinesProviderAllowsUTF16LEWithBOM(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 
 	g.Expect(f.IsBinary).To(BeFalse())
+
+	v, ok := f.Quantity(FileLines)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(v).To(Equal(int64(2)))
 }
 
-func TestFileLinesProviderAllowsUTF16BEWithBOM(t *testing.T) {
+func TestFileLinesProviderCountsUTF16BELines(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
 	dir := t.TempDir()
 
-	// UTF-16 BE BOM (FE FF) followed by ASCII 'a' in UTF-16 BE (00 61) + newline (00 0A)
+	// UTF-16 BE BOM (FE FF) followed by "a\nb\n" encoded in UTF-16 BE:
+	// 'a'=00 61, '\n'=00 0A, 'b'=00 62, '\n'=00 0A  →  2 lines
 	content := []byte{0xFE, 0xFF, 0x00, 0x61, 0x00, 0x0A, 0x00, 0x62, 0x00, 0x0A}
 	_ = os.WriteFile(filepath.Join(dir, "code.cs"), content, 0o600)
 
@@ -188,6 +194,10 @@ func TestFileLinesProviderAllowsUTF16BEWithBOM(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 
 	g.Expect(f.IsBinary).To(BeFalse())
+
+	v, ok := f.Quantity(FileLines)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(v).To(Equal(int64(2)))
 }
 
 func TestFileLinesProviderHandlesEmptyFile(t *testing.T) {


### PR DESCRIPTION
When a UTF-16 BOM (LE or BE) is detected during the binary probe, wrap the file reader in a golang.org/x/text unicode decoder before counting lines. This ensures two-byte newlines are decoded to single U+000A bytes that bufio.Scanner splits on correctly.

Previously the scanner split on every raw 0x0A byte, causing:
- UTF-16 LE: spurious extra line from the trailing 0x00 after each newline
- UTF-16 BE: possible false splits inside two-byte characters

Also promotes golang.org/x/text from indirect to direct dependency, replaces the boolean hasUTF16BOM helper with detectUTF16Encoding (returning LE/BE/notUTF16), and updates probeBinary to return the encoding alongside the binary flag.

Updates tests to verify correct line counts (not just non-binary status).

Closes #105