### PR TITLE
Fix spiral visualization bugs (#139)

### DIFF
--- a/cmd/codeviz/spiral_cmd.go
+++ b/cmd/codeviz/spiral_cmd.go
@@ -215,7 +215,8 @@ func (c *SpiralCmd) layoutAndRender(
 	labels := c.resolveLabels(cfg)
 
 	nodes := spiral.Layout(buckets, width, height, resolution, labels)
-	applySpiralDiscSizes(nodes, buckets)
+	maxDisc := spiral.MaxDiscRadius(len(buckets), width, height, resolution)
+	applySpiralDiscSizes(nodes, buckets, maxDisc)
 
 	fillMetric, fillPaletteName := c.applyFill(nodes, buckets, cfg)
 	borderMetric, borderPaletteName := c.applyBorder(nodes, buckets, cfg)
@@ -532,13 +533,13 @@ func assignFilesToBuckets(buckets []spiral.TimeBucket, records []spiral.CommitRe
 	}
 }
 
-// emptyBucketRadius is the small disc radius for time buckets with no activity.
-// These are still drawn to preserve the smooth spiral shape.
-const emptyBucketRadius = 2.0
+// minDiscRadius is the minimum visible disc radius for active time buckets.
+const minDiscRadius = 3.0
 
 // applySpiralDiscSizes sets disc radii on nodes proportional to their size values.
-// Empty buckets (no activity) keep a small fixed radius to maintain spiral continuity.
-func applySpiralDiscSizes(nodes []spiral.SpiralNode, buckets []spiral.TimeBucket) {
+// Empty buckets (no activity) get zero radius so they are not drawn.
+// Active buckets are clamped between minDiscRadius and maxDisc.
+func applySpiralDiscSizes(nodes []spiral.SpiralNode, buckets []spiral.TimeBucket, maxDisc float64) {
 	maxSize := 0.0
 
 	for _, b := range buckets {
@@ -552,12 +553,12 @@ func applySpiralDiscSizes(nodes []spiral.SpiralNode, buckets []spiral.TimeBucket
 	}
 
 	for i := range nodes {
-		if buckets[i].SizeValue == 0 {
-			nodes[i].DiscRadius = emptyBucketRadius
+		if buckets[i].SizeValue == 0 && len(buckets[i].Files) == 0 {
+			nodes[i].DiscRadius = 0
 		} else {
 			ratio := buckets[i].SizeValue / maxSize
-			// sqrt scaling gives area-proportional discs
-			nodes[i].DiscRadius *= math.Sqrt(ratio)
+			scaled := nodes[i].DiscRadius * math.Sqrt(ratio)
+			nodes[i].DiscRadius = max(minDiscRadius, min(scaled, maxDisc))
 		}
 	}
 }

--- a/cmd/codeviz/spiral_cmd.go
+++ b/cmd/codeviz/spiral_cmd.go
@@ -548,14 +548,25 @@ func applySpiralDiscSizes(nodes []spiral.SpiralNode, buckets []spiral.TimeBucket
 		}
 	}
 
+	// Zero out empty buckets first (before maxSize==0 check)
+	for i := range nodes {
+		if buckets[i].SizeValue == 0 && len(buckets[i].Files) == 0 {
+			nodes[i].DiscRadius = 0
+		}
+	}
+
 	if maxSize == 0 {
+		// All remaining active buckets get minDiscRadius
+		for i := range nodes {
+			if nodes[i].DiscRadius != 0 {
+				nodes[i].DiscRadius = minDiscRadius
+			}
+		}
 		return
 	}
 
 	for i := range nodes {
-		if buckets[i].SizeValue == 0 && len(buckets[i].Files) == 0 {
-			nodes[i].DiscRadius = 0
-		} else {
+		if nodes[i].DiscRadius != 0 {
 			ratio := buckets[i].SizeValue / maxSize
 			scaled := nodes[i].DiscRadius * math.Sqrt(ratio)
 			nodes[i].DiscRadius = max(minDiscRadius, min(scaled, maxDisc))

--- a/cmd/codeviz/spiral_cmd.go
+++ b/cmd/codeviz/spiral_cmd.go
@@ -548,29 +548,22 @@ func applySpiralDiscSizes(nodes []spiral.SpiralNode, buckets []spiral.TimeBucket
 		}
 	}
 
-	// Zero out empty buckets first (before maxSize==0 check)
 	for i := range nodes {
 		if buckets[i].SizeValue == 0 && len(buckets[i].Files) == 0 {
 			nodes[i].DiscRadius = 0
-		}
-	}
 
-	if maxSize == 0 {
-		// All remaining active buckets get minDiscRadius
-		for i := range nodes {
-			if nodes[i].DiscRadius != 0 {
-				nodes[i].DiscRadius = minDiscRadius
-			}
+			continue
 		}
-		return
-	}
 
-	for i := range nodes {
-		if nodes[i].DiscRadius != 0 {
-			ratio := buckets[i].SizeValue / maxSize
-			scaled := nodes[i].DiscRadius * math.Sqrt(ratio)
-			nodes[i].DiscRadius = max(minDiscRadius, min(scaled, maxDisc))
+		if maxSize == 0 {
+			nodes[i].DiscRadius = minDiscRadius
+
+			continue
 		}
+
+		ratio := buckets[i].SizeValue / maxSize
+		scaled := nodes[i].DiscRadius * math.Sqrt(ratio)
+		nodes[i].DiscRadius = max(minDiscRadius, min(scaled, maxDisc))
 	}
 }
 

--- a/internal/render/spiral.go
+++ b/internal/render/spiral.go
@@ -23,6 +23,15 @@ const (
 	spiralTrackMinSteps = 500
 )
 
+// spiralBorderWidth returns the border stroke width for a spiral disc.
+func spiralBorderWidth(discRadius float64) float64 {
+	if discRadius < 8 {
+		return 2.0
+	}
+
+	return 3.0
+}
+
 // spiralTrackSteps returns the number of interpolation steps for the track curve.
 // Uses the greater of 500 and 3× the node count to ensure the track never skips
 // over nodes on tightly-wound spirals.
@@ -172,7 +181,7 @@ func drawSingleSpot(dc *gg.Context, n spiral.SpiralNode) {
 	}
 
 	dc.SetColor(border)
-	dc.SetLineWidth(1.0)
+	dc.SetLineWidth(spiralBorderWidth(n.DiscRadius))
 	dc.DrawCircle(n.X, n.Y, n.DiscRadius)
 	dc.Stroke()
 }

--- a/internal/render/svg_spiral.go
+++ b/internal/render/svg_spiral.go
@@ -103,9 +103,9 @@ func writeSpiralSVGDiscs(f *os.File, nodes []spiral.SpiralNode) {
 
 		fmt.Fprintf(f,
 			"<circle cx=\"%.2f\" cy=\"%.2f\" r=\"%.2f\""+
-				" fill=\"%s\" stroke=\"%s\" stroke-width=\"1\"/>\n",
+				" fill=\"%s\" stroke=\"%s\" stroke-width=\"%.0f\"/>\n",
 			n.X, n.Y, n.DiscRadius,
-			colourToHex(fill), colourToHex(border))
+			colourToHex(fill), colourToHex(border), spiralBorderWidth(n.DiscRadius))
 	}
 }
 

--- a/internal/spiral/layout.go
+++ b/internal/spiral/layout.go
@@ -85,6 +85,23 @@ func computeTotalAngle(n, spotsPerLap int) float64 {
 	return float64(n-1) * (2 * math.Pi / float64(spotsPerLap))
 }
 
+// MaxDiscRadius returns the maximum disc radius that avoids overlap for the
+// given layout parameters. Use this to clamp disc sizes in the CLI layer.
+func MaxDiscRadius(
+	bucketCount int,
+	width int,
+	height int,
+	resolution Resolution,
+) float64 {
+	if bucketCount == 0 {
+		return defaultDiscRadius
+	}
+
+	params := computeSpiralParams(bucketCount, width, height, resolution)
+
+	return params.maxDisc
+}
+
 // computeMaxDisc calculates the maximum disc radius that avoids overlap.
 func computeMaxDisc(innerRadius, outerRadius float64, spotsPerLap int, totalAngle float64) float64 {
 	angularStep := 2 * math.Pi / float64(spotsPerLap)


### PR DESCRIPTION
Three fixes:
- Hide dots for empty time buckets (no activity = no dot)
- Dynamic dot sizes with min/max clamping using exposed maxDisc from layout
- Wider borders (2px small dots, 3px large) for better metric colour visibility

Fixes #139