### PR TITLE
Fix bubbletree legend overlap

### DIFF
--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -10,6 +10,14 @@
 
 <!-- Append learnings below -->
 
+### Issue #282 — Bubbletree Legend Overlap (2026-05-23)
+
+- **Root cause:** `internal/bubbletree/stages.go` explicitly left legend handling in overlay mode; unlike treemap, bubbletree ran layout against the full canvas and only attached the legend at render time.
+- **Adopted pattern:** Use shared legend helpers from `internal/legend/reserve.go` — `ReserveAndLayout()` to shrink the layout area and `LayoutOffset()` to translate the finished layout into the non-legend region.
+- **Bubble-specific detail:** Bubbletree needed its own recursive translation helper (`OffsetNodes` in `internal/bubbletree/layout.go`) because its layout stores absolute node centres, not rectangles.
+- **Regression coverage:** `internal/bubbletree/layout_stage_test.go` verifies top and left legend positions reserve space and keep bubble content inside the remaining drawable bounds.
+- **Key files:** `internal/bubbletree/stages.go`, `internal/bubbletree/layout.go`, `internal/bubbletree/layout_stage_test.go`, `internal/legend/reserve.go`, `internal/treemap/stages.go`.
+
 ### PR Review Etiquette (Team Directive, 2026-05-13)
 
 - **PR review reply protocol:** After addressing a PR review comment, ALWAYS reply to the comment indicating what was done. Don't leave reviewers hanging. This closes the feedback loop and keeps communication clear for all stakeholders.

--- a/.squad/decisions/inbox/ripley-282-legend-overlap.md
+++ b/.squad/decisions/inbox/ripley-282-legend-overlap.md
@@ -1,0 +1,28 @@
+# Issue #282 — Bubbletree Legend Reservation
+
+**Author:** Ripley  
+**Date:** 2026-05-23  
+**Status:** Proposed  
+**Issue:** #282 — Bubbletree legend overlaps visualisation
+
+## Decision
+
+Bubbletree should reserve legend space using the same shared legend-reservation flow as treemap instead of drawing the legend as an overlay on the full-layout canvas.
+
+## Implementation Pattern
+
+1. Build `LegendConfig` as today.
+2. Call `legend.ReserveAndLayout()` before bubble layout to reduce the layout width/height.
+3. Run `bubbletree.Layout()` within the reduced dimensions.
+4. If space was reserved, call `LegendConfig.ReserveSpace()` plus `legend.LayoutOffset()` and translate the whole bubble node tree into the remaining drawable region.
+
+## Rationale
+
+The existing overlay behaviour causes the legend to sit on top of bubble content whenever the visualisation fills the full canvas. Treemap already solved this with shared helpers in `internal/legend/reserve.go`; reusing that path keeps legend behaviour consistent across visualisations and preserves the fallback to overlay mode when reserving space would make the drawable area too small.
+
+## Code Impact
+
+- `internal/bubbletree/stages.go`
+- `internal/bubbletree/layout.go`
+- `internal/bubbletree/layout_stage_test.go`
+- Reference pattern: `internal/treemap/stages.go`, `internal/legend/reserve.go`

--- a/internal/bubbletree/layout.go
+++ b/internal/bubbletree/layout.go
@@ -637,3 +637,13 @@ func applyScale(parent *BubbleNode, scale float64) {
 		applyScale(child, scale)
 	}
 }
+
+// OffsetNodes shifts every node in the tree by (dx, dy).
+func OffsetNodes(node *BubbleNode, dx, dy float64) {
+	node.X += dx
+	node.Y += dy
+
+	for i := range node.Children {
+		OffsetNodes(&node.Children[i], dx, dy)
+	}
+}

--- a/internal/bubbletree/layout_stage_test.go
+++ b/internal/bubbletree/layout_stage_test.go
@@ -14,56 +14,66 @@ import (
 	"github.com/theunrepentantgeek/code-visualizer/internal/stages"
 )
 
-func TestLayoutStage_ReservesTopLegendSpace(t *testing.T) {
+func TestLayoutStage_ReservesLegendSpace(t *testing.T) {
 	t.Parallel()
-	g := NewGomegaWithT(t)
 
-	cfg := testLegendConfig(canvasmodel.LegendPositionTopCenter, canvasmodel.LegendOrientationHorizontal)
-	state := &State{
-		CommonState:  stages.CommonState{Root: testLayoutRoot(), Width: 1200, Height: 800},
-		Size:         filesystem.FileSize,
-		Labels:       LabelAll,
-		LegendConfig: cfg,
+	tests := []struct {
+		name         string
+		position     canvasmodel.LegendPosition
+		orientation  canvasmodel.LegendOrientation
+		startOnX     bool
+		startMessage string
+	}{
+		{
+			name:         "top legend",
+			position:     canvasmodel.LegendPositionTopCenter,
+			orientation:  canvasmodel.LegendOrientationHorizontal,
+			startMessage: "bubble layout should start below the reserved top legend area",
+		},
+		{
+			name:         "left legend",
+			position:     canvasmodel.LegendPositionCenterLeft,
+			orientation:  canvasmodel.LegendOrientationVertical,
+			startOnX:     true,
+			startMessage: "bubble layout should start to the right of the reserved left legend area",
+		},
 	}
 
-	g.Expect(LayoutStage(state)).To(Succeed())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
 
-	wReduce, hReduce := cfg.ReserveSpace()
-	layoutW, layoutH := legend.ReserveAndLayout(cfg, state.Width, state.Height)
-	dx, dy := legend.LayoutOffset(cfg, wReduce, hReduce)
-	box := childrenBounds(&state.Nodes)
+			cfg := testLegendConfig(tt.position, tt.orientation)
+			state := &State{
+				CommonState:  stages.CommonState{Root: testLayoutRoot(), Width: 1200, Height: 800},
+				Size:         filesystem.FileSize,
+				Labels:       LabelAll,
+				LegendConfig: cfg,
+			}
 
-	g.Expect(box.minY).To(BeNumerically(">=", dy-1.0),
-		"bubble layout should start below the reserved top legend area")
-	g.Expect(box.maxY).To(BeNumerically("<=", dy+float64(layoutH)+1.0))
-	g.Expect(box.minX).To(BeNumerically(">=", dx-1.0))
-	g.Expect(box.maxX).To(BeNumerically("<=", dx+float64(layoutW)+1.0))
-}
+			g.Expect(LayoutStage(state)).To(Succeed())
 
-func TestLayoutStage_ReservesLeftLegendSpace(t *testing.T) {
-	t.Parallel()
-	g := NewGomegaWithT(t)
+			wReduce, hReduce := cfg.ReserveSpace()
+			layoutW, layoutH := legend.ReserveAndLayout(cfg, state.Width, state.Height)
+			dx, dy := legend.LayoutOffset(cfg, wReduce, hReduce)
+			box := childrenBounds(&state.Nodes)
 
-	cfg := testLegendConfig(canvasmodel.LegendPositionCenterLeft, canvasmodel.LegendOrientationVertical)
-	state := &State{
-		CommonState:  stages.CommonState{Root: testLayoutRoot(), Width: 1200, Height: 800},
-		Size:         filesystem.FileSize,
-		Labels:       LabelAll,
-		LegendConfig: cfg,
+			if tt.startOnX {
+				g.Expect(box.minX).To(BeNumerically(">=", dx-1.0), tt.startMessage)
+				g.Expect(box.maxX).To(BeNumerically("<=", dx+float64(layoutW)+1.0))
+				g.Expect(box.minY).To(BeNumerically(">=", dy-1.0))
+				g.Expect(box.maxY).To(BeNumerically("<=", dy+float64(layoutH)+1.0))
+
+				return
+			}
+
+			g.Expect(box.minY).To(BeNumerically(">=", dy-1.0), tt.startMessage)
+			g.Expect(box.maxY).To(BeNumerically("<=", dy+float64(layoutH)+1.0))
+			g.Expect(box.minX).To(BeNumerically(">=", dx-1.0))
+			g.Expect(box.maxX).To(BeNumerically("<=", dx+float64(layoutW)+1.0))
+		})
 	}
-
-	g.Expect(LayoutStage(state)).To(Succeed())
-
-	wReduce, hReduce := cfg.ReserveSpace()
-	layoutW, layoutH := legend.ReserveAndLayout(cfg, state.Width, state.Height)
-	dx, dy := legend.LayoutOffset(cfg, wReduce, hReduce)
-	box := childrenBounds(&state.Nodes)
-
-	g.Expect(box.minX).To(BeNumerically(">=", dx-1.0),
-		"bubble layout should start to the right of the reserved left legend area")
-	g.Expect(box.maxX).To(BeNumerically("<=", dx+float64(layoutW)+1.0))
-	g.Expect(box.minY).To(BeNumerically(">=", dy-1.0))
-	g.Expect(box.maxY).To(BeNumerically("<=", dy+float64(layoutH)+1.0))
 }
 
 func testLegendConfig(pos canvasmodel.LegendPosition, orient canvasmodel.LegendOrientation) *canvas.LegendConfig {

--- a/internal/bubbletree/layout_stage_test.go
+++ b/internal/bubbletree/layout_stage_test.go
@@ -1,0 +1,102 @@
+package bubbletree
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/canvas"
+	canvasmodel "github.com/theunrepentantgeek/code-visualizer/internal/canvas/model"
+	"github.com/theunrepentantgeek/code-visualizer/internal/legend"
+	"github.com/theunrepentantgeek/code-visualizer/internal/model"
+	"github.com/theunrepentantgeek/code-visualizer/internal/palette"
+	"github.com/theunrepentantgeek/code-visualizer/internal/provider/filesystem"
+	"github.com/theunrepentantgeek/code-visualizer/internal/stages"
+)
+
+func TestLayoutStage_ReservesTopLegendSpace(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	cfg := testLegendConfig(canvasmodel.LegendPositionTopCenter, canvasmodel.LegendOrientationHorizontal)
+	state := &State{
+		CommonState:  stages.CommonState{Root: testLayoutRoot(), Width: 1200, Height: 800},
+		Size:         filesystem.FileSize,
+		Labels:       LabelAll,
+		LegendConfig: cfg,
+	}
+
+	g.Expect(LayoutStage(state)).To(Succeed())
+
+	wReduce, hReduce := cfg.ReserveSpace()
+	layoutW, layoutH := legend.ReserveAndLayout(cfg, state.Width, state.Height)
+	dx, dy := legend.LayoutOffset(cfg, wReduce, hReduce)
+	box := childrenBounds(&state.Nodes)
+
+	g.Expect(box.minY).To(BeNumerically(">=", dy-1.0),
+		"bubble layout should start below the reserved top legend area")
+	g.Expect(box.maxY).To(BeNumerically("<=", dy+float64(layoutH)+1.0))
+	g.Expect(box.minX).To(BeNumerically(">=", dx-1.0))
+	g.Expect(box.maxX).To(BeNumerically("<=", dx+float64(layoutW)+1.0))
+}
+
+func TestLayoutStage_ReservesLeftLegendSpace(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	cfg := testLegendConfig(canvasmodel.LegendPositionCenterLeft, canvasmodel.LegendOrientationVertical)
+	state := &State{
+		CommonState:  stages.CommonState{Root: testLayoutRoot(), Width: 1200, Height: 800},
+		Size:         filesystem.FileSize,
+		Labels:       LabelAll,
+		LegendConfig: cfg,
+	}
+
+	g.Expect(LayoutStage(state)).To(Succeed())
+
+	wReduce, hReduce := cfg.ReserveSpace()
+	layoutW, layoutH := legend.ReserveAndLayout(cfg, state.Width, state.Height)
+	dx, dy := legend.LayoutOffset(cfg, wReduce, hReduce)
+	box := childrenBounds(&state.Nodes)
+
+	g.Expect(box.minX).To(BeNumerically(">=", dx-1.0),
+		"bubble layout should start to the right of the reserved left legend area")
+	g.Expect(box.maxX).To(BeNumerically("<=", dx+float64(layoutW)+1.0))
+	g.Expect(box.minY).To(BeNumerically(">=", dy-1.0))
+	g.Expect(box.maxY).To(BeNumerically("<=", dy+float64(layoutH)+1.0))
+}
+
+func testLegendConfig(pos canvasmodel.LegendPosition, orient canvasmodel.LegendOrientation) *canvas.LegendConfig {
+	fill := canvas.NumericInk("file-size", []float64{100, 200, 400}, palette.GetPalette(palette.Temperature))
+
+	return &canvas.LegendConfig{
+		Position:    pos,
+		Orientation: orient,
+		Entries: []canvas.LegendEntry{{
+			Role:       canvas.LegendRoleFill,
+			MetricName: "file-size",
+			Ink:        fill,
+		}},
+	}
+}
+
+func testLayoutRoot() *model.Directory {
+	root := &model.Directory{
+		Name: "root",
+		Path: "root",
+		Files: []*model.File{
+			testLayoutFile("root/a.go", 100),
+			testLayoutFile("root/b.go", 200),
+			testLayoutFile("root/c.go", 300),
+		},
+	}
+
+	return root
+}
+
+func testLayoutFile(path string, size int64) *model.File {
+	f := &model.File{Name: path, Path: path}
+	f.SetQuantity(filesystem.FileSize, size)
+
+	return f
+}

--- a/internal/bubbletree/stages.go
+++ b/internal/bubbletree/stages.go
@@ -55,8 +55,7 @@ func BuildInksStage(s *State) error {
 	return nil
 }
 
-// BuildLegendStage builds the legend config from inks. Bubbletree does not
-// reserve canvas space for the legend; the legend overlays the bubbles.
+// BuildLegendStage builds the legend config from inks.
 func BuildLegendStage(s *State) error {
 	pos, orient := legend.ResolveOptions(
 		stages.PtrString(s.Config.Legend),
@@ -72,11 +71,21 @@ func BuildLegendStage(s *State) error {
 	return nil
 }
 
-// LayoutStage runs the bubble layout algorithm.
+// LayoutStage reserves legend space, runs the bubble layout algorithm, and
+// offsets the result into the remaining canvas area.
 func LayoutStage(s *State) error {
 	c := s.Common()
+	layoutW, layoutH := legend.ReserveAndLayout(s.LegendConfig, c.Width, c.Height)
 
-	s.Nodes = Layout(c.Root, c.Width, c.Height, s.Size, s.Labels)
+	s.Nodes = Layout(c.Root, layoutW, layoutH, s.Size, s.Labels)
+
+	if layoutW < c.Width || layoutH < c.Height {
+		if s.LegendConfig != nil {
+			wReduce, hReduce := s.LegendConfig.ReserveSpace()
+			dx, dy := legend.LayoutOffset(s.LegendConfig, wReduce, hReduce)
+			OffsetNodes(&s.Nodes, dx, dy)
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
Fixes #282

## Summary
- reserve bubbletree layout space for legends using the same shared helpers as treemap
- offset the laid out bubble nodes into the remaining drawable area
- add regression coverage for top and left legend reservations

## Verification
- task build
- task test