### PR TITLE
Add new git metrics (#136)

### DIFF
--- a/internal/provider/git/churn_metrics.go
+++ b/internal/provider/git/churn_metrics.go
@@ -1,0 +1,65 @@
+package git
+
+import (
+	"github.com/bevan/code-visualizer/internal/metric"
+	"github.com/bevan/code-visualizer/internal/model"
+	"github.com/bevan/code-visualizer/internal/palette"
+)
+
+// TotalLinesAddedProvider reports accumulated lines added over all commits
+// (excluding the first commit which creates the file).
+type TotalLinesAddedProvider struct {
+	onFile func()
+}
+
+func (*TotalLinesAddedProvider) Name() metric.Name { return TotalLinesAdded }
+func (*TotalLinesAddedProvider) Kind() metric.Kind { return metric.Quantity }
+func (*TotalLinesAddedProvider) Description() string {
+	return "Accumulated lines added over all commits (excluding file creation); high churn files score higher."
+}
+func (*TotalLinesAddedProvider) Dependencies() []metric.Name         { return nil }
+func (*TotalLinesAddedProvider) DefaultPalette() palette.PaletteName { return palette.Temperature }
+
+func (p *TotalLinesAddedProvider) SetOnFileProcessed(fn func()) { p.onFile = fn }
+
+func (p *TotalLinesAddedProvider) Load(root *model.Directory) error {
+	return loadGitMetric(root, TotalLinesAdded, "total-lines-added", (*repoService).totalLinesAdded, p.onFile)
+}
+
+// TotalLinesRemovedProvider reports accumulated lines removed over all commits.
+type TotalLinesRemovedProvider struct {
+	onFile func()
+}
+
+func (*TotalLinesRemovedProvider) Name() metric.Name { return TotalLinesRemoved }
+func (*TotalLinesRemovedProvider) Kind() metric.Kind { return metric.Quantity }
+func (*TotalLinesRemovedProvider) Description() string {
+	return "Accumulated lines removed over all commits; high churn files score higher."
+}
+func (*TotalLinesRemovedProvider) Dependencies() []metric.Name         { return nil }
+func (*TotalLinesRemovedProvider) DefaultPalette() palette.PaletteName { return palette.Temperature }
+
+func (p *TotalLinesRemovedProvider) SetOnFileProcessed(fn func()) { p.onFile = fn }
+
+func (p *TotalLinesRemovedProvider) Load(root *model.Directory) error {
+	return loadGitMetric(root, TotalLinesRemoved, "total-lines-removed", (*repoService).totalLinesRemoved, p.onFile)
+}
+
+// CommitDensityProvider reports commits per month of file lifetime.
+type CommitDensityProvider struct {
+	onFile func()
+}
+
+func (*CommitDensityProvider) Name() metric.Name { return CommitDensity }
+func (*CommitDensityProvider) Kind() metric.Kind { return metric.Measure }
+func (*CommitDensityProvider) Description() string {
+	return "Commits per month of file lifetime; frequently changed files score higher."
+}
+func (*CommitDensityProvider) Dependencies() []metric.Name         { return nil }
+func (*CommitDensityProvider) DefaultPalette() palette.PaletteName { return palette.Temperature }
+
+func (p *CommitDensityProvider) SetOnFileProcessed(fn func()) { p.onFile = fn }
+
+func (p *CommitDensityProvider) Load(root *model.Directory) error {
+	return loadGitMeasureMetric(root, CommitDensity, "commit-density", (*repoService).commitDensity, p.onFile)
+}

--- a/internal/provider/git/metrics.go
+++ b/internal/provider/git/metrics.go
@@ -13,10 +13,13 @@ import (
 )
 
 const (
-	FileAge       metric.Name = "file-age"
-	FileFreshness metric.Name = "file-freshness"
-	AuthorCount   metric.Name = "author-count"
-	CommitCount   metric.Name = "commit-count"
+	FileAge           metric.Name = "file-age"
+	FileFreshness     metric.Name = "file-freshness"
+	AuthorCount       metric.Name = "author-count"
+	CommitCount       metric.Name = "commit-count"
+	TotalLinesAdded   metric.Name = "total-lines-added"
+	TotalLinesRemoved metric.Name = "total-lines-removed"
+	CommitDensity     metric.Name = "commit-density"
 )
 
 // FileAgeProvider reports time since first commit in days.
@@ -60,7 +63,8 @@ func (p *FileFreshnessProvider) Load(root *model.Directory) error {
 // IsGitMetric reports whether name is a metric that requires a git repository.
 func IsGitMetric(name metric.Name) bool {
 	switch name {
-	case FileAge, FileFreshness, AuthorCount, CommitCount:
+	case FileAge, FileFreshness, AuthorCount, CommitCount,
+		TotalLinesAdded, TotalLinesRemoved, CommitDensity:
 		return true
 	default:
 		return false
@@ -105,15 +109,57 @@ func (p *CommitCountProvider) Load(root *model.Directory) error {
 	return loadGitMetric(root, CommitCount, "commit-count", (*repoService).commitCount, p.onFile)
 }
 
-// loadGitMetric is the shared implementation for all git-based metric providers.
-// It opens the repo service, walks all files, computes paths relative to the git
-// worktree root (not the scan root), and sets the metric via the supplied fn.
+// loadGitMetric is the shared implementation for all git-based quantity metric providers.
 func loadGitMetric(
 	root *model.Directory,
 	name metric.Name,
 	desc string,
 	fn func(*repoService, string) (int64, error),
 	onFile func(),
+) error {
+	return walkGitFiles(root, desc, onFile, func(s *repoService, f *model.File, relPath string) {
+		val, err := fn(s, relPath)
+		if err != nil {
+			if !errors.Is(err, errUntracked) {
+				slog.Debug("could not get "+desc, "path", relPath, "error", err)
+			}
+
+			return
+		}
+
+		f.SetQuantity(name, val)
+	})
+}
+
+// loadGitMeasureMetric is the shared implementation for git-based measure (float64) providers.
+func loadGitMeasureMetric(
+	root *model.Directory,
+	name metric.Name,
+	desc string,
+	fn func(*repoService, string) (float64, error),
+	onFile func(),
+) error {
+	return walkGitFiles(root, desc, onFile, func(s *repoService, f *model.File, relPath string) {
+		val, err := fn(s, relPath)
+		if err != nil {
+			if !errors.Is(err, errUntracked) {
+				slog.Debug("could not get "+desc, "path", relPath, "error", err)
+			}
+
+			return
+		}
+
+		f.SetMeasure(name, val)
+	})
+}
+
+// walkGitFiles opens the repo service, walks all files, computes paths relative
+// to the git worktree root, and invokes the process callback for each file.
+func walkGitFiles(
+	root *model.Directory,
+	desc string,
+	onFile func(),
+	process func(*repoService, *model.File, string),
 ) error {
 	s, err := getService(root.Path)
 	if err != nil {
@@ -132,16 +178,7 @@ func loadGitMetric(
 			return
 		}
 
-		val, err := fn(s, relPath)
-		if err != nil {
-			if !errors.Is(err, errUntracked) {
-				slog.Debug("could not get "+desc, "path", relPath, "error", err)
-			}
-
-			return
-		}
-
-		f.SetQuantity(name, val)
+		process(s, f, relPath)
 	})
 
 	return nil

--- a/internal/provider/git/metrics_test.go
+++ b/internal/provider/git/metrics_test.go
@@ -626,3 +626,212 @@ func TestCommitCountProvider_SubdirectoryScanning(t *testing.T) {
 	g.Expect(ok).To(BeTrue(), "commit-count metric should be set for file in subdirectory")
 	g.Expect(count).To(Equal(int64(1)), "code.go was committed once")
 }
+
+func TestIsGitMetric_NewMetrics(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	g.Expect(IsGitMetric(TotalLinesAdded)).To(BeTrue())
+	g.Expect(IsGitMetric(TotalLinesRemoved)).To(BeTrue())
+	g.Expect(IsGitMetric(CommitDensity)).To(BeTrue())
+}
+
+func TestTotalLinesAddedProviderMetadata(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	p := &TotalLinesAddedProvider{}
+	g.Expect(p.Name()).To(Equal(TotalLinesAdded))
+	g.Expect(p.Kind()).To(Equal(metric.Quantity))
+	g.Expect(p.Description()).NotTo(BeEmpty())
+	g.Expect(p.DefaultPalette()).NotTo(BeEmpty())
+	g.Expect(p.Dependencies()).To(BeNil())
+}
+
+func TestTotalLinesRemovedProviderMetadata(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	p := &TotalLinesRemovedProvider{}
+	g.Expect(p.Name()).To(Equal(TotalLinesRemoved))
+	g.Expect(p.Kind()).To(Equal(metric.Quantity))
+	g.Expect(p.Description()).NotTo(BeEmpty())
+	g.Expect(p.DefaultPalette()).NotTo(BeEmpty())
+	g.Expect(p.Dependencies()).To(BeNil())
+}
+
+func TestCommitDensityProviderMetadata(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	p := &CommitDensityProvider{}
+	g.Expect(p.Name()).To(Equal(CommitDensity))
+	g.Expect(p.Kind()).To(Equal(metric.Measure))
+	g.Expect(p.Description()).NotTo(BeEmpty())
+	g.Expect(p.DefaultPalette()).NotTo(BeEmpty())
+	g.Expect(p.Dependencies()).To(BeNil())
+}
+
+// setupDiffRepo creates a git repo with a file that has measurable additions
+// and removals across multiple commits.
+func setupDiffRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+
+		cmd := exec.Command(args[0], args[1:]...) //nolint:gosec // test helper
+		cmd.Dir = dir
+
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=Alice",
+			"GIT_AUTHOR_EMAIL=alice@example.com",
+			"GIT_COMMITTER_NAME=Alice",
+			"GIT_COMMITTER_EMAIL=alice@example.com",
+		)
+
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("command %v failed: %s\n%s", args, err, out)
+		}
+	}
+
+	run("git", "init")
+	run("git", "config", "user.name", "Alice")
+	run("git", "config", "user.email", "alice@example.com")
+
+	// Commit 1: create file with 3 lines (creation commit — excluded from stats)
+	_ = os.WriteFile(filepath.Join(dir, "churn.go"),
+		[]byte("line1\nline2\nline3\n"), 0o600)
+
+	run("git", "add", ".")
+	run("git", "commit", "-m", "initial", "--date=2024-01-01T00:00:00+00:00")
+
+	// Commit 2: add 2 lines (total: 5 lines)
+	_ = os.WriteFile(filepath.Join(dir, "churn.go"),
+		[]byte("line1\nline2\nline3\nline4\nline5\n"), 0o600)
+
+	run("git", "add", ".")
+	run("git", "commit", "-m", "add lines", "--date=2024-02-01T00:00:00+00:00")
+
+	// Commit 3: remove 1 line, add 1 line (replace line2 with lineX)
+	_ = os.WriteFile(filepath.Join(dir, "churn.go"),
+		[]byte("line1\nlineX\nline3\nline4\nline5\n"), 0o600)
+
+	run("git", "add", ".")
+	run("git", "commit", "-m", "modify", "--date=2024-03-01T00:00:00+00:00")
+
+	// Also create a stable file with no changes after creation
+	_ = os.WriteFile(filepath.Join(dir, "stable.go"),
+		[]byte("package stable\n"), 0o600)
+
+	run("git", "add", ".")
+	run("git", "commit", "-m", "add stable", "--date=2024-03-15T00:00:00+00:00")
+
+	return dir
+}
+
+func TestTotalLinesAddedProvider(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir := setupDiffRepo(t)
+	root := buildTree(dir, "churn.go", "stable.go")
+
+	resetService()
+
+	p := &TotalLinesAddedProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// churn.go: commit 2 adds 2 lines, commit 3 adds 1 line = 3 total
+	added, ok := root.Files[0].Quantity(TotalLinesAdded)
+	g.Expect(ok).To(BeTrue(), "total-lines-added should be set for churn.go")
+	g.Expect(added).To(Equal(int64(3)), "churn.go: 2 lines in commit 2 + 1 line in commit 3")
+
+	// stable.go: created in a non-root commit but only has the creation commit
+	// (no subsequent modifications) — should be 0
+	added, ok = root.Files[1].Quantity(TotalLinesAdded)
+	g.Expect(ok).To(BeTrue(), "total-lines-added should be set for stable.go")
+	g.Expect(added).To(Equal(int64(0)), "stable.go has no modifications after creation")
+}
+
+func TestTotalLinesRemovedProvider(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir := setupDiffRepo(t)
+	root := buildTree(dir, "churn.go", "stable.go")
+
+	resetService()
+
+	p := &TotalLinesRemovedProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// churn.go: commit 3 removes 1 line (line2 → lineX) = 1 total
+	removed, ok := root.Files[0].Quantity(TotalLinesRemoved)
+	g.Expect(ok).To(BeTrue(), "total-lines-removed should be set for churn.go")
+	g.Expect(removed).To(Equal(int64(1)), "churn.go: 1 line removed in commit 3")
+
+	// stable.go: no removals
+	removed, ok = root.Files[1].Quantity(TotalLinesRemoved)
+	g.Expect(ok).To(BeTrue(), "total-lines-removed should be set for stable.go")
+	g.Expect(removed).To(Equal(int64(0)), "stable.go has no modifications")
+}
+
+func TestCommitDensityProvider(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir := setupDiffRepo(t)
+	root := buildTree(dir, "churn.go")
+
+	resetService()
+
+	p := &CommitDensityProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// churn.go: 3 commits, age > 1 month. Density = 3 / age_months.
+	density, ok := root.Files[0].Measure(CommitDensity)
+	g.Expect(ok).To(BeTrue(), "commit-density should be set for churn.go")
+	g.Expect(density).To(BeNumerically(">", 0), "commit-density should be positive")
+	// With ~18 months of age: 3/18 ≈ 0.17. Allow a wide range for time passing.
+	g.Expect(density).To(BeNumerically("<", 3), "commit-density should be reasonable")
+}
+
+func TestCommitDensityProvider_YoungFile(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir := setupTestGitRepo(t) // new.go was just committed
+	root := buildTree(dir, "new.go")
+
+	resetService()
+
+	p := &CommitDensityProvider{}
+	err := p.Load(root)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// new.go: 1 commit, age < 1 month → clamped to 1 month. Density = 1/1 = 1.0
+	density, ok := root.Files[0].Measure(CommitDensity)
+	g.Expect(ok).To(BeTrue(), "commit-density should be set for new.go")
+	g.Expect(density).To(BeNumerically("~", 1.0, 0.01),
+		"young file with 1 commit should have density ≈ 1.0")
+}
+
+func TestTotalLinesAdded_NotAGitRepo(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir := t.TempDir()
+	root := buildTree(dir, "file.go")
+
+	resetService()
+
+	p := &TotalLinesAddedProvider{}
+	err := p.Load(root)
+	g.Expect(err).To(MatchError(ContainSubstring("git")))
+}

--- a/internal/provider/git/register.go
+++ b/internal/provider/git/register.go
@@ -8,4 +8,7 @@ func Register() {
 	provider.Register(&FileFreshnessProvider{})
 	provider.Register(&AuthorCountProvider{})
 	provider.Register(&CommitCountProvider{})
+	provider.Register(&TotalLinesAddedProvider{})
+	provider.Register(&TotalLinesRemovedProvider{})
+	provider.Register(&CommitDensityProvider{})
 }

--- a/internal/provider/git/service.go
+++ b/internal/provider/git/service.go
@@ -16,10 +16,12 @@ import (
 
 // commitData holds all per-file commit information collected in a single git log pass.
 type commitData struct {
-	oldest  time.Time
-	newest  time.Time
-	count   int64
-	authors map[string]bool
+	oldest       time.Time
+	newest       time.Time
+	count        int64
+	authors      map[string]bool
+	linesAdded   int64
+	linesRemoved int64
 }
 
 type repoService struct {
@@ -149,6 +151,110 @@ func (s *repoService) commitCount(relPath string) (int64, error) {
 	return data.count, nil
 }
 
+func (s *repoService) totalLinesAdded(relPath string) (int64, error) {
+	data, err := s.getCommitData(relPath)
+	if err != nil {
+		return 0, err
+	}
+
+	if data.count == 0 {
+		return 0, errUntracked
+	}
+
+	return data.linesAdded, nil
+}
+
+func (s *repoService) totalLinesRemoved(relPath string) (int64, error) {
+	data, err := s.getCommitData(relPath)
+	if err != nil {
+		return 0, err
+	}
+
+	if data.count == 0 {
+		return 0, errUntracked
+	}
+
+	return data.linesRemoved, nil
+}
+
+const monthHours = 24 * 30.44
+
+func (s *repoService) commitDensity(relPath string) (float64, error) {
+	data, err := s.getCommitData(relPath)
+	if err != nil {
+		return 0, err
+	}
+
+	if data.count == 0 {
+		return 0, errUntracked
+	}
+
+	fileAgeMonths := time.Since(data.oldest).Hours() / monthHours
+	if fileAgeMonths < 1 {
+		fileAgeMonths = 1
+	}
+
+	return float64(data.count) / fileAgeMonths, nil
+}
+
+// computeFileDiffStats computes the lines added and removed for a file in a
+// non-root commit by diffing against the first parent. Returns (0, 0) for
+// creation commits (file doesn't exist in parent).
+func computeFileDiffStats(c *object.Commit, relPath string) (added, removed int64) {
+	parent, err := c.Parent(0)
+	if err != nil {
+		return 0, 0
+	}
+
+	// Skip creation commits — file doesn't exist in parent.
+	if _, hashErr := blobHash(parent, relPath); hashErr != nil {
+		return 0, 0
+	}
+
+	parentTree, err := parent.Tree()
+	if err != nil {
+		return 0, 0
+	}
+
+	commitTree, err := c.Tree()
+	if err != nil {
+		return 0, 0
+	}
+
+	changes, err := object.DiffTree(parentTree, commitTree)
+	if err != nil {
+		return 0, 0
+	}
+
+	fileChanges := filterChangesForFile(changes, relPath)
+	if len(fileChanges) == 0 {
+		return 0, 0
+	}
+
+	patch, err := fileChanges.Patch()
+	if err != nil {
+		return 0, 0
+	}
+
+	for _, stat := range patch.Stats() {
+		added += int64(stat.Addition)
+		removed += int64(stat.Deletion)
+	}
+
+	return added, removed
+}
+
+// filterChangesForFile returns only the changes that affect the given file.
+func filterChangesForFile(changes object.Changes, relPath string) object.Changes {
+	for _, change := range changes {
+		if changeName(change) == relPath {
+			return object.Changes{change}
+		}
+	}
+
+	return nil
+}
+
 // getCommitData returns cached commit data for the given file path, fetching it
 // from git on first access. Concurrent requests for the same path are coalesced
 // via singleflight so the git log is only read once per file per process run.
@@ -199,24 +305,7 @@ func (s *repoService) fetchCommitData(relPath string) (*commitData, error) {
 	}
 
 	err = log.ForEach(func(c *object.Commit) error {
-		// go-git's FileName filter includes merge commits that didn't
-		// actually modify the file. Skip those to avoid polluting
-		// the newest timestamp with unrelated commit dates.
-		if !commitModifiedFile(c, relPath) {
-			return nil
-		}
-
-		when := c.Author.When
-		if data.oldest.IsZero() || when.Before(data.oldest) {
-			data.oldest = when
-		}
-
-		if data.newest.IsZero() || when.After(data.newest) {
-			data.newest = when
-		}
-
-		data.authors[c.Author.Email] = true
-		data.count++
+		processCommitForFile(c, relPath, data)
 
 		return nil
 	})
@@ -225,6 +314,37 @@ func (s *repoService) fetchCommitData(relPath string) (*commitData, error) {
 	}
 
 	return data, nil
+}
+
+// processCommitForFile updates commitData for a single commit that may or may
+// not have modified the file. It checks TREESAME filtering, updates timestamps,
+// author set, commit count, and diff stats.
+func processCommitForFile(c *object.Commit, relPath string, data *commitData) {
+	// go-git's FileName filter includes merge commits that didn't
+	// actually modify the file. Skip those to avoid polluting
+	// the newest timestamp with unrelated commit dates.
+	if !commitModifiedFile(c, relPath) {
+		return
+	}
+
+	when := c.Author.When
+	if data.oldest.IsZero() || when.Before(data.oldest) {
+		data.oldest = when
+	}
+
+	if data.newest.IsZero() || when.After(data.newest) {
+		data.newest = when
+	}
+
+	data.authors[c.Author.Email] = true
+	data.count++
+
+	// Accumulate diff stats for non-root commits that modify an existing file.
+	if c.NumParents() > 0 {
+		added, removed := computeFileDiffStats(c, relPath)
+		data.linesAdded += added
+		data.linesRemoved += removed
+	}
 }
 
 // commitModifiedFile returns true if the commit actually changed the file at


### PR DESCRIPTION
Three new git-based metrics:
- `total-lines-added`: accumulated lines added over all commits (excluding file creation)
- `total-lines-removed`: accumulated lines removed over all commits
- `commit-density`: commits per month of file lifetime

Fixes #136