### PR TITLE
Extract shared progress ticker pattern

### DIFF
--- a/.squad/agents/bishop/history.md
+++ b/.squad/agents/bishop/history.md
@@ -42,3 +42,42 @@
 - Not blocking, but watch for more folder metrics tipping toward DRY
 
 **Review output:** Orchestration log at `.squad/orchestration-log/2026-04-15T04:50:46Z-bishop.md`
+
+### Full Structural Audit (2026-07-07)
+
+**Scope:** Complete review of `cmd/codeviz/` and all `internal/` packages.
+
+**Issues filed (11 total):**
+- #152 — Extract shared command workflow (highest impact, ~1,500 lines duplicated across 4 commands)
+- #153 — Extract shared base config struct (data clump across 4 viz config types)
+- #154 — Extract shared LabelMode type (triplicated across radialtree/bubbletree/spiral)
+- #155 — Replace 7 git provider wrappers with declarative registration (WET boilerplate)
+- #156 — Extract MetricBag from File/Directory (duplicated metric storage, ~130 lines)
+- #157 — Deduplicate luminance calculation (render vs palette)
+- #158 — Unify raster/SVG rendering paths (duplicated across 8 renderer files + legend)
+- #159 — Move git history loading out of spiral layout package (boundary violation)
+- #160 — LegendEntry union type permits invalid states
+- #161 — Extract shared progress ticker pattern (triplicated goroutine lifecycle)
+- #162 — Consider splitting Provider interface (ISP)
+
+**Key structural observations:**
+- The cmd/ layer is the primary pain point: ~2,576 lines across 4 commands with ~60% duplication
+- The render package is the second hotspot: ~2,300 lines with raster/SVG duplication throughout
+- The model layer has clean semantics but duplicated implementation (metric storage)
+- Provider/git has good centralised helpers (`loadGitMetric`) but 7 near-identical wrapper files
+- Config package acknowledges its own duplication via `//nolint:dupl` comments
+- The spiral package is the only layout package with a data-access dependency (boundary smell)
+- The codebase is well-structured overall — issues are about duplication and missing abstractions, not about fundamental design problems
+
+**Priority ranking:**
+1. #152 (command workflow) — highest leverage, eliminates most duplication
+2. #158 (render unification) — second highest, prevents duplication scaling with new viz types
+3. #155 (git providers) — quick win, enables cleaner provider model
+4. #153 (config base) — quick win, removes acknowledged duplication
+5. #156 (MetricBag) — clean extraction, low risk
+6. #154 (LabelMode) — trivial but prevents drift
+7. #157 (luminance) — trivial fix
+8. #159 (spiral boundary) — important for testability
+9. #160 (LegendEntry) — moderate, prevents nil bugs
+10. #161 (progress ticker) — small cleanup
+11. #162 (provider ISP) — consider alongside #155

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -740,3 +740,47 @@ The architecture proposal was written before MetricSpec consolidation (#118/#120
 - PR #144 edge case was fixed by Dallas (moved empty-bucket handling before maxSize check).
 - `task ci` not available in environment (task not installed).
 - `go test ./...` passes locally.
+
+---
+
+### Structural Audit — Codebase Review and Refactoring Strategy
+
+**Author:** Bishop (Artificer)  
+**Date:** 2026-05-03  
+**Status:** Proposed  
+
+## Summary
+
+Completed a full structural audit of `cmd/codeviz/` and all `internal/` packages. Filed 11 issues (#152–#162) covering the most impactful structural improvements needed to reduce duplication and clarify abstractions.
+
+## Structural Health
+
+The codebase is **well-designed at the package level** — boundaries are mostly correct, types are meaningful, and the metric/provider/model/layout/render pipeline makes sense. Issues are almost entirely about **duplication and missing intermediate abstractions**, not fundamental design flaws. This is natural for a codebase that grew from one viz type to four without extracting common patterns.
+
+## Top 3 High-Leverage Refactoring Opportunities
+
+### 1. Extract Shared Command Workflow (Issue #152)
+The four viz commands (treemap, radial, bubbletree, spiral) duplicate ~60% of their code. A shared pipeline/template method would eliminate ~1,500 lines and make new viz types trivial to add. **Single highest-leverage change.**
+
+### 2. Unify Raster/SVG Rendering (Issue #158)
+Each viz type has paired raster + SVG renderers that duplicate traversal and drawing logic. A rendering abstraction (draw-list or backend interface) would halve the render package and prevent duplication from scaling.
+
+### 3. Declarative Git Providers (Issue #155)
+Seven git provider files are structurally identical wrappers differing only in 4 parameters. Replace with table-driven registration to eliminate ~180 lines and make new metrics a one-liner.
+
+## Sequencing Recommendation
+
+- **Quick wins:** Issues #155 (git providers) and #153 (config base) are independent and low-risk
+- **Major refactor:** Issue #152 (command workflow) is largest but most impactful; should be planned carefully
+- **Dependent:** Issue #158 (render unification) best tackled after #152, since command layer cleanup will clarify render API surface
+
+## Issues Filed
+
+#152–#162 (11 total):
+- #152: Extract shared command workflow
+- #153: Config base abstraction
+- #154: Metrics registration
+- #155: Git provider consolidation
+- #156–#162: Additional refactoring opportunities
+
+All issues include detailed scope, acceptance criteria, and implementation notes.

--- a/cmd/codeviz/progress.go
+++ b/cmd/codeviz/progress.go
@@ -63,9 +63,9 @@ func (s *scanCounter) OnDirectoryScanned(path string, fileCount int) {
 	}
 }
 
-// startScanTicker starts a goroutine that logs cumulative scan progress every second.
-// Call the returned stop function when scanning is done.
-func startScanTicker(counter *scanCounter) (stop func()) {
+// startProgressTicker starts a goroutine that calls logFn every second.
+// Call the returned stop function when the operation completes.
+func startProgressTicker(logFn func()) (stop func()) {
 	done := make(chan struct{})
 
 	go func() {
@@ -75,7 +75,7 @@ func startScanTicker(counter *scanCounter) (stop func()) {
 		for {
 			select {
 			case <-ticker.C:
-				slog.Debug("Scanning...", "files", counter.files.Load(), "dirs", counter.dirs.Load())
+				logFn()
 
 			case <-done:
 				return
@@ -84,6 +84,14 @@ func startScanTicker(counter *scanCounter) (stop func()) {
 	}()
 
 	return func() { close(done) }
+}
+
+// startScanTicker starts a goroutine that logs cumulative scan progress every second.
+// Call the returned stop function when scanning is done.
+func startScanTicker(counter *scanCounter) (stop func()) {
+	return startProgressTicker(func() {
+		slog.Debug("Scanning...", "files", counter.files.Load(), "dirs", counter.dirs.Load())
+	})
 }
 
 // metricProgressTracker implements provider.MetricProgress for verbose mode.
@@ -146,24 +154,9 @@ func (t *metricProgressTracker) activeNames() []metric.Name {
 // startMetricTicker starts a goroutine that logs metric calculation progress every second.
 // Call the returned stop function when metric calculation is done.
 func startMetricTicker(tracker *metricProgressTracker) (stop func()) {
-	done := make(chan struct{})
-
-	go func() {
-		ticker := time.NewTicker(time.Second)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ticker.C:
-				logMetricProgress(tracker)
-
-			case <-done:
-				return
-			}
-		}
-	}()
-
-	return func() { close(done) }
+	return startProgressTicker(func() {
+		logMetricProgress(tracker)
+	})
 }
 
 func logMetricProgress(tracker *metricProgressTracker) {
@@ -207,23 +200,8 @@ func buildHistoryProgress(flags *Flags) (onCommit func(), stop func()) {
 
 // startHistoryTicker starts a goroutine that logs commit history progress every second.
 func startHistoryTicker(counter *atomic.Int64) (stop func()) {
-	done := make(chan struct{})
-
-	go func() {
-		ticker := time.NewTicker(time.Second)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ticker.C:
-				slog.Debug("Loading history...",
-					"commits", counter.Load())
-
-			case <-done:
-				return
-			}
-		}
-	}()
-
-	return func() { close(done) }
+	return startProgressTicker(func() {
+		slog.Debug("Loading history...",
+			"commits", counter.Load())
+	})
 }


### PR DESCRIPTION
Closes #161

Extracted `startProgressTicker(logFn func()) func()` to eliminate triplicated goroutine+ticker+done-channel boilerplate in `cmd/codeviz/progress.go`. Three ticker functions now delegate to a single implementation via logging closures, cutting 41 lines down to 19.