### PR TITLE
Fix squad triage routing: use routing.md keyword scoring instead of hardcoded roles

### DIFF
--- a/.github/workflows/squad-triage.yml
+++ b/.github/workflows/squad-triage.yml
@@ -142,43 +142,76 @@ jobs:
               }
             }
 
-            // If not routed to @copilot, use keyword-based routing
-            if (!assignedMember) {
-              for (const member of members) {
-                const role = member.role.toLowerCase();
-                if ((role.includes('frontend') || role.includes('ui')) &&
-                    (issueText.includes('ui') || issueText.includes('frontend') ||
-                     issueText.includes('css') || issueText.includes('component') ||
-                     issueText.includes('button') || issueText.includes('page') ||
-                     issueText.includes('layout') || issueText.includes('design'))) {
-                  assignedMember = member;
-                  triageReason = 'Issue relates to frontend/UI work';
+            // If not routed to @copilot, use routing.md keyword scoring
+            if (!assignedMember && routingContent) {
+              // Parse "Work Type → Agent" table from routing.md
+              const routingRules = [];
+              const routingLines = routingContent.split('\n');
+              let inRoutingTable = false;
+              let pastSeparator = false;
+
+              for (const rline of routingLines) {
+                if (rline.match(/^#+.*Work Type/i)) {
+                  inRoutingTable = true;
+                  pastSeparator = false;
+                  continue;
+                }
+                if (inRoutingTable && /^#+\s/.test(rline) && !rline.match(/Work Type/i)) {
                   break;
                 }
-                if ((role.includes('backend') || role.includes('api') || role.includes('server')) &&
-                    (issueText.includes('api') || issueText.includes('backend') ||
-                     issueText.includes('database') || issueText.includes('endpoint') ||
-                     issueText.includes('server') || issueText.includes('auth'))) {
-                  assignedMember = member;
-                  triageReason = 'Issue relates to backend/API work';
-                  break;
+                if (inRoutingTable && rline.includes('---')) {
+                  pastSeparator = true;
+                  continue;
                 }
-                if ((role.includes('test') || role.includes('qa') || role.includes('quality')) &&
-                    (issueText.includes('test') || issueText.includes('bug') ||
-                     issueText.includes('fix') || issueText.includes('regression') ||
-                     issueText.includes('coverage'))) {
-                  assignedMember = member;
-                  triageReason = 'Issue relates to testing/quality work';
-                  break;
+                if (inRoutingTable && pastSeparator && rline.startsWith('|')) {
+                  const cells = rline.split('|').map(c => c.trim()).filter(Boolean);
+                  if (cells.length >= 2) {
+                    const keywords = cells[0].toLowerCase().split(',').map(s => s.trim()).filter(Boolean);
+                    const memberName = cells[1].trim();
+                    // Skip placeholder/empty rows
+                    if (memberName.startsWith('{') || memberName === '—' || memberName === '-') continue;
+                    const member = members.find(m => m.name.toLowerCase() === memberName.toLowerCase());
+                    if (member) {
+                      routingRules.push({ member, keywords });
+                    }
+                  }
                 }
-                if ((role.includes('devops') || role.includes('infra') || role.includes('ops')) &&
-                    (issueText.includes('deploy') || issueText.includes('ci') ||
-                     issueText.includes('pipeline') || issueText.includes('docker') ||
-                     issueText.includes('infrastructure'))) {
-                  assignedMember = member;
-                  triageReason = 'Issue relates to DevOps/infrastructure work';
-                  break;
+              }
+
+              // Score each member by weighted keyword matches.
+              // Multi-word phrases are more specific and score higher than
+              // single common words like "review" or "tests".
+              // NOTE: Review keyword weights when adding or retiring team
+              // members — the balance depends on relative specificity across
+              // the whole routing table.
+              function keywordWeight(kw) {
+                const words = kw.split(/\s+/).length;
+                return words * words; // 1-word=1, 2-word=4, 3-word=9
+              }
+
+              let bestScore = 0;
+              let bestMember = null;
+              let bestKeywords = [];
+
+              for (const rule of routingRules) {
+                let score = 0;
+                const matched = [];
+                for (const kw of rule.keywords) {
+                  if (issueText.includes(kw)) {
+                    score += keywordWeight(kw);
+                    matched.push(kw);
+                  }
                 }
+                if (score > bestScore) {
+                  bestScore = score;
+                  bestMember = rule.member;
+                  bestKeywords = matched;
+                }
+              }
+
+              if (bestMember) {
+                assignedMember = bestMember;
+                triageReason = `Matched routing keywords: ${bestKeywords.join(', ')}`;
               }
             }
 

--- a/.squad/templates/workflows/squad-triage.yml
+++ b/.squad/templates/workflows/squad-triage.yml
@@ -142,43 +142,76 @@ jobs:
               }
             }
 
-            // If not routed to @copilot, use keyword-based routing
-            if (!assignedMember) {
-              for (const member of members) {
-                const role = member.role.toLowerCase();
-                if ((role.includes('frontend') || role.includes('ui')) &&
-                    (issueText.includes('ui') || issueText.includes('frontend') ||
-                     issueText.includes('css') || issueText.includes('component') ||
-                     issueText.includes('button') || issueText.includes('page') ||
-                     issueText.includes('layout') || issueText.includes('design'))) {
-                  assignedMember = member;
-                  triageReason = 'Issue relates to frontend/UI work';
+            // If not routed to @copilot, use routing.md keyword scoring
+            if (!assignedMember && routingContent) {
+              // Parse "Work Type → Agent" table from routing.md
+              const routingRules = [];
+              const routingLines = routingContent.split('\n');
+              let inRoutingTable = false;
+              let pastSeparator = false;
+
+              for (const rline of routingLines) {
+                if (rline.match(/^#+.*Work Type/i)) {
+                  inRoutingTable = true;
+                  pastSeparator = false;
+                  continue;
+                }
+                if (inRoutingTable && /^#+\s/.test(rline) && !rline.match(/Work Type/i)) {
                   break;
                 }
-                if ((role.includes('backend') || role.includes('api') || role.includes('server')) &&
-                    (issueText.includes('api') || issueText.includes('backend') ||
-                     issueText.includes('database') || issueText.includes('endpoint') ||
-                     issueText.includes('server') || issueText.includes('auth'))) {
-                  assignedMember = member;
-                  triageReason = 'Issue relates to backend/API work';
-                  break;
+                if (inRoutingTable && rline.includes('---')) {
+                  pastSeparator = true;
+                  continue;
                 }
-                if ((role.includes('test') || role.includes('qa') || role.includes('quality')) &&
-                    (issueText.includes('test') || issueText.includes('bug') ||
-                     issueText.includes('fix') || issueText.includes('regression') ||
-                     issueText.includes('coverage'))) {
-                  assignedMember = member;
-                  triageReason = 'Issue relates to testing/quality work';
-                  break;
+                if (inRoutingTable && pastSeparator && rline.startsWith('|')) {
+                  const cells = rline.split('|').map(c => c.trim()).filter(Boolean);
+                  if (cells.length >= 2) {
+                    const keywords = cells[0].toLowerCase().split(',').map(s => s.trim()).filter(Boolean);
+                    const memberName = cells[1].trim();
+                    // Skip placeholder/empty rows
+                    if (memberName.startsWith('{') || memberName === '—' || memberName === '-') continue;
+                    const member = members.find(m => m.name.toLowerCase() === memberName.toLowerCase());
+                    if (member) {
+                      routingRules.push({ member, keywords });
+                    }
+                  }
                 }
-                if ((role.includes('devops') || role.includes('infra') || role.includes('ops')) &&
-                    (issueText.includes('deploy') || issueText.includes('ci') ||
-                     issueText.includes('pipeline') || issueText.includes('docker') ||
-                     issueText.includes('infrastructure'))) {
-                  assignedMember = member;
-                  triageReason = 'Issue relates to DevOps/infrastructure work';
-                  break;
+              }
+
+              // Score each member by weighted keyword matches.
+              // Multi-word phrases are more specific and score higher than
+              // single common words like "review" or "tests".
+              // NOTE: Review keyword weights when adding or retiring team
+              // members — the balance depends on relative specificity across
+              // the whole routing table.
+              function keywordWeight(kw) {
+                const words = kw.split(/\s+/).length;
+                return words * words; // 1-word=1, 2-word=4, 3-word=9
+              }
+
+              let bestScore = 0;
+              let bestMember = null;
+              let bestKeywords = [];
+
+              for (const rule of routingRules) {
+                let score = 0;
+                const matched = [];
+                for (const kw of rule.keywords) {
+                  if (issueText.includes(kw)) {
+                    score += keywordWeight(kw);
+                    matched.push(kw);
+                  }
                 }
+                if (score > bestScore) {
+                  bestScore = score;
+                  bestMember = rule.member;
+                  bestKeywords = matched;
+                }
+              }
+
+              if (bestMember) {
+                assignedMember = bestMember;
+                triageReason = `Matched routing keywords: ${bestKeywords.join(', ')}`;
               }
             }
 


### PR DESCRIPTION
## Problem

The `squad-triage` workflow used hardcoded role categories (`frontend`, `backend`, `test/qa`, `devops`) to route issues to team members. This team's roles (Lead, Go Dev, CLI Dev, Tester, Staff Developer, Artificer) don't match those categories.

**Lambert (Tester)** was the only member whose role matched any category (`test/qa`), and her trigger keywords (`test`, `bug`, `fix`, `regression`, `coverage`) appeared in virtually every issue body. Result: **every issue routed to Lambert**.

## Fix

Replace hardcoded routing with **routing.md-based keyword scoring**:

1. Parse the `Work Type → Agent` table from `routing.md` (which the workflow already read but ignored)
2. Score each member by matching their keywords against the issue text
3. **Weight multi-word phrases higher** (`word_count²`) so specific terms like `design patterns` (weight 4) or `technical debt` (weight 4) outweigh generic words like `review` (weight 1) or `tests` (weight 1)
4. Highest-scoring member wins; Lead as fallback when nothing matches

## Before / After

| Issue | Before | After |
|-------|--------|-------|
| #192 (command helpers) | Lambert | **Kane** (commands, config) |
| #198 (LegendData types) | Lambert | **Bishop** (type design, api design) |
| #196 (border metric color) | Lambert | **Dallas** (metrics) |
| #205 (treemap size metric) | Lambert | **Kane** (commands, config, wiring) |

## Maintenance Note

The weighting function (`words² → 1/4/9`) should be reviewed when adding or retiring team members, since the balance depends on relative keyword specificity across the routing table.

## Changes

- `.github/workflows/squad-triage.yml` — live workflow
- `.squad/templates/workflows/squad-triage.yml` — template for new installs