### PR TITLE
Fix #202: Unify *Inks structs and extract ink builder

### DIFF
--- a/cmd/codeviz/bubble_canvas.go
+++ b/cmd/codeviz/bubble_canvas.go
@@ -31,12 +31,6 @@ const (
 	bubbleMaxArcFraction  = math.Pi / 2.0
 )
 
-// bubbleInks holds the Ink instances for a bubbletree render pass.
-type bubbleInks struct {
-	fill   canvas.Ink
-	border canvas.Ink
-}
-
 // buildBubbleInks creates fill and border inks from metric configuration.
 func buildBubbleInks(
 	root *model.Directory,
@@ -44,8 +38,8 @@ func buildBubbleInks(
 	fillPaletteName palette.PaletteName,
 	borderMetric metric.Name,
 	borderPaletteName palette.PaletteName,
-) bubbleInks {
-	inks := bubbleInks{
+) vizInks {
+	inks := vizInks{
 		border: canvas.FixedInk(bubbleDefaultBorder),
 	}
 
@@ -63,7 +57,7 @@ func renderBubbleToCanvas(
 	nodes *bubbletree.BubbleNode,
 	root *model.Directory,
 	width, height int,
-	inks bubbleInks,
+	inks vizInks,
 ) *canvas.Canvas {
 	cv := canvas.NewCanvas(width, height)
 
@@ -185,7 +179,7 @@ func addBubbleFileDiscs(
 	cv *canvas.Canvas,
 	fileIndex map[string]*bubbletree.BubbleNode,
 	root *model.Directory,
-	inks bubbleInks,
+	inks vizInks,
 ) {
 	addBubbleFileDiscsWalk(cv, fileIndex, root, inks)
 }
@@ -194,7 +188,7 @@ func addBubbleFileDiscsWalk(
 	cv *canvas.Canvas,
 	fileIndex map[string]*bubbletree.BubbleNode,
 	dir *model.Directory,
-	inks bubbleInks,
+	inks vizInks,
 ) {
 	fileSpec := &canvas.DiscSpec{
 		ShapeStyle: canvas.ShapeStyle{

--- a/cmd/codeviz/ink_builder.go
+++ b/cmd/codeviz/ink_builder.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"image/color"
+	"slices"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/canvas"
+	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
+	"github.com/theunrepentantgeek/code-visualizer/internal/model"
+	"github.com/theunrepentantgeek/code-visualizer/internal/palette"
+	"github.com/theunrepentantgeek/code-visualizer/internal/provider"
+)
+
+// buildMetricInk creates an Ink for a given metric, using the appropriate
+// constructor based on the metric kind (numeric vs categorical).
+func buildMetricInk(
+	root *model.Directory,
+	m metric.Name,
+	palName palette.PaletteName,
+	fallback color.RGBA,
+) canvas.Ink {
+	p, ok := provider.Get(m)
+	if !ok {
+		return canvas.FixedInk(fallback)
+	}
+
+	pal := palette.GetPalette(palName)
+
+	if p.Kind() == metric.Quantity || p.Kind() == metric.Measure {
+		values := collectNumericValues(root, m)
+		if len(values) == 0 {
+			return canvas.FixedInk(fallback)
+		}
+
+		return canvas.NumericInk(m, values, pal)
+	}
+
+	types := collectDistinctTypes(root, m)
+
+	return canvas.CategoricalInk(m, types, pal)
+}
+
+// metricValueForFile builds a MetricValue from a file's data for the given ink.
+func metricValueForFile(file *model.File, ink canvas.Ink) canvas.MetricValue {
+	if file == nil {
+		return canvas.MetricValue{}
+	}
+
+	info := ink.Info()
+
+	switch info.Kind {
+	case canvas.InkNumeric:
+		m := info.MetricName
+		if v, ok := file.Quantity(m); ok {
+			return canvas.MetricValue{Kind: metric.Quantity, Quantity: int(v)}
+		}
+
+		if v, ok := file.Measure(m); ok {
+			return canvas.MetricValue{Kind: metric.Measure, Measure: v}
+		}
+
+		return canvas.MetricValue{}
+	case canvas.InkCategorical:
+		m := info.MetricName
+		if v, ok := file.Classification(m); ok {
+			return canvas.MetricValue{Kind: metric.Classification, Category: v}
+		}
+
+		return canvas.MetricValue{}
+	default:
+		return canvas.MetricValue{}
+	}
+}
+
+func extractNumeric(f *model.File, m metric.Name) float64 {
+	if v, ok := f.Quantity(m); ok {
+		return float64(v)
+	}
+
+	if v, ok := f.Measure(m); ok {
+		return v
+	}
+
+	return 0
+}
+
+func collectNumericValues(root *model.Directory, m metric.Name) []float64 {
+	var values []float64
+
+	model.WalkFiles(root, func(f *model.File) {
+		values = append(values, extractNumeric(f, m))
+	})
+
+	return values
+}
+
+func collectDistinctTypes(root *model.Directory, m metric.Name) []string {
+	seen := map[string]bool{}
+
+	model.WalkFiles(root, func(f *model.File) {
+		if v, ok := f.Classification(m); ok {
+			seen[v] = true
+		}
+	})
+
+	types := make([]string, 0, len(seen))
+	for t := range seen {
+		types = append(types, t)
+	}
+
+	slices.Sort(types)
+
+	return types
+}

--- a/cmd/codeviz/radial_canvas.go
+++ b/cmd/codeviz/radial_canvas.go
@@ -27,12 +27,6 @@ const (
 	radialLabelGap  = 4.0
 )
 
-// radialInks holds the Ink instances for a radial tree render pass.
-type radialInks struct {
-	fill   canvas.Ink
-	border canvas.Ink
-}
-
 // buildRadialInks creates fill and border inks from metric configuration.
 // Uses the same buildMetricInk helper as the treemap bridge since both
 // visualizations derive colours from the model.Directory tree.
@@ -42,8 +36,8 @@ func buildRadialInks(
 	fillPaletteName palette.PaletteName,
 	borderMetric metric.Name,
 	borderPaletteName palette.PaletteName,
-) radialInks {
-	inks := radialInks{
+) vizInks {
+	inks := vizInks{
 		border: canvas.FixedInk(radialDefaultBorder),
 	}
 
@@ -61,7 +55,7 @@ func renderRadialToCanvas(
 	nodes *radialtree.RadialNode,
 	root *model.Directory,
 	canvasSize int,
-	inks radialInks,
+	inks vizInks,
 ) *canvas.Canvas {
 	cv := canvas.NewCanvas(canvasSize, canvasSize)
 
@@ -186,7 +180,7 @@ func addRadialDiscs(
 	nodes *radialtree.RadialNode,
 	root *model.Directory,
 	cx, cy float64,
-	inks radialInks,
+	inks vizInks,
 ) {
 	entries := collectRadialDiscs(nodes, root, cx, cy)
 
@@ -200,9 +194,9 @@ func addRadialDiscs(
 }
 
 // addRadialDisc adds a single disc shape to the canvas.
-func addRadialDisc(cv *canvas.Canvas, e radialDiscEntry, inks radialInks) {
-	fillMV := radialMetricValue(e.file, inks.fill)
-	borderMV := radialMetricValue(e.file, inks.border)
+func addRadialDisc(cv *canvas.Canvas, e radialDiscEntry, inks vizInks) {
+	fillMV := metricValueForFile(e.file, inks.fill)
+	borderMV := metricValueForFile(e.file, inks.border)
 
 	fill := inks.fill
 	border := inks.border
@@ -231,22 +225,12 @@ func addRadialDisc(cv *canvas.Canvas, e radialDiscEntry, inks radialInks) {
 	})
 }
 
-// radialMetricValue builds a MetricValue from a file's data for the given ink.
-// For directory nodes (file == nil), returns an empty MetricValue.
-func radialMetricValue(file *model.File, ink canvas.Ink) canvas.MetricValue {
-	if file == nil {
-		return canvas.MetricValue{}
-	}
-
-	return metricValueForFile(file, ink)
-}
-
 // addRadialLabels recursively adds text labels for nodes with ShowLabel set.
 func addRadialLabels(
 	cv *canvas.Canvas,
 	node radialtree.RadialNode,
 	cx, cy float64,
-	inks radialInks,
+	inks vizInks,
 ) {
 	if node.ShowLabel && node.Label != "" {
 		dist := math.Sqrt(node.X*node.X + node.Y*node.Y)
@@ -269,7 +253,7 @@ func addRadialRootLabel(
 	cv *canvas.Canvas,
 	node radialtree.RadialNode,
 	cx, cy float64,
-	inks radialInks,
+	inks vizInks,
 ) {
 	fill := radialEffectiveFill(node, inks)
 	labelColour := canvas.TextColourFor(fill)
@@ -333,7 +317,7 @@ func addRadialExternalLabel(
 
 // radialEffectiveFill returns the fill colour for a node, resolving defaults.
 // Used for computing label contrast colour on the root node.
-func radialEffectiveFill(node radialtree.RadialNode, inks radialInks) color.RGBA {
+func radialEffectiveFill(node radialtree.RadialNode, inks vizInks) color.RGBA {
 	if node.IsDirectory {
 		return radialDefaultDirFill
 	}

--- a/cmd/codeviz/spiral_canvas.go
+++ b/cmd/codeviz/spiral_canvas.go
@@ -25,12 +25,6 @@ const (
 	spiralTrackMinSteps = 500
 )
 
-// spiralInks holds the Ink instances for a spiral render pass.
-type spiralInks struct {
-	fill   canvas.Ink
-	border canvas.Ink
-}
-
 // buildSpiralInks creates fill and border inks from aggregated time-bucket data.
 func buildSpiralInks(
 	buckets []spiral.TimeBucket,
@@ -38,8 +32,8 @@ func buildSpiralInks(
 	fillPaletteName palette.PaletteName,
 	borderMetric metric.Name,
 	borderPaletteName palette.PaletteName,
-) spiralInks {
-	inks := spiralInks{
+) vizInks {
+	inks := vizInks{
 		fill:   canvas.FixedInk(spiralDefaultFill),
 		border: canvas.FixedInk(spiralDefaultBorder),
 	}
@@ -112,7 +106,7 @@ func renderSpiralToCanvas(
 	layout spiral.SpiralLayout,
 	buckets []spiral.TimeBucket,
 	width, height int,
-	inks spiralInks,
+	inks vizInks,
 ) *canvas.Canvas {
 	cv := canvas.NewCanvas(width, height)
 
@@ -175,7 +169,7 @@ func addSpiralDiscs(
 	cv *canvas.Canvas,
 	nodes []spiral.SpiralNode,
 	buckets []spiral.TimeBucket,
-	inks spiralInks,
+	inks vizInks,
 ) {
 	for i, n := range nodes {
 		if n.DiscRadius <= 0 {

--- a/cmd/codeviz/treemap_canvas.go
+++ b/cmd/codeviz/treemap_canvas.go
@@ -7,7 +7,6 @@ import (
 	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
 	"github.com/theunrepentantgeek/code-visualizer/internal/model"
 	"github.com/theunrepentantgeek/code-visualizer/internal/palette"
-	"github.com/theunrepentantgeek/code-visualizer/internal/provider"
 	"github.com/theunrepentantgeek/code-visualizer/internal/treemap"
 )
 
@@ -25,12 +24,6 @@ var (
 	treemapWhiteText        = color.RGBA{R: 0xFF, G: 0xFF, B: 0xFF, A: 0xFF}
 )
 
-// treemapInks holds the Ink instances for a treemap render pass.
-type treemapInks struct {
-	fill   canvas.Ink
-	border canvas.Ink
-}
-
 // buildTreemapInks creates fill and border inks from metric configuration.
 func buildTreemapInks(
 	root *model.Directory,
@@ -38,8 +31,8 @@ func buildTreemapInks(
 	fillPaletteName palette.PaletteName,
 	borderMetric metric.Name,
 	borderPaletteName palette.PaletteName,
-) treemapInks {
-	inks := treemapInks{
+) vizInks {
+	inks := vizInks{
 		border: canvas.FixedInk(treemapStructuralBorder),
 	}
 
@@ -51,42 +44,13 @@ func buildTreemapInks(
 	return inks
 }
 
-// buildMetricInk creates an Ink for a given metric, using the appropriate
-// constructor based on the metric kind (numeric vs categorical).
-func buildMetricInk(
-	root *model.Directory,
-	m metric.Name,
-	palName palette.PaletteName,
-	fallback color.RGBA,
-) canvas.Ink {
-	p, ok := provider.Get(m)
-	if !ok {
-		return canvas.FixedInk(fallback)
-	}
-
-	pal := palette.GetPalette(palName)
-
-	if p.Kind() == metric.Quantity || p.Kind() == metric.Measure {
-		values := collectNumericValues(root, m)
-		if len(values) == 0 {
-			return canvas.FixedInk(fallback)
-		}
-
-		return canvas.NumericInk(m, values, pal)
-	}
-
-	types := collectDistinctTypes(root, m)
-
-	return canvas.CategoricalInk(m, types, pal)
-}
-
 // renderTreemapToCanvas walks the layout tree and model tree in parallel,
 // adding shapes to the canvas. Returns the populated canvas.
 func renderTreemapToCanvas(
 	rects treemap.TreemapRectangle,
 	root *model.Directory,
 	width, height int,
-	inks treemapInks,
+	inks vizInks,
 ) *canvas.Canvas {
 	cv := canvas.NewCanvas(width, height)
 
@@ -114,7 +78,7 @@ func addTreemapRect(
 	cv *canvas.Canvas,
 	rect treemap.TreemapRectangle,
 	node *model.Directory,
-	inks treemapInks,
+	inks vizInks,
 ) {
 	if !rect.IsDirectory {
 		addFileRectForFile(cv, rect, nil, inks)
@@ -191,7 +155,7 @@ func addFileRectForFile(
 	cv *canvas.Canvas,
 	rect treemap.TreemapRectangle,
 	file *model.File,
-	inks treemapInks,
+	inks vizInks,
 ) {
 	if rect.W <= 0 || rect.H <= 0 {
 		return
@@ -235,38 +199,6 @@ func addFileRectForFile(
 			Y:       rect.Y + rect.H/2,
 			Content: rect.Label,
 		})
-	}
-}
-
-// metricValueForFile builds a MetricValue from a file's data for the given ink.
-func metricValueForFile(file *model.File, ink canvas.Ink) canvas.MetricValue {
-	if file == nil {
-		return canvas.MetricValue{}
-	}
-
-	info := ink.Info()
-
-	switch info.Kind {
-	case canvas.InkNumeric:
-		m := info.MetricName
-		if v, ok := file.Quantity(m); ok {
-			return canvas.MetricValue{Kind: metric.Quantity, Quantity: int(v)}
-		}
-
-		if v, ok := file.Measure(m); ok {
-			return canvas.MetricValue{Kind: metric.Measure, Measure: v}
-		}
-
-		return canvas.MetricValue{}
-	case canvas.InkCategorical:
-		m := info.MetricName
-		if v, ok := file.Classification(m); ok {
-			return canvas.MetricValue{Kind: metric.Classification, Category: v}
-		}
-
-		return canvas.MetricValue{}
-	default:
-		return canvas.MetricValue{}
 	}
 }
 

--- a/cmd/codeviz/treemap_cmd.go
+++ b/cmd/codeviz/treemap_cmd.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"log/slog"
-	"slices"
 	"strings"
 
 	"github.com/rotisserie/eris"
@@ -364,45 +363,4 @@ func (*TreemapCmd) resolveFillMetric(cfg *config.Treemap) metric.Name {
 	}
 
 	return metric.Name(ptrString(cfg.Size))
-}
-
-func extractNumeric(f *model.File, m metric.Name) float64 {
-	if v, ok := f.Quantity(m); ok {
-		return float64(v)
-	}
-
-	if v, ok := f.Measure(m); ok {
-		return v
-	}
-
-	return 0
-}
-
-func collectNumericValues(root *model.Directory, m metric.Name) []float64 {
-	var values []float64
-
-	model.WalkFiles(root, func(f *model.File) {
-		values = append(values, extractNumeric(f, m))
-	})
-
-	return values
-}
-
-func collectDistinctTypes(root *model.Directory, m metric.Name) []string {
-	seen := map[string]bool{}
-
-	model.WalkFiles(root, func(f *model.File) {
-		if v, ok := f.Classification(m); ok {
-			seen[v] = true
-		}
-	})
-
-	types := make([]string, 0, len(seen))
-	for t := range seen {
-		types = append(types, t)
-	}
-
-	slices.Sort(types)
-
-	return types
 }

--- a/cmd/codeviz/viz_inks.go
+++ b/cmd/codeviz/viz_inks.go
@@ -1,0 +1,9 @@
+package main
+
+import "github.com/theunrepentantgeek/code-visualizer/internal/canvas"
+
+// vizInks holds the Ink instances for any visualization render pass.
+type vizInks struct {
+	fill   canvas.Ink
+	border canvas.Ink
+}

--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,13 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/fogleman/gg v1.3.0
 	github.com/go-git/go-git/v5 v5.19.0
+	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
 	github.com/lmittmann/tint v1.1.3
 	github.com/nikolaydubina/treemap v1.2.5
 	github.com/onsi/gomega v1.40.0
 	github.com/rotisserie/eris v0.5.4
 	go.yaml.in/yaml/v3 v3.0.4
+	golang.org/x/image v0.40.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/text v0.37.0
 )
@@ -25,7 +27,6 @@ require (
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.9.0 // indirect
-	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
@@ -36,7 +37,6 @@ require (
 	github.com/skeema/knownhosts v1.3.1 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
-	golang.org/x/image v0.40.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/internal/canvas/legend.go
+++ b/internal/canvas/legend.go
@@ -69,7 +69,7 @@ func DefaultOrientation(pos LegendPosition) LegendOrientation {
 func (lc *LegendConfig) ReserveSpace() (widthReduction, heightReduction float64) {
 	data := lc.toLegendData()
 
-	return legendlayout.ReserveSpace(data)
+	return legendlayout.ReserveSpace(data, legendlayout.NewBasicMeasurer())
 }
 
 // toLegendData converts the canvas-facing LegendConfig to the backend-facing

--- a/internal/canvas/legendlayout/layout.go
+++ b/internal/canvas/legendlayout/layout.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/fogleman/gg"
-
 	"github.com/theunrepentantgeek/code-visualizer/internal/canvas/model"
 )
 
@@ -22,18 +20,16 @@ func FormatBreakpoint(v float64) string {
 
 // MeasureLegend computes the total width and height of the legend box
 // including padding. Returns (0, 0) if data is nil or has no entries.
-func MeasureLegend(data *model.LegendData) (width, height float64) {
+func MeasureLegend(data *model.LegendData, measurer StringMeasurer) (width, height float64) {
 	if data == nil || len(data.Entries) == 0 {
 		return 0, 0
 	}
 
-	dc := gg.NewContext(1, 1)
-
 	if data.Orientation == "horizontal" {
-		return measureLegendH(dc, data)
+		return measureLegendH(measurer, data)
 	}
 
-	return measureLegendV(dc, data)
+	return measureLegendV(measurer, data)
 }
 
 // LegendOrigin computes the top-left (x, y) for the legend box.
@@ -67,12 +63,12 @@ func LegendOrigin(
 // ReserveSpace computes the width and height reductions needed to reserve
 // space for the legend. Returns zeros if data is nil, position is "none",
 // or there are no entries.
-func ReserveSpace(data *model.LegendData) (widthReduction, heightReduction float64) {
+func ReserveSpace(data *model.LegendData, measurer StringMeasurer) (widthReduction, heightReduction float64) {
 	if data == nil || data.Position == "none" || len(data.Entries) == 0 {
 		return 0, 0
 	}
 
-	w, h := MeasureLegend(data)
+	w, h := MeasureLegend(data, measurer)
 	m := model.LegendMargin
 
 	switch data.Position {
@@ -89,7 +85,7 @@ func ReserveSpace(data *model.LegendData) (widthReduction, heightReduction float
 	}
 }
 
-func measureLegendV(dc *gg.Context, data *model.LegendData) (width, height float64) {
+func measureLegendV(measurer StringMeasurer, data *model.LegendData) (width, height float64) {
 	var totalH float64
 
 	maxW := 0.0
@@ -99,14 +95,14 @@ func measureLegendV(dc *gg.Context, data *model.LegendData) (width, height float
 			totalH += model.EntryGap
 		}
 
-		tw, _ := dc.MeasureString(entry.Title)
+		tw, _ := measurer.MeasureString(entry.Title)
 		totalH += model.TitleFontSize + model.LabelGap
 
 		if tw > maxW {
 			maxW = tw
 		}
 
-		entryW, entryH := measureEntryV(dc, entry)
+		entryW, entryH := measureEntryV(measurer, entry)
 		totalH += entryH
 
 		if entryW > maxW {
@@ -117,7 +113,7 @@ func measureLegendV(dc *gg.Context, data *model.LegendData) (width, height float
 	return maxW + 2*model.LegendPadding, totalH + 2*model.LegendPadding
 }
 
-func measureLegendH(dc *gg.Context, data *model.LegendData) (width, height float64) {
+func measureLegendH(measurer StringMeasurer, data *model.LegendData) (width, height float64) {
 	var totalW float64
 
 	maxH := 0.0
@@ -127,7 +123,7 @@ func measureLegendH(dc *gg.Context, data *model.LegendData) (width, height float
 			totalW += model.EntryGap
 		}
 
-		entryW, entryH := measureSingleEntryH(dc, entry)
+		entryW, entryH := measureSingleEntryH(measurer, entry)
 		totalW += entryW
 
 		if entryH > maxH {
@@ -138,11 +134,11 @@ func measureLegendH(dc *gg.Context, data *model.LegendData) (width, height float
 	return totalW + 2*model.LegendPadding, maxH + 2*model.LegendPadding
 }
 
-func measureSingleEntryH(dc *gg.Context, entry model.LegendEntryData) (width, height float64) {
-	tw, _ := dc.MeasureString(entry.Title)
+func measureSingleEntryH(measurer StringMeasurer, entry model.LegendEntryData) (width, height float64) {
+	tw, _ := measurer.MeasureString(entry.Title)
 	titleH := model.TitleFontSize + model.LabelGap
 
-	entryW, entryH := measureEntryH(dc, entry)
+	entryW, entryH := measureEntryH(measurer, entry)
 
 	w := max(tw, entryW)
 	h := titleH + entryH
@@ -150,30 +146,30 @@ func measureSingleEntryH(dc *gg.Context, entry model.LegendEntryData) (width, he
 	return w, h
 }
 
-func measureEntryV(dc *gg.Context, entry model.LegendEntryData) (width, height float64) {
+func measureEntryV(measurer StringMeasurer, entry model.LegendEntryData) (width, height float64) {
 	if entry.Kind == model.LegendEntryCategorical {
-		return measureCategoryV(dc, entry)
+		return measureCategoryV(measurer, entry)
 	}
 
-	return measureNumericV(dc, entry)
+	return measureNumericV(measurer, entry)
 }
 
-func measureEntryH(dc *gg.Context, entry model.LegendEntryData) (width, height float64) {
+func measureEntryH(measurer StringMeasurer, entry model.LegendEntryData) (width, height float64) {
 	if entry.Kind == model.LegendEntryCategorical {
-		return measureCategoryH(dc, entry)
+		return measureCategoryH(measurer, entry)
 	}
 
 	return measureNumericH(entry)
 }
 
-func measureNumericV(dc *gg.Context, entry model.LegendEntryData) (width, height float64) {
+func measureNumericV(measurer StringMeasurer, entry model.LegendEntryData) (width, height float64) {
 	n := len(entry.Swatches)
 	h := float64(n) * model.SwatchSize
 	w := model.SwatchSize
 
 	for _, sw := range entry.Swatches {
 		if sw.Label != "" {
-			tw, _ := dc.MeasureString(sw.Label)
+			tw, _ := measurer.MeasureString(sw.Label)
 
 			if bw := model.SwatchSize + model.LabelGap + tw; bw > w {
 				w = bw
@@ -192,14 +188,14 @@ func measureNumericH(entry model.LegendEntryData) (width, height float64) {
 	return w, h
 }
 
-func measureCategoryV(dc *gg.Context, entry model.LegendEntryData) (width, height float64) {
+func measureCategoryV(measurer StringMeasurer, entry model.LegendEntryData) (width, height float64) {
 	n := len(entry.Swatches)
 
 	w := model.SwatchSize
 	h := float64(n) * (model.SwatchSize + model.SwatchGap)
 
 	for _, sw := range entry.Swatches {
-		tw, _ := dc.MeasureString(sw.Label)
+		tw, _ := measurer.MeasureString(sw.Label)
 
 		if cw := model.SwatchSize + model.LabelGap + tw; cw > w {
 			w = cw
@@ -209,11 +205,11 @@ func measureCategoryV(dc *gg.Context, entry model.LegendEntryData) (width, heigh
 	return w, h
 }
 
-func measureCategoryH(dc *gg.Context, entry model.LegendEntryData) (width, height float64) {
+func measureCategoryH(measurer StringMeasurer, entry model.LegendEntryData) (width, height float64) {
 	w := 0.0
 
 	for _, sw := range entry.Swatches {
-		tw, _ := dc.MeasureString(sw.Label)
+		tw, _ := measurer.MeasureString(sw.Label)
 		w += max(model.SwatchSize, tw) + model.SwatchGap + model.LabelGap
 	}
 

--- a/internal/canvas/legendlayout/layout_test.go
+++ b/internal/canvas/legendlayout/layout_test.go
@@ -73,7 +73,7 @@ func TestMeasureLegend_EmptyEntries_ReturnsZero(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	data := &model.LegendData{Orientation: "vertical"}
-	w, h := MeasureLegend(data)
+	w, h := MeasureLegend(data, NewBasicMeasurer())
 	g.Expect(w).To(BeZero())
 	g.Expect(h).To(BeZero())
 }
@@ -82,7 +82,7 @@ func TestMeasureLegend_Nil_ReturnsZero(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	w, h := MeasureLegend(nil)
+	w, h := MeasureLegend(nil, NewBasicMeasurer())
 	g.Expect(w).To(BeZero())
 	g.Expect(h).To(BeZero())
 }
@@ -92,7 +92,7 @@ func TestMeasureLegend_Vertical_NonZero(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	data := makeSampleLegendData("vertical")
-	w, h := MeasureLegend(data)
+	w, h := MeasureLegend(data, NewBasicMeasurer())
 	g.Expect(w).To(BeNumerically(">", 0))
 	g.Expect(h).To(BeNumerically(">", 0))
 }
@@ -101,10 +101,11 @@ func TestMeasureLegend_Horizontal_WiderThanVertical(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
+	m := NewBasicMeasurer()
 	dataH := makeSampleLegendData("horizontal")
 	dataV := makeSampleLegendData("vertical")
-	wH, _ := MeasureLegend(dataH)
-	wV, _ := MeasureLegend(dataV)
+	wH, _ := MeasureLegend(dataH, m)
+	wV, _ := MeasureLegend(dataV, m)
 	g.Expect(wH).To(BeNumerically(">", wV),
 		"horizontal legend should be wider than vertical")
 }
@@ -113,10 +114,11 @@ func TestMeasureLegend_Horizontal_ShorterThanVertical(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
+	m := NewBasicMeasurer()
 	dataH := makeSampleLegendData("horizontal")
 	dataV := makeSampleLegendData("vertical")
-	_, hH := MeasureLegend(dataH)
-	_, hV := MeasureLegend(dataV)
+	_, hH := MeasureLegend(dataH, m)
+	_, hV := MeasureLegend(dataV, m)
 	g.Expect(hH).To(BeNumerically("<", hV),
 		"horizontal legend should be shorter than vertical")
 }
@@ -125,7 +127,7 @@ func TestReserveSpace_NilData_ReturnsZero(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	wReduce, hReduce := ReserveSpace(nil)
+	wReduce, hReduce := ReserveSpace(nil, NewBasicMeasurer())
 	g.Expect(wReduce).To(BeZero())
 	g.Expect(hReduce).To(BeZero())
 }
@@ -135,7 +137,7 @@ func TestReserveSpace_NonePosition_ReturnsZero(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	data := &model.LegendData{Position: "none"}
-	wReduce, hReduce := ReserveSpace(data)
+	wReduce, hReduce := ReserveSpace(data, NewBasicMeasurer())
 	g.Expect(wReduce).To(BeZero())
 	g.Expect(hReduce).To(BeZero())
 }
@@ -146,7 +148,7 @@ func TestReserveSpace_CenterRight_ReducesWidth(t *testing.T) {
 
 	data := makeSampleLegendData("vertical")
 	data.Position = "center-right"
-	wReduce, hReduce := ReserveSpace(data)
+	wReduce, hReduce := ReserveSpace(data, NewBasicMeasurer())
 	g.Expect(wReduce).To(BeNumerically(">", 0))
 	g.Expect(hReduce).To(BeZero())
 }
@@ -157,7 +159,7 @@ func TestReserveSpace_BottomCenter_ReducesHeight(t *testing.T) {
 
 	data := makeSampleLegendData("vertical")
 	data.Position = "bottom-center"
-	wReduce, hReduce := ReserveSpace(data)
+	wReduce, hReduce := ReserveSpace(data, NewBasicMeasurer())
 	g.Expect(wReduce).To(BeZero())
 	g.Expect(hReduce).To(BeNumerically(">", 0))
 }
@@ -168,7 +170,7 @@ func TestReserveSpace_CornerVertical_ReducesWidth(t *testing.T) {
 
 	data := makeSampleLegendData("vertical")
 	data.Position = "bottom-right"
-	wReduce, hReduce := ReserveSpace(data)
+	wReduce, hReduce := ReserveSpace(data, NewBasicMeasurer())
 	g.Expect(wReduce).To(BeNumerically(">", 0))
 	g.Expect(hReduce).To(BeZero())
 }
@@ -179,7 +181,7 @@ func TestReserveSpace_CornerHorizontal_ReducesHeight(t *testing.T) {
 
 	data := makeSampleLegendData("horizontal")
 	data.Position = "bottom-right"
-	wReduce, hReduce := ReserveSpace(data)
+	wReduce, hReduce := ReserveSpace(data, NewBasicMeasurer())
 	g.Expect(wReduce).To(BeZero())
 	g.Expect(hReduce).To(BeNumerically(">", 0))
 }

--- a/internal/canvas/legendlayout/measurer.go
+++ b/internal/canvas/legendlayout/measurer.go
@@ -1,0 +1,32 @@
+package legendlayout
+
+import (
+	"golang.org/x/image/font"
+	"golang.org/x/image/font/basicfont"
+)
+
+// StringMeasurer measures the rendered width and height of a string.
+// Implementations may use actual font metrics or a fixed-width approximation.
+type StringMeasurer interface {
+	MeasureString(s string) (w, h float64)
+}
+
+// basicFontMeasurer uses the 7×13 bitmap font from golang.org/x/image,
+// which is the same default font that gg.NewContext uses.
+type basicFontMeasurer struct {
+	face font.Face
+}
+
+// NewBasicMeasurer returns a StringMeasurer backed by the standard 7×13
+// bitmap font. This matches the default font used by gg.NewContext(1, 1),
+// so measurements are identical to the previous gg-based implementation.
+func NewBasicMeasurer() StringMeasurer {
+	return &basicFontMeasurer{face: basicfont.Face7x13}
+}
+
+func (m *basicFontMeasurer) MeasureString(s string) (w, h float64) {
+	d := &font.Drawer{Face: m.face}
+	advance := d.MeasureString(s)
+
+	return float64(advance >> 6), float64(m.face.Metrics().Height >> 6)
+}

--- a/internal/canvas/legendlayout/measurer_test.go
+++ b/internal/canvas/legendlayout/measurer_test.go
@@ -1,0 +1,44 @@
+package legendlayout
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestNewBasicMeasurer_ReturnsNonNil(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	m := NewBasicMeasurer()
+	g.Expect(m).NotTo(BeNil())
+}
+
+func TestBasicMeasurer_MeasureString_NonEmptyReturnsPositiveWidth(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	m := NewBasicMeasurer()
+	w, h := m.MeasureString("hello")
+	g.Expect(w).To(BeNumerically(">", 0))
+	g.Expect(h).To(BeNumerically(">", 0))
+}
+
+func TestBasicMeasurer_MeasureString_EmptyReturnsZeroWidth(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	m := NewBasicMeasurer()
+	w, _ := m.MeasureString("")
+	g.Expect(w).To(BeZero())
+}
+
+func TestBasicMeasurer_MeasureString_LongerStringIsWider(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	m := NewBasicMeasurer()
+	wShort, _ := m.MeasureString("ab")
+	wLong, _ := m.MeasureString("abcdef")
+	g.Expect(wLong).To(BeNumerically(">", wShort))
+}

--- a/internal/canvas/raster/legend.go
+++ b/internal/canvas/raster/legend.go
@@ -15,7 +15,7 @@ func drawLegend(dc *gg.Context, data model.LegendData, canvasW, canvasH int) {
 		return
 	}
 
-	w, h := legendlayout.MeasureLegend(&data)
+	w, h := legendlayout.MeasureLegend(&data, legendlayout.NewBasicMeasurer())
 	ox, oy := legendlayout.LegendOrigin(data.Position, float64(canvasW), float64(canvasH), w, h)
 
 	drawLegendBackground(dc, ox, oy, w, h)

--- a/internal/canvas/svg/legend.go
+++ b/internal/canvas/svg/legend.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"html"
 
-	"github.com/fogleman/gg"
-
 	"github.com/theunrepentantgeek/code-visualizer/internal/canvas/legendlayout"
 	"github.com/theunrepentantgeek/code-visualizer/internal/canvas/model"
 )
@@ -20,7 +18,7 @@ func writeSVGLegend(buf *bytes.Buffer, data model.LegendData, canvasW, canvasH i
 		return
 	}
 
-	w, h := legendlayout.MeasureLegend(&data)
+	w, h := legendlayout.MeasureLegend(&data, legendlayout.NewBasicMeasurer())
 	ox, oy := legendlayout.LegendOrigin(data.Position, float64(canvasW), float64(canvasH), w, h)
 
 	fmt.Fprintf(buf, "<g transform=\"translate(%.2f,%.2f)\">\n", ox, oy)
@@ -60,7 +58,7 @@ func writeSVGLegendEntries(buf *bytes.Buffer, data *model.LegendData) {
 
 // writeSVGLegendEntriesH renders entries side-by-side for horizontal layout.
 func writeSVGLegendEntriesH(buf *bytes.Buffer, data *model.LegendData) {
-	dc := gg.NewContext(1, 1)
+	measurer := legendlayout.NewBasicMeasurer()
 	cx := model.LegendPadding
 
 	for i, entry := range data.Entries {
@@ -68,20 +66,20 @@ func writeSVGLegendEntriesH(buf *bytes.Buffer, data *model.LegendData) {
 			cx += model.EntryGap
 		}
 
-		ew := measureSingleEntryHWidth(dc, entry)
+		ew := measureSingleEntryHWidth(measurer, entry)
 		writeSVGSingleEntry(buf, data.Orientation, entry, cx, model.LegendPadding)
 		cx += ew
 	}
 }
 
 // measureSingleEntryHWidth measures just the width of a horizontal entry.
-func measureSingleEntryHWidth(dc *gg.Context, entry model.LegendEntryData) float64 {
-	tw, _ := dc.MeasureString(entry.Title)
+func measureSingleEntryHWidth(measurer legendlayout.StringMeasurer, entry model.LegendEntryData) float64 {
+	tw, _ := measurer.MeasureString(entry.Title)
 
 	var entryW float64
 
 	if entry.Kind == model.LegendEntryCategorical {
-		entryW = measureCatHWidth(dc, entry)
+		entryW = measureCatHWidth(measurer, entry)
 	} else {
 		entryW = float64(len(entry.Swatches)) * model.SwatchSize
 	}
@@ -90,11 +88,11 @@ func measureSingleEntryHWidth(dc *gg.Context, entry model.LegendEntryData) float
 }
 
 // measureCatHWidth measures the width of horizontal category swatches.
-func measureCatHWidth(dc *gg.Context, entry model.LegendEntryData) float64 {
+func measureCatHWidth(measurer legendlayout.StringMeasurer, entry model.LegendEntryData) float64 {
 	w := 0.0
 
 	for _, sw := range entry.Swatches {
-		tw, _ := dc.MeasureString(sw.Label)
+		tw, _ := measurer.MeasureString(sw.Label)
 		w += max(model.SwatchSize, tw) + model.SwatchGap + model.LabelGap
 	}
 
@@ -219,7 +217,7 @@ func writeSVGCategoryV(buf *bytes.Buffer, entry model.LegendEntryData, x, y floa
 
 // writeSVGCategoryH writes horizontally arranged category swatches.
 func writeSVGCategoryH(buf *bytes.Buffer, entry model.LegendEntryData, x, y float64) float64 {
-	dc := gg.NewContext(1, 1)
+	measurer := legendlayout.NewBasicMeasurer()
 	cx := x
 
 	for _, sw := range entry.Swatches {
@@ -233,7 +231,7 @@ func writeSVGCategoryH(buf *bytes.Buffer, entry model.LegendEntryData, x, y floa
 			cx+model.SwatchSize/2, y+model.SwatchSize+model.LegendLineHeight,
 			model.LegendFontSize, html.EscapeString(sw.Label))
 
-		tw, _ := dc.MeasureString(sw.Label)
+		tw, _ := measurer.MeasureString(sw.Label)
 		cx += max(model.SwatchSize, tw) + model.SwatchGap + model.LabelGap
 	}
 


### PR DESCRIPTION
Fixes #202

## Changes
- Replace treemapInks/radialInks/bubbleInks/spiralInks with shared vizInks struct
- Extract buildMetricInk and helpers to new ink_builder.go
- Remove redundant radialMetricValue wrapper (confirmed: it nil-checks what metricValueForFile already nil-checks)

## Testing
- task ci passes
- No behavioral changes — pure structural refactoring