### PR TITLE
Add gaps between radial folder groups

### DIFF
--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -10,6 +10,14 @@
 
 <!-- Append learnings below -->
 
+### Issue #284 — Radial Group Gaps (2026-05-23)
+
+- **Layout pattern:** `internal/radialtree/layout.go` is the sole source of angular placement; rendering in `internal/radialtree/render.go` just consumes node angles/positions, so visual spacing changes belong in layout, not rendering.
+- **Gap design:** Non-root directory sectors now reserve one child-sized blank slot at both the leading and trailing edges of the sector. This keeps sibling folder groups visually separated without adding CLI/config surface.
+- **Allocation rule:** Angular budgeting must count empty directories too. `childAllocationUnits()` sums direct files plus `childWeight()` for each subdir, where empty subdirs still reserve one unit instead of collapsing onto the same angle.
+- **Regression coverage:** `internal/radialtree/layout_test.go` now covers both grouped file gaps and empty sibling directories getting distinct sectors.
+- **Key files:** `internal/radialtree/layout.go`, `internal/radialtree/layout_test.go`, `cmd/codeviz/radialtree_cmd.go`.
+
 ### PR Review Etiquette (Team Directive, 2026-05-13)
 
 - **PR review reply protocol:** After addressing a PR review comment, ALWAYS reply to the comment indicating what was done. Don't leave reviewers hanging. This closes the feedback loop and keeps communication clear for all stakeholders.

--- a/cmd/codeviz/bubbletree_cmd.go
+++ b/cmd/codeviz/bubbletree_cmd.go
@@ -17,8 +17,7 @@ type BubbletreeCmd struct {
 	TargetPath string `arg:"" help:"Path to directory to scan."`
 	Output     string `help:"Output image file path (png, jpg, jpeg, svg)." required:"true" short:"o"`
 
-	//nolint:revive // kong struct tags require long lines
-	Size metric.Name `default:"" help:"Metric for circle size; run 'codeviz help-metrics' for available metrics." short:"s"`
+	Size metric.Name `default:"" help:"Metric for circle size; run 'codeviz help-metrics' for available metrics." short:"s"` //nolint:revive,nolintlint // kong struct tags require long lines
 
 	Fill config.MetricSpec `help:"Fill colour: metric[,palette] (e.g. file-type,categorization)." optional:"" short:"f"`
 
@@ -26,11 +25,8 @@ type BubbletreeCmd struct {
 
 	Labels string `enum:",all,folders,none" default:"" help:"Labels to display: all, folders, or none."`
 
-	//nolint:revive // kong struct tags require long lines
-	Legend string `default:"" enum:",top-left,top-center,top-right,center-right,bottom-right,bottom-center,bottom-left,center-left,none" help:"Legend position (default: bottom-right)." optional:""`
-
-	//nolint:revive // kong struct tags require long lines
-	LegendOrientation string `default:"" enum:",vertical,horizontal" help:"Legend orientation (auto-detected from position if omitted)." name:"legend-orientation" optional:""`
+	Legend            string `default:"" enum:",top-left,top-center,top-right,center-right,bottom-right,bottom-center,bottom-left,center-left,none" help:"Legend position (default: bottom-right)." optional:""` //nolint:revive,nolintlint // kong struct tags require long lines
+	LegendOrientation string `default:"" enum:",vertical,horizontal" help:"Legend orientation (auto-detected from position if omitted)." name:"legend-orientation" optional:""`                                  //nolint:revive,nolintlint // kong struct tags require long lines
 
 	Width  int `default:"1920" help:"Image width in pixels."`
 	Height int `default:"1080" help:"Image height in pixels."`

--- a/cmd/codeviz/main_test.go
+++ b/cmd/codeviz/main_test.go
@@ -80,6 +80,41 @@ func TestCLI_ParsesTreemapFlatFlag(t *testing.T) {
 	g.Expect(cli.Render.Treemap.Flat).To(BeTrue())
 }
 
+func TestCLI_BubbletreeLegendFlags_UseKongEnumValidation(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "legend",
+			args:    []string{"render", "bubbletree", ".", "-o", "out.png", "--legend", "sideways"},
+			wantErr: "--legend must be one of",
+		},
+		{
+			name:    "legend-orientation",
+			args:    []string{"render", "bubbletree", ".", "-o", "out.png", "--legend-orientation", "diagonal"},
+			wantErr: "--legend-orientation must be one of",
+		},
+	}
+
+	for _, tc := range cases {
+		cli := CLI{}
+		parser, err := kong.New(
+			&cli,
+			kong.Name("codeviz"),
+			kong.Exit(func(int) {}),
+		)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		_, err = parser.Parse(tc.args)
+		g.Expect(err).To(MatchError(ContainSubstring(tc.wantErr)), tc.name)
+	}
+}
+
 func TestClassifyNoFilesAfterFilterError(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)

--- a/internal/radialtree/layout.go
+++ b/internal/radialtree/layout.go
@@ -98,10 +98,7 @@ func layoutDir(
 	angle := startAngle + sweepAngle/2
 	radius := float64(depth) * ringSpacing
 
-	dirDisc := ringSpacing * dirDiscFactor
-	if dirDisc < minDirDisc {
-		dirDisc = minDirDisc
-	}
+	dirDisc := math.Max(ringSpacing*dirDiscFactor, minDirDisc)
 
 	node := RadialNode{
 		X:           radius * math.Cos(angle),
@@ -120,6 +117,7 @@ func layoutDir(
 
 	contentSweep := sweepAngle
 	childStart := startAngle
+
 	if depth > 0 {
 		// Reserve one child-sized blank slot on each side of non-root directory
 		// groups so sibling folders don't run directly into each other.

--- a/internal/radialtree/layout.go
+++ b/internal/radialtree/layout.go
@@ -113,18 +113,27 @@ func layoutDir(
 		ShowLabel:   labels == LabelAll || labels == LabelFoldersOnly,
 	}
 
-	parentLeafCount := computeLeafCount(dir)
-	if parentLeafCount == 0 {
-		parentLeafCount = 1
+	allocationUnits := childAllocationUnits(dir)
+	if allocationUnits == 0 {
+		return node
 	}
 
+	contentSweep := sweepAngle
 	childStart := startAngle
-	childRadius := float64(depth+1) * ringSpacing
+	if depth > 0 {
+		// Reserve one child-sized blank slot on each side of non-root directory
+		// groups so sibling folders don't run directly into each other.
+		paddingSweep := sweepAngle / float64(allocationUnits+2)
+		contentSweep -= 2 * paddingSweep
+		childStart += paddingSweep
+	}
 
-	// Files first: each file is a leaf occupying 1/parentLeafCount of the sweep.
+	childRadius := float64(depth+1) * ringSpacing
+	fileSweep := contentSweep / float64(allocationUnits)
+
+	// Files first: each file occupies one allocation unit of the padded sweep.
 	for _, f := range dir.Files {
-		childSweep := sweepAngle / float64(parentLeafCount)
-		childAngle := childStart + childSweep/2
+		childAngle := childStart + fileSweep/2
 
 		fileNode := RadialNode{
 			X:           childRadius * math.Cos(childAngle),
@@ -137,17 +146,14 @@ func layoutDir(
 		}
 
 		node.Children = append(node.Children, fileNode)
-		childStart += childSweep
+		childStart += fileSweep
 	}
 
-	// Subdirs: each gets a proportional slice of the sweep based on its leaf count.
+	// Subdirs: each gets a proportional slice of the padded sweep based on its
+	// file-leaf weight, with empty directories still reserving one unit.
 	for _, d := range dir.Dirs {
-		childLeafCount := computeLeafCount(d)
-		if childLeafCount == 0 {
-			childLeafCount = 1
-		}
-
-		childSweep := float64(childLeafCount) / float64(parentLeafCount) * sweepAngle
+		weight := childWeight(d)
+		childSweep := float64(weight) / float64(allocationUnits) * contentSweep
 		child := layoutDir(d, depth+1, childStart, childSweep, ringSpacing, discMetric, labels, dp)
 		node.Children = append(node.Children, child)
 		childStart += childSweep
@@ -209,6 +215,24 @@ func computeLeafCount(dir *model.Directory) int {
 	}
 
 	return count
+}
+
+func childAllocationUnits(dir *model.Directory) int {
+	units := len(dir.Files)
+	for _, d := range dir.Dirs {
+		units += childWeight(d)
+	}
+
+	return units
+}
+
+func childWeight(dir *model.Directory) int {
+	leafCount := computeLeafCount(dir)
+	if leafCount == 0 {
+		return 1
+	}
+
+	return leafCount
 }
 
 // computeMaxDepth returns the maximum depth of any node in the tree rooted at dir.

--- a/internal/radialtree/layout_test.go
+++ b/internal/radialtree/layout_test.go
@@ -113,6 +113,65 @@ func TestLayoutAnglesFullCircle(t *testing.T) {
 	}
 }
 
+func TestLayoutDirectoryGroupsAddAngularGaps(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := &model.Directory{
+		Name: "root",
+		Dirs: []*model.Directory{
+			{
+				Name: "species",
+				Files: []*model.File{
+					makeFile("centauri", 100),
+					makeFile("human", 100),
+				},
+			},
+			{
+				Name: "ambassadors",
+				Files: []*model.File{
+					makeFile("delenn", 100),
+					makeFile("gkar", 100),
+				},
+			},
+		},
+	}
+
+	node := Layout(root, 800, filesystem.FileSize, LabelAll)
+	g.Expect(node.Children).To(HaveLen(2))
+	g.Expect(node.Children[0].Children).To(HaveLen(2))
+	g.Expect(node.Children[1].Children).To(HaveLen(2))
+
+	speciesGap := clockwiseGap(node.Children[0].Children[0].Angle, node.Children[0].Children[1].Angle)
+	ambassadorsGap := clockwiseGap(node.Children[1].Children[0].Angle, node.Children[1].Children[1].Angle)
+	betweenGroups := clockwiseGap(node.Children[0].Children[1].Angle, node.Children[1].Children[0].Angle)
+	wrapGap := clockwiseGap(node.Children[1].Children[1].Angle, node.Children[0].Children[0].Angle)
+
+	g.Expect(speciesGap).To(BeNumerically("~", ambassadorsGap, 0.001))
+	g.Expect(betweenGroups).To(BeNumerically(">", speciesGap))
+	g.Expect(betweenGroups).To(BeNumerically("~", wrapGap, 0.001))
+}
+
+func TestLayoutEmptySiblingDirectoriesGetDistinctSectors(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := &model.Directory{
+		Name: "root",
+		Dirs: []*model.Directory{
+			{Name: "empty-a"},
+			{Name: "empty-b"},
+		},
+	}
+
+	node := Layout(root, 800, filesystem.FileSize, LabelAll)
+	g.Expect(node.Children).To(HaveLen(2))
+	g.Expect(node.Children[0].Angle).NotTo(BeNumerically("~", node.Children[1].Angle, 0.001))
+
+	gap := clockwiseGap(node.Children[0].Angle, node.Children[1].Angle)
+	g.Expect(gap).To(BeNumerically("~", math.Pi, 0.001))
+}
+
 func TestLayoutNestedDepth(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
@@ -359,4 +418,17 @@ func TestClamp_AtBoundaries(t *testing.T) {
 
 	g.Expect(clamp(0.0, 0.0, 10.0)).To(BeNumerically("==", 0.0))
 	g.Expect(clamp(10.0, 0.0, 10.0)).To(BeNumerically("==", 10.0))
+}
+
+func clockwiseGap(from, to float64) float64 {
+	return math.Mod(normalizeAngle(to)-normalizeAngle(from)+2*math.Pi, 2*math.Pi)
+}
+
+func normalizeAngle(angle float64) float64 {
+	normalized := math.Mod(angle, 2*math.Pi)
+	if normalized < 0 {
+		normalized += 2 * math.Pi
+	}
+
+	return normalized
 }


### PR DESCRIPTION
Fixes #284

## Summary
- reserve leading and trailing angular padding inside non-root radial directory sectors
- count empty directories in angular allocation so sibling empty folders still get distinct sectors
- add regression tests for grouped folder gaps and empty sibling directories