### PR TITLE
refactor(provider): split Interface into MetricDescriptor + Loader

### DIFF
--- a/cmd/codeviz/bubbletree_cmd.go
+++ b/cmd/codeviz/bubbletree_cmd.go
@@ -56,13 +56,13 @@ func (c *BubbletreeCmd) Validate() error {
 func (*BubbletreeCmd) validateConfig(cfg *config.Bubbletree) error {
 	size := ptrString(cfg.Size)
 
-	p, ok := provider.Get(metric.Name(size))
+	d, ok := provider.GetDescriptor(metric.Name(size))
 	if !ok {
 		return eris.Errorf("unknown size metric %q; available metrics: %s", size, formatMetricNames())
 	}
 
-	if p.Kind() != metric.Quantity && p.Kind() != metric.Measure {
-		return eris.Errorf("size metric must be numeric, got %q (kind: %d)", size, p.Kind())
+	if d.Kind != metric.Quantity && d.Kind != metric.Measure {
+		return eris.Errorf("size metric must be numeric, got %q (kind: %d)", size, d.Kind)
 	}
 
 	if err := cfg.Fill.Validate("fill"); err != nil {

--- a/cmd/codeviz/help_metrics_cmd.go
+++ b/cmd/codeviz/help_metrics_cmd.go
@@ -15,22 +15,22 @@ type HelpMetricsCmd struct{}
 
 //nolint:unparam // nil error required to satisfy the interface for Kong
 func (HelpMetricsCmd) Run(_ *Flags) error {
-	providers := provider.All()
+	descriptors := provider.AllDescriptors()
 
 	tbl := table.New("Metric", "Kind", "Default Palette", "Description")
 
 	hasGit := false
 
-	for _, p := range providers {
-		k := kindLabel(p.Kind())
-		desc := p.Description()
+	for _, d := range descriptors {
+		k := kindLabel(d.Kind)
+		desc := d.Description
 
-		if git.IsGitMetric(p.Name()) {
+		if git.IsGitMetric(d.Name) {
 			hasGit = true
 			desc += " †"
 		}
 
-		tbl.AddRow(string(p.Name()), k, string(p.DefaultPalette()), desc)
+		tbl.AddRow(string(d.Name), k, string(d.DefaultPalette), desc)
 	}
 
 	content := &strings.Builder{}

--- a/cmd/codeviz/ink_builder.go
+++ b/cmd/codeviz/ink_builder.go
@@ -19,14 +19,14 @@ func buildMetricInk(
 	palName palette.PaletteName,
 	fallback color.RGBA,
 ) canvas.Ink {
-	p, ok := provider.Get(m)
+	d, ok := provider.GetDescriptor(m)
 	if !ok {
 		return canvas.FixedInk(fallback)
 	}
 
 	pal := palette.GetPalette(palName)
 
-	if p.Kind() == metric.Quantity || p.Kind() == metric.Measure {
+	if d.Kind == metric.Quantity || d.Kind == metric.Measure {
 		values := collectNumericValues(root, m)
 		if len(values) == 0 {
 			return canvas.FixedInk(fallback)

--- a/cmd/codeviz/radialtree_cmd.go
+++ b/cmd/codeviz/radialtree_cmd.go
@@ -51,13 +51,13 @@ func (c *RadialCmd) Validate() error {
 func (*RadialCmd) validateConfig(cfg *config.Radial) error {
 	discSize := ptrString(cfg.DiscSize)
 
-	p, ok := provider.Get(metric.Name(discSize))
+	d, ok := provider.GetDescriptor(metric.Name(discSize))
 	if !ok {
 		return eris.Errorf("unknown disc-size metric %q; available metrics: %s", discSize, formatMetricNames())
 	}
 
-	if p.Kind() != metric.Quantity && p.Kind() != metric.Measure {
-		return eris.Errorf("disc-size metric must be numeric, got %q (kind: %d)", discSize, p.Kind())
+	if d.Kind != metric.Quantity && d.Kind != metric.Measure {
+		return eris.Errorf("disc-size metric must be numeric, got %q (kind: %d)", discSize, d.Kind)
 	}
 
 	if err := cfg.Fill.Validate("fill"); err != nil {

--- a/cmd/codeviz/spiral_canvas.go
+++ b/cmd/codeviz/spiral_canvas.go
@@ -70,14 +70,14 @@ func buildBucketInk(
 	categoryFn func(*spiral.TimeBucket) string,
 	fallback color.RGBA,
 ) canvas.Ink {
-	p, ok := provider.Get(m)
+	d, ok := provider.GetDescriptor(m)
 	if !ok {
 		return canvas.FixedInk(fallback)
 	}
 
 	pal := palette.GetPalette(palName)
 
-	if p.Kind() == metric.Quantity || p.Kind() == metric.Measure {
+	if d.Kind == metric.Quantity || d.Kind == metric.Measure {
 		values := make([]float64, len(buckets))
 		for i := range buckets {
 			values[i] = numericFn(&buckets[i])

--- a/cmd/codeviz/spiral_cmd.go
+++ b/cmd/codeviz/spiral_cmd.go
@@ -57,13 +57,13 @@ func (c *SpiralCmd) Validate() error {
 func (*SpiralCmd) validateConfig(cfg *config.Spiral) error {
 	size := ptrString(cfg.Size)
 	if size != "" {
-		p, ok := provider.Get(metric.Name(size))
+		d, ok := provider.GetDescriptor(metric.Name(size))
 		if !ok {
 			return eris.Errorf("unknown size metric %q; available metrics: %s", size, formatMetricNames())
 		}
 
-		if p.Kind() != metric.Quantity && p.Kind() != metric.Measure {
-			return eris.Errorf("size metric must be numeric, got %q (kind: %d)", size, p.Kind())
+		if d.Kind != metric.Quantity && d.Kind != metric.Measure {
+			return eris.Errorf("size metric must be numeric, got %q (kind: %d)", size, d.Kind)
 		}
 	}
 
@@ -362,12 +362,12 @@ func aggregateColourMetric(files []*model.File, m metric.Name, numVal *float64, 
 		return
 	}
 
-	p, ok := provider.Get(m)
+	d, ok := provider.GetDescriptor(m)
 	if !ok {
 		return
 	}
 
-	if p.Kind() == metric.Quantity || p.Kind() == metric.Measure {
+	if d.Kind == metric.Quantity || d.Kind == metric.Measure {
 		*numVal = sumNumericMetric(files, m)
 	} else {
 		*catLabel = modeCategory(files, m)

--- a/cmd/codeviz/treemap_cmd.go
+++ b/cmd/codeviz/treemap_cmd.go
@@ -51,13 +51,13 @@ func (c *TreemapCmd) Validate() error {
 func (*TreemapCmd) validateConfig(cfg *config.Treemap) error {
 	size := ptrString(cfg.Size)
 
-	p, ok := provider.Get(metric.Name(size))
+	d, ok := provider.GetDescriptor(metric.Name(size))
 	if !ok {
 		return eris.Errorf("unknown size metric %q; available metrics: %s", size, formatMetricNames())
 	}
 
-	if p.Kind() != metric.Quantity && p.Kind() != metric.Measure {
-		return eris.Errorf("size metric must be numeric, got %q (kind: %d)", size, p.Kind())
+	if d.Kind != metric.Quantity && d.Kind != metric.Measure {
+		return eris.Errorf("size metric must be numeric, got %q (kind: %d)", size, d.Kind)
 	}
 
 	if err := cfg.Fill.Validate("fill"); err != nil {

--- a/cmd/codeviz/viz_cmd_helpers.go
+++ b/cmd/codeviz/viz_cmd_helpers.go
@@ -150,8 +150,8 @@ func resolveFillPalette(fill *config.MetricSpec, fillMetric metric.Name) palette
 		return fp
 	}
 
-	if p, ok := provider.Get(fillMetric); ok {
-		return p.DefaultPalette()
+	if d, ok := provider.GetDescriptor(fillMetric); ok {
+		return d.DefaultPalette
 	}
 
 	return palette.Neutral
@@ -169,8 +169,8 @@ func resolveBorderMetricAndPalette(
 
 	borderPaletteName := specPalette(border)
 	if borderPaletteName == "" {
-		if p, ok := provider.Get(borderMetric); ok {
-			borderPaletteName = p.DefaultPalette()
+		if d, ok := provider.GetDescriptor(borderMetric); ok {
+			borderPaletteName = d.DefaultPalette
 		} else {
 			borderPaletteName = palette.Neutral
 		}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -7,12 +7,45 @@ import (
 	"github.com/theunrepentantgeek/code-visualizer/internal/palette"
 )
 
-// Interface is the contract every metric provider implements.
+// MetricDescriptor holds the static metadata for a metric provider.
+// This is the narrowest type for consumers that only need provider metadata
+// (e.g., help commands, UI lists, legend defaults).
+type MetricDescriptor struct {
+	Name           metric.Name
+	Kind           metric.Kind
+	Description    string
+	Dependencies   []metric.Name
+	DefaultPalette palette.PaletteName
+}
+
+// Loader is the execution interface for metric providers.
+// Providers implement this to populate metrics on a directory tree.
+type Loader interface {
+	Load(root *model.Directory) error
+}
+
+// Interface is the combined contract every metric provider implements.
+// It embeds both metadata and execution concerns.
+//
+// Deprecated: prefer accepting MetricDescriptor or Loader where possible.
 type Interface interface {
 	Name() metric.Name
 	Kind() metric.Kind
 	Description() string
 	Dependencies() []metric.Name
 	DefaultPalette() palette.PaletteName
-	Load(root *model.Directory) error
+	Loader
+}
+
+// Descriptor extracts the MetricDescriptor from a provider Interface.
+// This allows registry code to continue storing Interface while consumers
+// can receive only the metadata they need.
+func Descriptor(p Interface) MetricDescriptor {
+	return MetricDescriptor{
+		Name:           p.Name(),
+		Kind:           p.Kind(),
+		Description:    p.Description(),
+		Dependencies:   p.Dependencies(),
+		DefaultPalette: p.DefaultPalette(),
+	}
 }

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -78,8 +78,32 @@ func Register(p Interface) { globalRegistry.register(p) }
 // Get retrieves a provider by name from the global registry.
 func Get(name metric.Name) (Interface, bool) { return globalRegistry.get(name) }
 
+// GetDescriptor retrieves only the metadata for a provider by name.
+// Use this instead of Get() when you only need provider metadata.
+func GetDescriptor(name metric.Name) (MetricDescriptor, bool) {
+	p, ok := globalRegistry.get(name)
+	if !ok {
+		return MetricDescriptor{}, false
+	}
+
+	return Descriptor(p), true
+}
+
 // All returns all registered providers.
 func All() []Interface { return globalRegistry.all() }
+
+// AllDescriptors returns metadata for all registered providers.
+// Use this instead of All() when you only need provider metadata.
+func AllDescriptors() []MetricDescriptor {
+	providers := globalRegistry.all()
+
+	descriptors := make([]MetricDescriptor, len(providers))
+	for i, p := range providers {
+		descriptors[i] = Descriptor(p)
+	}
+
+	return descriptors
+}
 
 // Names returns the sorted names of all registered providers.
 func Names() []metric.Name { return globalRegistry.names() }


### PR DESCRIPTION
Fixes #162

Implements Interface Segregation Principle by separating provider concerns into static metadata and execution logic.

## Changes

**Core abstractions:**
- Add `MetricDescriptor` struct for static metadata (Name, Kind, Description, Dependencies, DefaultPalette)
- Add `Loader` interface for execution (Load method only)
- Keep `Interface` as combined contract for backward compatibility (marked deprecated)
- Add `Descriptor()` helper to extract metadata from Interface
- Add `GetDescriptor()` and `AllDescriptors()` registry functions

**Consumer updates (all using narrowest type):**
- `help_metrics_cmd.go`: uses `AllDescriptors()` for help output (metadata only)
- `viz_cmd_helpers.go`: uses `GetDescriptor()` for default palette lookup
- `ink_builder.go`, `spiral_canvas.go`: use `GetDescriptor()` for Kind checks
- All viz commands: use `GetDescriptor()` for size metric validation

## Benefits

✅ Metadata consumers no longer depend on Load capability  
✅ Providers that differ only in Load implementation don't need 6 boilerplate methods  
✅ Type system enforces correct usage at compile time  
✅ Existing providers continue to work without changes  
✅ All tests pass, lint clean (76 linters, 0 issues)

## Testing

```bash
task ci  # build + test + lint all pass
```

Related to (but distinct from) #155, which tackles git provider boilerplate via declarative registration.
