### PR TITLE
fix: detect binary files during scan, independent of requested metrics

### DIFF
--- a/internal/scan/binary.go
+++ b/internal/scan/binary.go
@@ -1,0 +1,68 @@
+package scan
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+
+	"github.com/rotisserie/eris"
+)
+
+// binaryProbeSize is the number of bytes read from the start of a file to
+// detect binary content. This matches the heuristic used by Git.
+const binaryProbeSize = 8000
+
+// IsBinaryFile reports whether the file at path appears to be binary.
+// It reads the first binaryProbeSize bytes and checks for null bytes,
+// skipping files that start with a UTF-16 BOM (which legitimately
+// contain null bytes).
+func IsBinaryFile(path string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, eris.Wrap(err, "opening file for binary probe")
+	}
+	defer f.Close()
+
+	header := make([]byte, binaryProbeSize)
+
+	n, readErr := f.Read(header)
+	if readErr != nil && !errors.Is(readErr, io.EOF) {
+		return false, eris.Wrap(readErr, "reading file header for binary probe")
+	}
+
+	if n == 0 {
+		return false, nil
+	}
+
+	buf := header[:n]
+
+	if hasUTF16BOM(buf) {
+		return false, nil
+	}
+
+	return bytes.IndexByte(buf, 0) >= 0, nil
+}
+
+// hasUTF16BOM reports whether buf starts with a UTF-16 byte-order mark.
+func hasUTF16BOM(buf []byte) bool {
+	if len(buf) < 2 {
+		return false
+	}
+
+	// UTF-16 LE: FF FE (but not FF FE 00 00, which is UTF-32 LE)
+	if buf[0] == 0xFF && buf[1] == 0xFE {
+		if len(buf) >= 4 && buf[2] == 0x00 && buf[3] == 0x00 {
+			return false // UTF-32 LE
+		}
+
+		return true
+	}
+
+	// UTF-16 BE: FE FF
+	if buf[0] == 0xFE && buf[1] == 0xFF {
+		return true
+	}
+
+	return false
+}

--- a/internal/scan/binary_test.go
+++ b/internal/scan/binary_test.go
@@ -1,0 +1,85 @@
+package scan_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/scan"
+)
+
+func TestIsBinaryFile_TextFile_ReturnsFalse(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	path := filepath.Join(t.TempDir(), "hello.go")
+	g.Expect(os.WriteFile(path, []byte("package main\n\nfunc main() {}\n"), 0o600)).To(Succeed())
+
+	binary, err := scan.IsBinaryFile(path)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(binary).To(BeFalse())
+}
+
+func TestIsBinaryFile_BinaryFile_ReturnsTrue(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	path := filepath.Join(t.TempDir(), "image.png")
+	// PNG header contains null bytes
+	data := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00}
+	g.Expect(os.WriteFile(path, data, 0o600)).To(Succeed())
+
+	binary, err := scan.IsBinaryFile(path)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(binary).To(BeTrue())
+}
+
+func TestIsBinaryFile_EmptyFile_ReturnsFalse(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	path := filepath.Join(t.TempDir(), "empty.txt")
+	g.Expect(os.WriteFile(path, []byte{}, 0o600)).To(Succeed())
+
+	binary, err := scan.IsBinaryFile(path)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(binary).To(BeFalse())
+}
+
+func TestIsBinaryFile_UTF16LE_ReturnsFalse(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	path := filepath.Join(t.TempDir(), "utf16le.txt")
+	// UTF-16 LE BOM followed by 'H' 'i' in UTF-16 LE (contains null bytes but is text)
+	data := []byte{0xFF, 0xFE, 0x48, 0x00, 0x69, 0x00}
+	g.Expect(os.WriteFile(path, data, 0o600)).To(Succeed())
+
+	binary, err := scan.IsBinaryFile(path)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(binary).To(BeFalse())
+}
+
+func TestIsBinaryFile_UTF16BE_ReturnsFalse(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	path := filepath.Join(t.TempDir(), "utf16be.txt")
+	// UTF-16 BE BOM followed by 'H' 'i' in UTF-16 BE
+	data := []byte{0xFE, 0xFF, 0x00, 0x48, 0x00, 0x69}
+	g.Expect(os.WriteFile(path, data, 0o600)).To(Succeed())
+
+	binary, err := scan.IsBinaryFile(path)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(binary).To(BeFalse())
+}
+
+func TestIsBinaryFile_NonexistentFile_ReturnsError(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	_, err := scan.IsBinaryFile("/nonexistent/path/file.bin")
+	g.Expect(err).To(HaveOccurred())
+}

--- a/internal/scan/scanner.go
+++ b/internal/scan/scanner.go
@@ -197,10 +197,16 @@ func processFile(node *model.Directory, entry os.DirEntry, info os.FileInfo, ent
 		fileType = "no-extension"
 	}
 
+	binary, err := IsBinaryFile(entryPath)
+	if err != nil {
+		slog.Warn("binary probe failed, assuming text", "path", entryPath, "error", err)
+	}
+
 	f := &model.File{
 		Path:      entryPath,
 		Name:      entry.Name(),
 		Extension: ext,
+		IsBinary:  binary,
 	}
 
 	f.SetQuantity(filesystem.FileSize, info.Size())


### PR DESCRIPTION
## Problem

Binary file exclusion was broken: `IsBinary` was only ever set by `FileLinesProvider.Load()`, which only runs when `file-lines` is explicitly requested as a metric. If the user uses `file-size` (the default) or any other metric, the provider never runs, `IsBinary` stays `false`, and `FilterBinaryFiles` becomes a no-op.

## Fix

Move the binary probe (null-byte heuristic, same as Git) into the scan phase. Every file is now probed during directory traversal in `processFile()`, so `IsBinary` is always set correctly regardless of which metrics are requested.

### Changes
- **`internal/scan/binary.go`** — new exported `IsBinaryFile(path)` function with the null-byte + UTF-16 BOM logic
- **`internal/scan/scanner.go`** — `processFile` calls `IsBinaryFile` and sets `f.IsBinary`
- **`internal/scan/binary_test.go`** — tests for text, binary, empty, UTF-16 LE/BE, and error cases

The existing `FileLinesProvider` still has its secondary detection (for files with extremely long lines that trigger `bufio.ErrTooLong`), and short-circuits on `f.IsBinary == true` as before.