### PR TITLE
Extract shared LabelMode type to internal/viz

### DIFF
--- a/.squad/agents/bishop/history.md
+++ b/.squad/agents/bishop/history.md
@@ -42,3 +42,42 @@
 - Not blocking, but watch for more folder metrics tipping toward DRY
 
 **Review output:** Orchestration log at `.squad/orchestration-log/2026-04-15T04:50:46Z-bishop.md`
+
+### Full Structural Audit (2026-07-07)
+
+**Scope:** Complete review of `cmd/codeviz/` and all `internal/` packages.
+
+**Issues filed (11 total):**
+- #152 — Extract shared command workflow (highest impact, ~1,500 lines duplicated across 4 commands)
+- #153 — Extract shared base config struct (data clump across 4 viz config types)
+- #154 — Extract shared LabelMode type (triplicated across radialtree/bubbletree/spiral)
+- #155 — Replace 7 git provider wrappers with declarative registration (WET boilerplate)
+- #156 — Extract MetricBag from File/Directory (duplicated metric storage, ~130 lines)
+- #157 — Deduplicate luminance calculation (render vs palette)
+- #158 — Unify raster/SVG rendering paths (duplicated across 8 renderer files + legend)
+- #159 — Move git history loading out of spiral layout package (boundary violation)
+- #160 — LegendEntry union type permits invalid states
+- #161 — Extract shared progress ticker pattern (triplicated goroutine lifecycle)
+- #162 — Consider splitting Provider interface (ISP)
+
+**Key structural observations:**
+- The cmd/ layer is the primary pain point: ~2,576 lines across 4 commands with ~60% duplication
+- The render package is the second hotspot: ~2,300 lines with raster/SVG duplication throughout
+- The model layer has clean semantics but duplicated implementation (metric storage)
+- Provider/git has good centralised helpers (`loadGitMetric`) but 7 near-identical wrapper files
+- Config package acknowledges its own duplication via `//nolint:dupl` comments
+- The spiral package is the only layout package with a data-access dependency (boundary smell)
+- The codebase is well-structured overall — issues are about duplication and missing abstractions, not about fundamental design problems
+
+**Priority ranking:**
+1. #152 (command workflow) — highest leverage, eliminates most duplication
+2. #158 (render unification) — second highest, prevents duplication scaling with new viz types
+3. #155 (git providers) — quick win, enables cleaner provider model
+4. #153 (config base) — quick win, removes acknowledged duplication
+5. #156 (MetricBag) — clean extraction, low risk
+6. #154 (LabelMode) — trivial but prevents drift
+7. #157 (luminance) — trivial fix
+8. #159 (spiral boundary) — important for testability
+9. #160 (LegendEntry) — moderate, prevents nil bugs
+10. #161 (progress ticker) — small cleanup
+11. #162 (provider ISP) — consider alongside #155

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -740,3 +740,47 @@ The architecture proposal was written before MetricSpec consolidation (#118/#120
 - PR #144 edge case was fixed by Dallas (moved empty-bucket handling before maxSize check).
 - `task ci` not available in environment (task not installed).
 - `go test ./...` passes locally.
+
+---
+
+### Structural Audit — Codebase Review and Refactoring Strategy
+
+**Author:** Bishop (Artificer)  
+**Date:** 2026-05-03  
+**Status:** Proposed  
+
+## Summary
+
+Completed a full structural audit of `cmd/codeviz/` and all `internal/` packages. Filed 11 issues (#152–#162) covering the most impactful structural improvements needed to reduce duplication and clarify abstractions.
+
+## Structural Health
+
+The codebase is **well-designed at the package level** — boundaries are mostly correct, types are meaningful, and the metric/provider/model/layout/render pipeline makes sense. Issues are almost entirely about **duplication and missing intermediate abstractions**, not fundamental design flaws. This is natural for a codebase that grew from one viz type to four without extracting common patterns.
+
+## Top 3 High-Leverage Refactoring Opportunities
+
+### 1. Extract Shared Command Workflow (Issue #152)
+The four viz commands (treemap, radial, bubbletree, spiral) duplicate ~60% of their code. A shared pipeline/template method would eliminate ~1,500 lines and make new viz types trivial to add. **Single highest-leverage change.**
+
+### 2. Unify Raster/SVG Rendering (Issue #158)
+Each viz type has paired raster + SVG renderers that duplicate traversal and drawing logic. A rendering abstraction (draw-list or backend interface) would halve the render package and prevent duplication from scaling.
+
+### 3. Declarative Git Providers (Issue #155)
+Seven git provider files are structurally identical wrappers differing only in 4 parameters. Replace with table-driven registration to eliminate ~180 lines and make new metrics a one-liner.
+
+## Sequencing Recommendation
+
+- **Quick wins:** Issues #155 (git providers) and #153 (config base) are independent and low-risk
+- **Major refactor:** Issue #152 (command workflow) is largest but most impactful; should be planned carefully
+- **Dependent:** Issue #158 (render unification) best tackled after #152, since command layer cleanup will clarify render API surface
+
+## Issues Filed
+
+#152–#162 (11 total):
+- #152: Extract shared command workflow
+- #153: Config base abstraction
+- #154: Metrics registration
+- #155: Git provider consolidation
+- #156–#162: Additional refactoring opportunities
+
+All issues include detailed scope, acceptance criteria, and implementation notes.

--- a/internal/bubbletree/node.go
+++ b/internal/bubbletree/node.go
@@ -1,17 +1,18 @@
 package bubbletree
 
-import "image/color"
+import (
+	"image/color"
 
-// LabelMode controls which node labels are shown in the diagram.
-type LabelMode string
+	"github.com/bevan/code-visualizer/internal/viz"
+)
+
+// LabelMode is an alias for [viz.LabelMode].
+type LabelMode = viz.LabelMode
 
 const (
-	// LabelAll shows labels for all nodes.
-	LabelAll LabelMode = "all"
-	// LabelFoldersOnly shows labels for directory nodes only.
-	LabelFoldersOnly LabelMode = "folders"
-	// LabelNone hides all labels.
-	LabelNone LabelMode = "none"
+	LabelAll         = viz.LabelAll
+	LabelFoldersOnly = viz.LabelFoldersOnly
+	LabelNone        = viz.LabelNone
 )
 
 // BubbleNode is a positioned visual element in the rendered bubble tree.

--- a/internal/radialtree/node.go
+++ b/internal/radialtree/node.go
@@ -1,17 +1,18 @@
 package radialtree
 
-import "image/color"
+import (
+	"image/color"
 
-// LabelMode controls which node labels are shown in the diagram.
-type LabelMode string
+	"github.com/bevan/code-visualizer/internal/viz"
+)
+
+// LabelMode is an alias for [viz.LabelMode].
+type LabelMode = viz.LabelMode
 
 const (
-	// LabelAll shows labels for all nodes.
-	LabelAll LabelMode = "all"
-	// LabelFoldersOnly shows labels for directory nodes only.
-	LabelFoldersOnly LabelMode = "folders"
-	// LabelNone hides all labels.
-	LabelNone LabelMode = "none"
+	LabelAll         = viz.LabelAll
+	LabelFoldersOnly = viz.LabelFoldersOnly
+	LabelNone        = viz.LabelNone
 )
 
 // RadialNode is a positioned visual element in the rendered radial tree.

--- a/internal/spiral/node.go
+++ b/internal/spiral/node.go
@@ -4,18 +4,17 @@ package spiral
 import (
 	"image/color"
 	"time"
+
+	"github.com/bevan/code-visualizer/internal/viz"
 )
 
-// LabelMode controls which node labels are shown in the diagram.
-type LabelMode string
+// LabelMode is an alias for [viz.LabelMode].
+type LabelMode = viz.LabelMode
 
 const (
-	// LabelAll shows labels for all spots on the spiral.
-	LabelAll LabelMode = "all"
-	// LabelLaps shows labels only at lap boundaries (e.g. midnight, week start).
-	LabelLaps LabelMode = "laps"
-	// LabelNone hides all labels.
-	LabelNone LabelMode = "none"
+	LabelAll  = viz.LabelAll
+	LabelLaps = viz.LabelLaps
+	LabelNone = viz.LabelNone
 )
 
 // SpiralNode is a positioned visual element on the rendered spiral timeline.

--- a/internal/viz/label_mode.go
+++ b/internal/viz/label_mode.go
@@ -1,0 +1,16 @@
+// Package viz provides shared types used across visualization layout packages.
+package viz
+
+// LabelMode controls which node labels are shown in a diagram.
+type LabelMode string
+
+const (
+	// LabelAll shows labels for all nodes.
+	LabelAll LabelMode = "all"
+	// LabelFoldersOnly shows labels for directory nodes only.
+	LabelFoldersOnly LabelMode = "folders"
+	// LabelLaps shows labels only at lap boundaries (e.g. midnight, week start).
+	LabelLaps LabelMode = "laps"
+	// LabelNone hides all labels.
+	LabelNone LabelMode = "none"
+)


### PR DESCRIPTION
Closes #154

Created `internal/viz/label_mode.go` as the single source of truth for `LabelMode` and its constants (`LabelAll`, `LabelFoldersOnly`, `LabelLaps`, `LabelNone`). Each layout package re-exports via type aliases so all consumers compile without changes.