### PR TITLE
Fix SVG text labels invisible due to FontSize: 0

### DIFF
--- a/internal/canvas/backend.go
+++ b/internal/canvas/backend.go
@@ -6,3 +6,7 @@ import (
 
 // Backend is re-exported from model for backward compatibility.
 type Backend = model.Backend
+
+// DefaultFontSize signals that the backend should use its built-in default
+// font size. Callers can set FontSize to this value instead of a bare 0.
+const DefaultFontSize = model.DefaultFontSize

--- a/internal/canvas/model/backend.go
+++ b/internal/canvas/model/backend.go
@@ -41,3 +41,7 @@ const (
 	// AnchorEnd aligns text to the right.
 	AnchorEnd
 )
+
+// DefaultFontSize signals that the backend should use its built-in default
+// font size. Callers can set FontSize to this value instead of a bare 0.
+const DefaultFontSize float64 = 0

--- a/internal/canvas/raster/backend.go
+++ b/internal/canvas/raster/backend.go
@@ -18,6 +18,10 @@ import (
 
 const jpegQuality = 95
 
+// defaultFontSize is the font size used when callers pass fontSize <= 0,
+// indicating "use the backend's default".
+const defaultFontSize = 12.0
+
 type rasterBackend struct {
 	dc *gg.Context
 }
@@ -115,6 +119,10 @@ func (r *rasterBackend) DrawArcText(
 ) {
 	if text == "" || radius <= 0 {
 		return
+	}
+
+	if fontSize <= 0 {
+		fontSize = defaultFontSize
 	}
 
 	r.dc.SetColor(ink)

--- a/internal/canvas/raster/backend.go
+++ b/internal/canvas/raster/backend.go
@@ -11,7 +11,10 @@ import (
 	"strings"
 
 	"github.com/fogleman/gg"
+	"github.com/golang/freetype/truetype"
 	"github.com/rotisserie/eris"
+	"golang.org/x/image/font"
+	"golang.org/x/image/font/gofont/goregular"
 
 	"github.com/theunrepentantgeek/code-visualizer/internal/canvas/model"
 )
@@ -21,6 +24,27 @@ const jpegQuality = 95
 // defaultFontSize is the font size used when callers pass fontSize <= 0,
 // indicating "use the backend's default".
 const defaultFontSize = 12.0
+
+// goFont is the parsed Go Regular TrueType font, used to create
+// font faces at arbitrary point sizes.
+//
+//nolint:gochecknoglobals // parsed once, read-only after init
+var goFont *truetype.Font
+
+func init() {
+	var err error
+
+	goFont, err = truetype.Parse(goregular.TTF)
+	if err != nil {
+		panic("raster: failed to parse Go Regular font: " + err.Error())
+	}
+}
+
+// fontFaceForSize returns a font.Face for the Go Regular font at the given
+// point size.
+func fontFaceForSize(points float64) font.Face {
+	return truetype.NewFace(goFont, &truetype.Options{Size: points})
+}
 
 type rasterBackend struct {
 	dc *gg.Context
@@ -92,10 +116,12 @@ func (r *rasterBackend) DrawText(
 	anchor model.TextAnchor,
 	rotation float64,
 ) {
+	if fontSize <= 0 {
+		fontSize = defaultFontSize
+	}
+
+	r.dc.SetFontFace(fontFaceForSize(fontSize))
 	r.dc.SetColor(ink)
-	// fontSize is accepted for interface conformance but requires a loaded
-	// font face to take effect; the default gg font ignores size changes.
-	_ = fontSize
 
 	ax := anchorX(anchor)
 
@@ -125,6 +151,7 @@ func (r *rasterBackend) DrawArcText(
 		fontSize = defaultFontSize
 	}
 
+	r.dc.SetFontFace(fontFaceForSize(fontSize))
 	r.dc.SetColor(ink)
 
 	arcRadius := radius - 14.0

--- a/internal/canvas/raster/backend_test.go
+++ b/internal/canvas/raster/backend_test.go
@@ -163,6 +163,117 @@ func TestRasterBackend_ImplementsBackendInterface(t *testing.T) {
 	g.Expect(b).NotTo(BeNil())
 }
 
+func TestRasterBackend_DrawArcText_ProducesValidPNG(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	b := New(400, 400)
+	blk := color.RGBA{A: 255}
+
+	b.DrawArcText(
+		model.Position{X: 200, Y: 200},
+		100, "hello", blk, 14.0,
+	)
+
+	out := filepath.Join(t.TempDir(), "arctext.png")
+	err := b.Finish(out)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	img := loadImage(t, out)
+	g.Expect(img.Bounds().Dx()).To(Equal(400))
+}
+
+func TestRasterBackend_DrawArcText_FontSizeZero_ProducesValidPNG(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	b := New(400, 400)
+	blk := color.RGBA{A: 255}
+
+	b.DrawArcText(
+		model.Position{X: 200, Y: 200},
+		100, "hello", blk, 0,
+	)
+
+	out := filepath.Join(t.TempDir(), "arctext-zero.png")
+	err := b.Finish(out)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	img := loadImage(t, out)
+	g.Expect(img.Bounds().Dx()).To(Equal(400))
+}
+
+func TestRasterBackend_DrawText_FontSizeZero_ProducesValidPNG(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	b := New(200, 100)
+	blk := color.RGBA{A: 255}
+
+	b.DrawText(
+		model.Position{X: 100, Y: 50},
+		"hello", blk, 0,
+		model.AnchorMiddle, 0,
+	)
+
+	out := filepath.Join(t.TempDir(), "text-zero.png")
+	err := b.Finish(out)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	info, err := os.Stat(out)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	if info != nil {
+		g.Expect(info.Size()).To(BeNumerically(">", 0))
+	}
+}
+
+func TestRasterBackend_DrawText_RespectsCustomFontSize(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	// Render the same text at two different font sizes and verify both produce
+	// valid output with different pixel content (larger font = more ink).
+	small := New(200, 100)
+	blk := color.RGBA{A: 255}
+
+	small.DrawText(
+		model.Position{X: 100, Y: 50},
+		"Hello", blk, 10.0,
+		model.AnchorMiddle, 0,
+	)
+
+	outSmall := filepath.Join(t.TempDir(), "text-small.png")
+	err := small.Finish(outSmall)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	large := New(200, 100)
+
+	large.DrawText(
+		model.Position{X: 100, Y: 50},
+		"Hello", blk, 28.0,
+		model.AnchorMiddle, 0,
+	)
+
+	outLarge := filepath.Join(t.TempDir(), "text-large.png")
+	err = large.Finish(outLarge)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	infoSmall, err := os.Stat(outSmall)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	infoLarge, err := os.Stat(outLarge)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Larger text produces a different (usually larger) PNG due to more ink.
+	g.Expect(infoSmall).NotTo(BeNil())
+	g.Expect(infoLarge).NotTo(BeNil())
+
+	if infoSmall != nil && infoLarge != nil {
+		g.Expect(infoSmall.Size()).NotTo(Equal(infoLarge.Size()))
+	}
+}
+
 func loadImage(t *testing.T, path string) image.Image {
 	t.Helper()
 

--- a/internal/canvas/svg/backend.go
+++ b/internal/canvas/svg/backend.go
@@ -16,6 +16,10 @@ import (
 	"github.com/theunrepentantgeek/code-visualizer/internal/canvas/model"
 )
 
+// defaultFontSize is the font size used when callers pass fontSize <= 0,
+// indicating "use the backend's default".
+const defaultFontSize = 12.0
+
 type svgBackend struct {
 	width  int
 	height int
@@ -89,6 +93,10 @@ func (s *svgBackend) DrawText(
 	anchor model.TextAnchor,
 	rotation float64,
 ) {
+	if fontSize <= 0 {
+		fontSize = defaultFontSize
+	}
+
 	anchorStr := svgAnchor(anchor)
 	escaped := html.EscapeString(text)
 
@@ -122,6 +130,10 @@ func (s *svgBackend) DrawArcText(
 ) {
 	if text == "" || radius <= 0 {
 		return
+	}
+
+	if fontSize <= 0 {
+		fontSize = defaultFontSize
 	}
 
 	arcR := radius - 14.0

--- a/internal/canvas/svg/backend_test.go
+++ b/internal/canvas/svg/backend_test.go
@@ -143,6 +143,74 @@ func TestSVGBackend_DrawArcText_ProducesValidSVG(t *testing.T) {
 	g.Expect(content).To(ContainSubstring("<textPath"))
 }
 
+func TestSVGBackend_DrawText_FontSizeZero_UsesDefault(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	b := New(200, 100)
+	blk := color.RGBA{A: 255}
+
+	b.DrawText(
+		model.Position{X: 100, Y: 50},
+		"hello", blk, 0,
+		model.AnchorMiddle, 0,
+	)
+
+	out := filepath.Join(t.TempDir(), "text-zero.svg")
+	err := b.Finish(out)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	content := readFile(t, out)
+	g.Expect(content).To(ContainSubstring("<text"))
+	g.Expect(content).NotTo(ContainSubstring(`font-size="0`))
+	g.Expect(content).To(ContainSubstring(`font-size="12.0"`))
+}
+
+func TestSVGBackend_DrawText_FontSizeNegative_UsesDefault(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	b := New(200, 100)
+	blk := color.RGBA{A: 255}
+
+	b.DrawText(
+		model.Position{X: 100, Y: 50},
+		"hello", blk, -5.0,
+		model.AnchorMiddle, 0,
+	)
+
+	out := filepath.Join(t.TempDir(), "text-neg.svg")
+	err := b.Finish(out)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	content := readFile(t, out)
+	g.Expect(content).NotTo(ContainSubstring(`font-size="0`))
+	g.Expect(content).NotTo(ContainSubstring(`font-size="-`))
+	g.Expect(content).To(ContainSubstring(`font-size="12.0"`))
+}
+
+func TestSVGBackend_DrawArcText_FontSizeZero_UsesDefault(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	b := New(400, 400)
+	blk := color.RGBA{A: 255}
+
+	b.DrawArcText(
+		model.Position{X: 200, Y: 200},
+		100, "hello", blk, 0,
+	)
+
+	out := filepath.Join(t.TempDir(), "arctext-zero.svg")
+	err := b.Finish(out)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	content := readFile(t, out)
+	g.Expect(content).To(ContainSubstring("<textPath"))
+	g.Expect(content).NotTo(ContainSubstring(`font-size="0`))
+	g.Expect(content).To(ContainSubstring(`font-size="12.0"`))
+}
+
 func TestSVGBackend_ImplementsBackendInterface(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)


### PR DESCRIPTION
All text labels in SVG output were invisible because every TextSpec set FontSize: 0, which the SVG backend wrote as `font-size="0.0"`. The raster backend ignores FontSize and uses its built-in default, so PNG output was unaffected.

Now both backends treat `fontSize <= 0` as "use default" and substitute a sensible 12px default. Also added `model.DefaultFontSize` constant to document the convention.

Fixes #190