### PR TITLE
Remove dead canvas API fields and unimplemented stubs

### DIFF
--- a/.squad/agents/bishop/history.md
+++ b/.squad/agents/bishop/history.md
@@ -131,3 +131,27 @@
 - **Spec finalized:** All 5 key design decisions codified and approved. Ready for implementation kickoff.
 - **Team log:** `.squad/log/2026-05-09T02:59:06Z-canvas-spec-review.md`
 - **Decisions merged:** All inbox items → `decisions.md`. Specifications finalized.
+
+### Issue #193 — Replace layeredShape Tagged Union with Go Interface (2026-07-16)
+
+- **Status:** ✅ Complete
+- **PR:** #212
+- **Branch:** `squad/193-layered-shape-interface`
+
+**What changed:**
+- Deleted `shapeKind` type (iota enum) and its 6 constants from `canvas.go`
+- Replaced 6-pointer tagged union in `layeredShape` with single `shape drawnShape` interface field
+- Defined `drawnShape` interface: `drawTo(backend Backend)`
+- Added `drawTo` method to each concrete shape type: `Rectangle`, `Disc`, `Text`, `Line`, `Path` (in `shape.go`), `ArcText` (in `text_spec.go`)
+- Deleted `dispatchShape` switch and 6 `Canvas.draw*` helper methods
+- Simplified all 6 `Add*` methods on Canvas — no more `kind` field or named pointer fields
+- Net result: -37 lines (81 added, 118 deleted across 3 files)
+
+**Key files:**
+- `internal/canvas/canvas.go` — `drawnShape` interface, simplified `layeredShape`, cleaned `Add*` methods, removed dispatch
+- `internal/canvas/shape.go` — `drawTo` on Rectangle, Disc, Text, Line, Path
+- `internal/canvas/text_spec.go` — `drawTo` on ArcText
+
+**Pattern observed:**
+- The old `Canvas.draw*` methods had unused `*Canvas` receivers — pure functions masquerading as methods. Moving them to shape types was zero-friction because they were already stateless. This is the classic signal that logic belongs on the data it operates on, not on the coordinator that holds it.
+- Adding a new shape is now safe by construction: implement `drawnShape`, and the compiler ensures it works end-to-end. No enum, no switch, no nullable pointer field to maintain.

--- a/.squad/agents/bishop/reviews/radial-canvas-review.md
+++ b/.squad/agents/bishop/reviews/radial-canvas-review.md
@@ -1,0 +1,68 @@
+# Bishop: Radial Canvas Migration Review
+
+## Summary
+
+Clean, well-structured migration that correctly follows the Canvas bridge pattern established by treemap and spiral. The data flow is sound, layer usage is correct, and the colour pipeline has been properly shifted from pre-applied node fields to deferred Ink resolution. Three lint warnings need fixing, and one piece of dead code was left behind by the deletions.
+
+## Issues Found
+
+### Minor: Lint — `isDir` control flag coupling
+- **File:** `cmd/codeviz/radial_canvas.go:229` and `:239`
+- **Problem:** `revive` flags `isDir` parameter as control coupling in `radialFillInk` and `radialMetricValue`. In `radialMetricValue`, the `isDir` guard is redundant — `file` is already `nil` for directory nodes, so `file == nil` alone suffices.
+- **Fix:** For `radialMetricValue`, drop the `isDir` parameter and rely on `file == nil`. For `radialFillInk`, consider inlining the decision at the call site in `addRadialDisc` instead of branching inside the function.
+
+### Minor: Lint — missing blank line above declaration
+- **File:** `cmd/codeviz/radial_canvas.go:310`
+- **Problem:** `wsl_v5` requires whitespace before `var rotation float64` when preceded by another `var` declaration.
+- **Fix:** Add a blank line between `var anchor canvas.TextAnchor` and `var rotation float64`, matching the spiral_canvas.go pattern at line 233.
+
+### Minor: Orphaned code from deletions
+- **File:** `internal/render/renderer_test.go:8` — `func makeFile` now unused
+- **File:** `internal/render/svg_helpers.go:38` — `func writeSVGTextRotated` now unused
+- **Problem:** Deleting `radialtree_test.go` and `svg_radial.go` left these helper functions without callers. This causes two `unused` lint errors.
+- **Fix:** Delete both orphaned functions in this PR so lint stays green.
+
+### Minor: Missing `FontSize: 0` in TextSpec
+- **File:** `cmd/codeviz/radial_canvas.go:266` and `:320`
+- **Problem:** The `TextSpec` structs in `addRadialRootLabel` and `addRadialExternalLabel` omit `FontSize: 0`. While Go zero-values handle this correctly, both `treemap_canvas.go` (lines 165, 231) and `spiral_canvas.go` (line 245) explicitly set `FontSize: 0`. Inconsistency across bridges.
+- **Fix:** Add `FontSize: 0` to both TextSpec literals for uniformity. This is cosmetic but aids grep-ability and pattern consistency.
+
+### Observation: `radialEffectiveFill` unreachable file path
+- **File:** `cmd/codeviz/radial_canvas.go:336-342`
+- **Problem:** `radialEffectiveFill` is only called from `addRadialRootLabel`, which is only reached when `dist == 0` (i.e., the root node). The root node is always a directory, so the `!node.IsDirectory` branch (`inks.fill.Dip(canvas.MetricValue{})`) is unreachable. If it were reached, it would dip with an empty MetricValue, returning the first bucket colour rather than the actual file colour. Not a bug today, but a latent defect if the function is ever reused.
+- **Fix:** No action required now. If the function scope widens, it would need the file's MetricValue passed in.
+
+## What Looks Good
+
+1. **Layer usage is correct:** Background=0 (white rect), Structure=10 (edges), Content=20 (discs), Overlay=30 (labels). Matches spec and other bridges.
+
+2. **Disc sorting preserved:** Largest-first draw order (`slices.SortFunc` with `cmp.Compare(b, a)`) correctly prevents small discs from being occluded. Faithful port from old renderer.
+
+3. **Ink construction pattern:** `buildRadialInks` → `buildMetricInk` (shared helper) follows the treemap bridge exactly. Properly handles the fill-always / border-optional asymmetry.
+
+4. **Parallel tree walk:** `collectRadialDiscs` correctly walks `RadialNode` and `model.Directory` trees in parallel using the files-first/dirs-second invariant. This is the right approach for deferred colour resolution.
+
+5. **Label geometry:** Radial label positioning (angle normalization, anchor flip, label gap) matches the old renderer's behaviour and is consistent with spiral_canvas.go's approach.
+
+6. **Legend deferral:** `slog.Warn` for unimplemented legend matches the spiral_cmd.go pattern.
+
+7. **Node stripping is clean:** Removing `FillColour` and `BorderColour` from `RadialNode` correctly makes it geometry-only, matching the Canvas spec's principle of separating layout from colour.
+
+8. **Error propagation:** `eris.Wrap(err, "render failed")` is consistent with other command pipelines.
+
+## Testing Gaps to Consider
+
+1. **No bridge-level tests exist** — `radial_canvas.go` has no `_test.go`. The treemap bridge also lacks unit tests, so this isn't a regression, but both would benefit from mock-backend tests (using `RenderTo` with a stub `Backend`).
+
+2. **Edge cases worth testing:**
+   - Empty root directory (no files, no subdirs) — does `collectRadialDiscs` return empty?
+   - Single file in root — does the parallel tree walk pair correctly?
+   - Deeply nested directories — does recursion work without stack issues at ~100 levels?
+   - Node with `ShowLabel=false` — confirm no text shapes added
+   - Node with `DiscRadius=0` — confirm it's excluded from disc entries but children are still walked
+
+3. **Ink edge case:** `buildRadialInks` with unknown `fillMetric` (provider not found) — should return fixed ink fallback. The shared `buildMetricInk` handles this, but it's worth a test.
+
+## Approved
+
+**Yes, with fixes** — the three lint issues (control flag, whitespace, orphaned code) should be resolved before merge. The FontSize consistency is optional but recommended.

--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -238,3 +238,10 @@ This is an accumulation of foundational learnings and architecture decisions fro
 - **Spec finalized:** All 5 key design decisions codified and approved. Ready for implementation kickoff.
 - **Team log:** `.squad/log/2026-05-09T02:59:06Z-canvas-spec-review.md`
 - **Decisions merged:** All inbox items → `decisions.md`. Specifications finalized.
+
+### Spiral layout struct — Issue #204 (2026-05-09)
+
+- **Change:** `spiral.Layout()` now returns `SpiralLayout` struct instead of `[]SpiralNode`. The struct bundles nodes with Archimedean spiral parameters (CX, CY, A, B, MaxTheta) so callers don't need to re-derive them.
+- **Deleted:** `inferSpiralTrackParams` and `spiralTrackParams` in `cmd/codeviz/spiral_canvas.go` — the bridge no longer reconstructs spiral geometry from node positions.
+- **Key files:** `internal/spiral/layout.go` (struct + return type), `cmd/codeviz/spiral_canvas.go` (track drawing uses layout params directly), `cmd/codeviz/spiral_cmd.go` (caller updated).
+- **PR:** #213, branch `squad/204-spiral-track-params`.

--- a/.squad/agents/kane/history.md
+++ b/.squad/agents/kane/history.md
@@ -166,3 +166,13 @@
 - **Testing:** All tests pass, zero regressions
 - **Committed:** `squad/161-extract-progress-ticker`
 - **PR:** #166
+
+### Issue #205 — Treemap Size Metric Accept Measure (2026-07-15)
+
+- **Status:** ✅ Complete
+- **Problem:** `TreemapCmd.validateConfig` only accepted `metric.Quantity` for size, rejecting `Measure` metrics like `commit-density`. The layout function `fileSize` in `internal/treemap/layout.go` only called `f.Quantity()`.
+- **Fix:** Two surgical changes:
+  1. `internal/treemap/layout.go:fileSize` — now tries `Quantity` first, then falls back to `Measure` (matching `bubbletree/layout.go:fileMetricValue` and `radialtree/layout.go:fileMetricValue`).
+  2. `cmd/codeviz/treemap_cmd.go:validateConfig` — validation now accepts `metric.Quantity || metric.Measure` (matching bubbletree and radial).
+- **Pattern:** All three viz commands (treemap, bubbletree, radial) now consistently accept both Quantity and Measure for size metrics.
+- **PR:** #209

--- a/.squad/agents/parker/history.md
+++ b/.squad/agents/parker/history.md
@@ -114,3 +114,11 @@ Reviewed PR #39 (issue #38) adding `Scope()` and `Description()` to `provider.In
 - **Spec finalized:** All 5 key design decisions codified and approved. Ready for implementation kickoff.
 - **Team log:** `.squad/log/2026-05-09T02:59:06Z-canvas-spec-review.md`
 - **Decisions merged:** All inbox items → `decisions.md`. Specifications finalized.
+
+### SVG FontSize: 0 fix (PR #210, issue #190)
+
+- **Root cause:** All `TextSpec` instances across all four visualization types set `FontSize: 0`. The SVG backend wrote this verbatim as `font-size="0.0"` — zero-height text that browsers don't render. The raster `DrawText` ignores fontSize entirely (`_ = fontSize`), so PNG was unaffected.
+- **Secondary bug:** Raster `DrawArcText` uses fontSize for arc math (`totalAngle = len(text) * fontSize * 0.6 / arcRadius`). With fontSize=0, totalAngle=0, collapsing all characters to the same point. Not previously reported because the built-in gg font still draws *something*, but positioning was wrong.
+- **Fix:** Added `defaultFontSize = 12.0` constant in both `internal/canvas/svg/backend.go` and `internal/canvas/raster/backend.go`. Both `DrawText` (SVG only) and `DrawArcText` (both backends) now substitute the default when `fontSize <= 0`.
+- **Convention documented:** Added `model.DefaultFontSize` (= 0) in `internal/canvas/model/backend.go` so callers can write `FontSize: model.DefaultFontSize` instead of a bare `0`, making the "use default" intent explicit.
+- **Callers unchanged:** The `*_canvas.go` files still pass `FontSize: 0` — the backends now honour the convention rather than requiring callers to pick a size.

--- a/.squad/agents/parker/reviews/radial-canvas-review.md
+++ b/.squad/agents/parker/reviews/radial-canvas-review.md
@@ -1,0 +1,80 @@
+# Parker: Radial Canvas Migration Review
+
+## Summary
+
+Solid migration that faithfully reproduces the old three-pass rendering logic (edges → discs → labels) via the Canvas retained-mode API. Architecture follows treemap/spiral bridge patterns correctly. However, the branch introduces **6 lint failures** (3 in new code, 3 from orphaned symbols in deleted-file dependants) that block CI.
+
+## Issues Found
+
+### Major: Orphaned `makeFile` in renderer_test.go
+
+- **File:** internal/render/renderer_test.go:8
+- **Problem:** Deleting `radialtree_test.go` removed all callers of `makeFile`, leaving an unused function that fails the `unused` linter. This was not an issue on main.
+- **Fix:** Delete or relocate `makeFile`. If other test files in `internal/render/` still exist and could use it, keep it; otherwise remove.
+
+### Major: Orphaned `writeSVGTextRotated` in svg_helpers.go
+
+- **File:** internal/render/svg_helpers.go:38
+- **Problem:** Deleting `svg_radial.go` removed all callers of `writeSVGTextRotated`, leaving an unused function that fails the `unused` linter. Not an issue on main.
+- **Fix:** Delete the function if no other SVG renderer uses it. If bubble/treemap SVG renderers are still in-flight, consider whether they'll need it.
+
+### Major: Stale nolint directive in bubbletree_cmd.go
+
+- **File:** cmd/codeviz/bubbletree_cmd.go:397
+- **Problem:** The `//nolint:dupl` directive was suppressing a duplicate warning between the bubbletree and radial versions of `applyBorderColours`. With the radial version deleted, `dupl` no longer fires, so the directive is unused and `nolintlint` flags it.
+- **Fix:** Remove the `//nolint:dupl` comment from `bubbletree_cmd.go:397`.
+
+### Minor: flag-parameter lint on `radialFillInk`
+
+- **File:** cmd/codeviz/radial_canvas.go:229
+- **Problem:** `isDir bool` parameter triggers revive `flag-parameter` — a control flag selects between two code paths.
+- **Fix:** Inline the check at the call site in `addRadialDisc` (line 210):
+  ```go
+  fill := inks.fill
+  if e.isDir {
+      fill = canvas.FixedInk(radialDefaultDirFill)
+  }
+  ```
+  Then delete `radialFillInk`.
+
+### Minor: flag-parameter lint on `radialMetricValue`
+
+- **File:** cmd/codeviz/radial_canvas.go:239
+- **Problem:** `isDir bool` parameter is redundant — directories always have `file == nil`. The bool triggers revive `flag-parameter`.
+- **Fix:** Remove the `isDir` parameter. The existing `file == nil` check is sufficient:
+  ```go
+  func radialMetricValue(file *model.File, ink canvas.Ink) canvas.MetricValue {
+      if file == nil {
+          return canvas.MetricValue{}
+      }
+      return metricValueForFile(file, ink)
+  }
+  ```
+
+### Minor: wsl_v5 blank line violation
+
+- **File:** cmd/codeviz/radial_canvas.go:310
+- **Problem:** `var rotation float64` is cuddled with the preceding `var anchor` declaration. `wsl_v5` requires a blank line before a new `var` declaration block.
+- **Fix:** Add blank line between the two `var` declarations (matching the pattern in `spiral_canvas.go:231-233`).
+
+## Correctness Notes (No Issues)
+
+- **Colour constants:** All 6 colour values match the old renderer exactly.
+- **Disc z-order:** Collect → sort descending by DiscRadius → draw. Faithful port.
+- **Label rotation:** Half-plane check (`angle <= π/2 || angle > 3π/2`), anchor flip, and angle+π offset all match the old `drawExternalLabel`.
+- **Root label contrast:** `radialEffectiveFill` returns `radialDefaultDirFill` for root (always a directory), then `TextColourFor()` computes contrast. Matches old `effectiveFill` behaviour.
+- **Tree walk invariant:** `collectRadialDiscs` uses `fileIdx`/`dirIdx` counters dispatched by `IsDirectory`, identical to the old `applyRadialFillColours` pattern and treemap's `addTreemapRect`.
+- **Edge width:** 0.5 matches the old renderer.
+- **Border width on discs:** 1.0 matches old `drawSingleDisc`.
+- **Empty directories / no children:** Handled correctly — parent disc still added, child loop is a no-op.
+- **Nil border metric:** `buildRadialInks` keeps `FixedInk(radialDefaultBorder)` when `borderMetric == ""`. Correct.
+- **`buildMetricInk` / `metricValueForFile` reuse:** Correctly shared from `treemap_canvas.go`. Same function, same semantics.
+- **Canvas layer assignments:** Background → Structure (edges) → Content (discs) → Overlay (labels). Correct z-ordering via Canvas layer system.
+
+## Legend Note
+
+Legend rendering is deferred with `slog.Warn`. This is expected — Canvas `SetLegend` exists but legend rendering is not yet implemented per the Canvas spec. Not a regression since the old legend path would need a Canvas-native rewrite.
+
+## Approved
+
+**Yes, with fixes** — the 3 Major lint issues (orphaned symbols + stale nolint) and 3 Minor lint issues must be resolved before merge. All are mechanical fixes. The rendering logic itself is correct.

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -149,3 +149,14 @@
 - **Stage 1 scope:** Dark-shipped package — zero changes to existing code. Full test coverage in isolation.
 - **Plan saved to:** `docs/superpowers/plans/2026-05-09-canvas-stage1.md`
 
+### Issue #196 — Directory Border Metric Color Fix (2026-07-21)
+
+- **Task:** Fix directory nodes always rendering with wrong border metric color in bubbletree and radial.
+- **Root cause:** Directory entries had no file to resolve metric values from, so `MetricValue{}` was passed to metric-based border inks, producing the minimum-value color instead of the default border color.
+- **Fix pattern:** Use `canvas.FixedInk(defaultBorder)` for directory border ink, matching the existing pattern for directory fill ink. Both visualizations already had default border color constants.
+- **Bubble (`bubble_canvas.go`):** Replaced `inks.border` with `canvas.FixedInk(bubbleDefaultBorder)` in `dirSpec`. Removed unused `inks` parameter from `addBubbleDirDiscs`.
+- **Radial (`radial_canvas.go`):** Added `border` variable alongside `fill`, overridden to `canvas.FixedInk(radialDefaultBorder)` when `e.isDir`. Used `border` in `discSpec` instead of `inks.border`.
+- **Key files:** `cmd/codeviz/bubble_canvas.go`, `cmd/codeviz/radial_canvas.go`.
+- **Lint fixes:** Removed unused parameter (`revive`), added blank line before `if` block (`wsl_v5`).
+- **Result:** PR #211 opened. All tests pass, zero lint issues.
+

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -856,3 +856,130 @@ User directive: **Don't push all testing work to Lambert.** Distribute test work
 - Dallas, Bishop, Kane responsible for unit tests in their respective areas
 - Lambert focuses on integration, system, and cross-component scenarios
 - Test distribution is implicit in issue scoping — each issue includes its own test coverage responsibility
+
+---
+
+### Replace layeredShape Tagged Union with drawnShape Interface
+
+**Author:** Bishop (Artificer)  
+**Date:** 2026-05-11  
+**Status:** Implemented (PR #212)  
+**Issue:** #193
+
+## Context
+
+`layeredShape` in `internal/canvas/canvas.go` used a C-style discriminated union: a `shapeKind` iota tag with six nullable pointer fields. Adding a shape required updating the enum, struct, switch, and draw method — four coordinated changes with no compiler enforcement.
+
+## Decision
+
+Replace the tagged union with a Go interface:
+
+```go
+type drawnShape interface {
+    drawTo(backend Backend)
+}
+
+type layeredShape struct {
+    layer Layer
+    order int
+    shape drawnShape
+}
+```
+
+Each shape type (`Rectangle`, `Disc`, `Text`, `Line`, `Path`, `ArcText`) implements `drawTo`. The `dispatchShape` switch, `shapeKind` type, and its constants are deleted.
+
+## Rationale
+
+- **Compiler-enforced exhaustiveness:** Adding a new shape means implementing `drawnShape`; no switch case can be missed.
+- **Cohesion:** Drawing logic lives on the data it operates on, not on a coordinator. The old `Canvas.draw*` methods had unused `*Canvas` receivers — they were already stateless.
+- **Simplicity:** Net -37 lines. Six pointer fields → one interface field.
+- **Open/Closed Principle:** New shapes extend without modifying existing code.
+
+## Impact
+
+- Canvas `Add*` methods and `RenderTo` are simplified.
+- No test changes required — all 22 test suites pass unchanged.
+- Future shape types (if any) are safe by construction.
+
+---
+
+### Canvas Spiral Migration - Structural Patterns
+
+**Author:** Bishop  
+**Date:** 2026-05-11  
+**Status:** Observation (no blocking decision needed)
+
+## Context
+
+During review of the spiral Canvas migration (Tasks 1–4), observed two bridge patterns emerging:
+
+1. **buildMetricInk** (treemap) - Walks tree structure, pulls metrics from model.File objects
+2. **buildBucketInk** (spiral) - Iterates flat list, pulls pre-aggregated values from TimeBucket via accessor functions
+
+## Pattern Analysis
+
+**buildMetricInk signature:**
+```go
+func buildMetricInk(
+    root *model.Directory,
+    m metric.Name,
+    palName palette.PaletteName,
+    fallback color.RGBA,
+) canvas.Ink
+```
+
+**buildBucketInk signature:**
+```go
+func buildBucketInk(
+    buckets []spiral.TimeBucket,
+    m metric.Name,
+    palName palette.PaletteName,
+    numericFn func(*spiral.TimeBucket) float64,
+    categoryFn func(*spiral.TimeBucket) string,
+    fallback color.RGBA,
+) canvas.Ink
+```
+
+## Structural Implication
+
+These are **not duplicates** - they reflect fundamental data-source differences:
+- Treemap: hierarchical file tree with per-file metrics
+- Spiral: flat time-series with pre-aggregated bucket values
+
+Radial tree and bubble tree visualizations will follow the treemap pattern (tree + File metrics).
+
+## Recommendation
+
+**Do not extract shared abstraction yet.** Wait until radial/bubble migrations complete. If all four viz types use variants of buildMetricInk, then extract to shared `cmd/codeviz/ink_builder.go` or promote to `internal/canvas/ink_builder.go`.
+
+Current state (2 patterns for 2 viz types) is acceptable and reflects legitimate structural differences.
+
+## Action
+
+None required. This is documentation for future refactoring consideration.
+
+---
+
+### Two-Reviewer Gate on Implementation Work
+
+**Author:** Bevan Arps (user directive via Copilot)  
+**Date:** 2026-05-10  
+**Status:** Active
+
+## Directive
+
+All implementation work must be reviewed by both Parker (Staff Developer) and Bishop (Artificer) going forward.
+
+## Scope
+
+- Current spiral migration (all remaining tasks)
+- All future implementation work
+
+## Rationale
+
+The team has been light on code reviews. Two-reviewer gate ensures quality and distributed ownership of changes.
+
+## Implementation
+
+- Each PR requires approvals from both Parker and Bishop before merge
+- Reviewers should use their respective expertise: Parker for maintainability and Go practices, Bishop for design and architecture patterns

--- a/cmd/codeviz/bubble_canvas.go
+++ b/cmd/codeviz/bubble_canvas.go
@@ -46,7 +46,6 @@ func buildBubbleInks(
 	borderPaletteName palette.PaletteName,
 ) bubbleInks {
 	inks := bubbleInks{
-		fill:   canvas.FixedInk(bubbleDefaultFileFill),
 		border: canvas.FixedInk(bubbleDefaultBorder),
 	}
 
@@ -126,7 +125,6 @@ func indexBubbleNodesWalk(
 // bubbleDirEntry holds a directory node for sorted drawing.
 type bubbleDirEntry struct {
 	node *bubbletree.BubbleNode
-	mv   canvas.MetricValue
 }
 
 // addBubbleDirDiscs collects directory nodes from the model tree (via path lookup),
@@ -159,7 +157,6 @@ func addBubbleDirDiscs(
 			X:      e.node.X,
 			Y:      e.node.Y,
 			Radius: e.node.Radius,
-			Border: e.mv,
 		})
 	}
 }

--- a/cmd/codeviz/radial_canvas.go
+++ b/cmd/codeviz/radial_canvas.go
@@ -44,7 +44,6 @@ func buildRadialInks(
 	borderPaletteName palette.PaletteName,
 ) radialInks {
 	inks := radialInks{
-		fill:   canvas.FixedInk(radialDefaultFileFill),
 		border: canvas.FixedInk(radialDefaultBorder),
 	}
 

--- a/cmd/codeviz/treemap_canvas.go
+++ b/cmd/codeviz/treemap_canvas.go
@@ -40,7 +40,6 @@ func buildTreemapInks(
 	borderPaletteName palette.PaletteName,
 ) treemapInks {
 	inks := treemapInks{
-		fill:   canvas.FixedInk(treemapDefaultFill),
 		border: canvas.FixedInk(treemapStructuralBorder),
 	}
 
@@ -219,7 +218,6 @@ func addFileRectForFile(
 		H:      rect.H,
 		Fill:   fillMV,
 		Border: borderMV,
-		Label:  rect.Label,
 	})
 
 	if rect.Label != "" && rect.W >= 40 && rect.H >= 16 {

--- a/internal/canvas/ink.go
+++ b/internal/canvas/ink.go
@@ -56,8 +56,6 @@ func NumericInk(name metric.Name, values []float64, pal palette.ColourPalette, o
 		o(&cfg)
 	}
 
-	// Strategy selection (quantile/linear/logarithmic) not yet implemented;
-	// currently always uses quantile via metric.ComputeBuckets.
 	buckets := metric.ComputeBuckets(values, len(pal.Colours))
 
 	return Ink{

--- a/internal/canvas/ink_options.go
+++ b/internal/canvas/ink_options.go
@@ -1,36 +1,15 @@
 package canvas
 
-// MappingStrategy controls how numeric metric values are mapped to palette colours.
-type MappingStrategy int
-
-const (
-	// Quantile uses equal-count buckets (current default behaviour).
-	Quantile MappingStrategy = iota
-	// Linear uses evenly spaced buckets across the min-max range.
-	Linear
-	// Logarithmic uses log-scale spacing.
-	Logarithmic
-)
-
 // InkOption configures ink behaviour.
 type InkOption func(*inkConfig)
 
 type inkConfig struct {
-	strategy MappingStrategy
-	opacity  float64
+	opacity float64
 }
 
 func defaultInkConfig() inkConfig {
 	return inkConfig{
-		strategy: Quantile,
-		opacity:  1.0,
-	}
-}
-
-// WithMapping sets the mapping strategy for numeric inks.
-func WithMapping(strategy MappingStrategy) InkOption {
-	return func(c *inkConfig) {
-		c.strategy = strategy
+		opacity: 1.0,
 	}
 }
 

--- a/internal/canvas/shape.go
+++ b/internal/canvas/shape.go
@@ -6,7 +6,6 @@ type Rectangle struct {
 	X, Y, W, H float64
 	Fill       MetricValue
 	Border     MetricValue
-	Label      string
 }
 
 // Disc carries geometry and metric values for circular shapes.
@@ -17,7 +16,6 @@ type Disc struct {
 	Angle  float64 // angular position; used for radial/external label orientation
 	Fill   MetricValue
 	Border MetricValue
-	Label  string
 }
 
 // Text carries position and content for standalone text.

--- a/internal/canvas/spec.go
+++ b/internal/canvas/spec.go
@@ -5,9 +5,6 @@ type ShapeStyle struct {
 	Fill        Ink
 	Border      Ink
 	BorderWidth float64
-	ShowLabel   bool
-	LabelInk    Ink
-	LabelStyle  LabelStyle
 }
 
 // RectangleSpec defines the visual template for rectangles.

--- a/internal/canvas/text_spec.go
+++ b/internal/canvas/text_spec.go
@@ -4,18 +4,6 @@ import (
 	"github.com/theunrepentantgeek/code-visualizer/internal/canvas/model"
 )
 
-// LabelStyle controls how labels are rendered on shapes.
-type LabelStyle int
-
-const (
-	// LabelCentered places text centered inside the shape.
-	LabelCentered LabelStyle = iota
-	// LabelArc curves text along a circle boundary (used by bubble tree directories).
-	LabelArc
-	// LabelRadial places text outside the shape, rotated outward (used by radial/spiral).
-	LabelRadial
-)
-
 // TextAnchor is re-exported from model for backward compatibility.
 type TextAnchor = model.TextAnchor
 

--- a/internal/treemap/node.go
+++ b/internal/treemap/node.go
@@ -7,7 +7,6 @@ type TreemapRectangle struct {
 	W           float64
 	H           float64
 	Label       string
-	ShowLabel   bool
 	IsDirectory bool
 	Children    []TreemapRectangle
 }


### PR DESCRIPTION
Removes dead exported fields, types, and initialisation code from the canvas API and related packages.

**Removed:**
1. **ShapeStyle.ShowLabel, .LabelInk, .LabelStyle** — never set by any caller
2. **LabelStyle type and constants** (LabelCentered, LabelArc, LabelRadial) — only referenced through dead ShapeStyle fields
3. **MappingStrategy type, Linear/Logarithmic constants, WithMapping()** — strategy stored but never read; quantile always used
4. **Rectangle.Label and Disc.Label** — set but never read by rendering backends
5. **Dead fill initialisation** in buildTreemapInks, buildRadialInks, buildBubbleInks — struct literal init unconditionally overwritten
6. **TreemapRectangle.ShowLabel** — never assigned, always false
7. **bubbleDirEntry.mv** — never populated (always zero value), field and usage removed

All 22 test packages pass. Build clean. Net -49 lines.

Fixes #195