### PR TITLE
Feature: Scatter visualization type

### DIFF
--- a/cmd/codeviz/main_test.go
+++ b/cmd/codeviz/main_test.go
@@ -542,3 +542,70 @@ func TestScatterCmd_ValidateConfig_SizeMustBeNumeric(t *testing.T) {
 	err := cmd.validateConfig(cfg.Scatter)
 	g.Expect(err).To(MatchError(ContainSubstring("size metric must be numeric")))
 }
+
+func TestScatterCmd_ConfigSuppliesAxesAndSize(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	g.Expect(os.WriteFile(cfgPath, []byte("scatter:\n  xAxis: file-type\n  yAxis: file-lines\n  size: file-size\n"), 0o600)).To(Succeed())
+
+	cfg := config.New()
+	g.Expect(cfg.Load(cfgPath)).To(Succeed())
+
+	cmd := &ScatterCmd{TargetPath: ".", Output: "out.png"}
+	cmd.applyOverrides(cfg)
+
+	g.Expect(cfg.Scatter).NotTo(BeNil())
+	g.Expect(cfg.Scatter.XAxis).NotTo(BeNil())
+	g.Expect(*cfg.Scatter.XAxis).To(Equal("file-type"))
+	g.Expect(cfg.Scatter.YAxis).NotTo(BeNil())
+	g.Expect(*cfg.Scatter.YAxis).To(Equal("file-lines"))
+	g.Expect(cfg.Scatter.Size).NotTo(BeNil())
+	g.Expect(*cfg.Scatter.Size).To(Equal("file-size"))
+}
+
+func TestScatterCmd_CLIAxesOverrideConfig(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	g.Expect(os.WriteFile(cfgPath, []byte("scatter:\n  xAxis: file-lines\n  yAxis: file-size\n  size: file-size\n"), 0o600)).To(Succeed())
+
+	cfg := config.New()
+	g.Expect(cfg.Load(cfgPath)).To(Succeed())
+
+	cmd := &ScatterCmd{
+		TargetPath: ".",
+		Output:     "out.png",
+		XAxis:      "file-type",
+		YAxis:      "file-lines",
+		Size:       "file-size",
+	}
+	cmd.applyOverrides(cfg)
+
+	g.Expect(cfg.Scatter).NotTo(BeNil())
+	g.Expect(*cfg.Scatter.XAxis).To(Equal("file-type"))
+	g.Expect(*cfg.Scatter.YAxis).To(Equal("file-lines"))
+	g.Expect(*cfg.Scatter.Size).To(Equal("file-size"))
+}
+
+func TestScatterCmd_MergeConfigAndValidate_LoadsScatterConfig(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	g.Expect(os.WriteFile(cfgPath, []byte("scatter:\n  xAxis: file-type\n  yAxis: file-lines\n  size: file-size\n"), 0o600)).To(Succeed())
+
+	cfg := config.New()
+	g.Expect(cfg.Load(cfgPath)).To(Succeed())
+
+	cmd := &ScatterCmd{TargetPath: ".", Output: filepath.Join(dir, "out.png")}
+	flags := &Flags{Config: cfg, configPath: cfgPath}
+
+	err := cmd.mergeConfigAndValidate(flags)
+	g.Expect(err).NotTo(HaveOccurred())
+}

--- a/cmd/codeviz/main_test.go
+++ b/cmd/codeviz/main_test.go
@@ -549,7 +549,8 @@ func TestScatterCmd_ConfigSuppliesAxesAndSize(t *testing.T) {
 
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
-	g.Expect(os.WriteFile(cfgPath, []byte("scatter:\n  xAxis: file-type\n  yAxis: file-lines\n  size: file-size\n"), 0o600)).To(Succeed())
+	configText := "scatter:\n  xAxis: file-type\n  yAxis: file-lines\n  size: file-size\n"
+	g.Expect(os.WriteFile(cfgPath, []byte(configText), 0o600)).To(Succeed())
 
 	cfg := config.New()
 	g.Expect(cfg.Load(cfgPath)).To(Succeed())
@@ -572,7 +573,8 @@ func TestScatterCmd_CLIAxesOverrideConfig(t *testing.T) {
 
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
-	g.Expect(os.WriteFile(cfgPath, []byte("scatter:\n  xAxis: file-lines\n  yAxis: file-size\n  size: file-size\n"), 0o600)).To(Succeed())
+	configText := "scatter:\n  xAxis: file-lines\n  yAxis: file-size\n  size: file-size\n"
+	g.Expect(os.WriteFile(cfgPath, []byte(configText), 0o600)).To(Succeed())
 
 	cfg := config.New()
 	g.Expect(cfg.Load(cfgPath)).To(Succeed())
@@ -598,7 +600,8 @@ func TestScatterCmd_MergeConfigAndValidate_LoadsScatterConfig(t *testing.T) {
 
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
-	g.Expect(os.WriteFile(cfgPath, []byte("scatter:\n  xAxis: file-type\n  yAxis: file-lines\n  size: file-size\n"), 0o600)).To(Succeed())
+	configText := "scatter:\n  xAxis: file-type\n  yAxis: file-lines\n  size: file-size\n"
+	g.Expect(os.WriteFile(cfgPath, []byte(configText), 0o600)).To(Succeed())
 
 	cfg := config.New()
 	g.Expect(cfg.Load(cfgPath)).To(Succeed())

--- a/cmd/codeviz/main_test.go
+++ b/cmd/codeviz/main_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alecthomas/kong"
 
 	"github.com/theunrepentantgeek/code-visualizer/internal/config"
+	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
 	"github.com/theunrepentantgeek/code-visualizer/internal/model"
 	"github.com/theunrepentantgeek/code-visualizer/internal/provider/filesystem"
 	"github.com/theunrepentantgeek/code-visualizer/internal/provider/git"
@@ -471,4 +472,73 @@ func TestSpiralCmd_ValidateConfig_InvalidFillPalette(t *testing.T) {
 	cmd := &SpiralCmd{}
 	err := cmd.validateConfig(cfg.Spiral)
 	g.Expect(err).To(MatchError(ContainSubstring("invalid fill palette")))
+}
+
+func TestCLI_ParsesScatterAxisFlags(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	cli := CLI{}
+	parser, err := kong.New(
+		&cli,
+		kong.Name("codeviz"),
+		kong.Exit(func(int) {}),
+	)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	_, err = parser.Parse([]string{
+		"render", "scatter", ".",
+		"-o", "out.png",
+		"--x-axis", "file-type",
+		"--y-axis", "file-lines",
+		"-s", "file-size",
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(cli.Render.Scatter.XAxis).To(Equal(metric.Name("file-type")))
+	g.Expect(cli.Render.Scatter.YAxis).To(Equal(metric.Name("file-lines")))
+	g.Expect(cli.Render.Scatter.Size).To(Equal(metric.Name("file-size")))
+}
+
+func TestScatterCmd_Validate_EmptyAxesPass(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	cmd := &ScatterCmd{
+		TargetPath: ".",
+		Output:     "out.png",
+		XAxis:      "",
+		YAxis:      "",
+		Size:       "",
+	}
+
+	err := cmd.Validate()
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+func TestScatterCmd_ValidateConfig_CategoricalAxesAreAccepted(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	cfg := config.New()
+	cfg.Scatter.XAxis = new("file-type")
+	cfg.Scatter.YAxis = new("file-lines")
+	cfg.Scatter.Size = new("file-size")
+
+	cmd := &ScatterCmd{}
+	err := cmd.validateConfig(cfg.Scatter)
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+func TestScatterCmd_ValidateConfig_SizeMustBeNumeric(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	cfg := config.New()
+	cfg.Scatter.XAxis = new("file-type")
+	cfg.Scatter.YAxis = new("file-lines")
+	cfg.Scatter.Size = new("file-type")
+
+	cmd := &ScatterCmd{}
+	err := cmd.validateConfig(cfg.Scatter)
+	g.Expect(err).To(MatchError(ContainSubstring("size metric must be numeric")))
 }

--- a/cmd/codeviz/render_cmd.go
+++ b/cmd/codeviz/render_cmd.go
@@ -5,4 +5,5 @@ type RenderCmd struct {
 	Radial     RadialCmd     `cmd:"" help:"Generate a radial tree visualization."`
 	Bubbletree BubbletreeCmd `cmd:"" help:"Generate a bubble tree visualization."`
 	Spiral     SpiralCmd     `cmd:"" help:"Generate a spiral timeline visualization."`
+	Scatter    ScatterCmd    `cmd:"" help:"Generate a scatter plot visualization."`
 }

--- a/cmd/codeviz/scatter_cmd.go
+++ b/cmd/codeviz/scatter_cmd.go
@@ -54,6 +54,7 @@ func (*ScatterCmd) validateConfig(cfg *config.Scatter) error {
 
 	size := ptrString(cfg.Size)
 	d, ok := provider.GetDescriptor(metric.Name(size))
+
 	if !ok {
 		return eris.Errorf("unknown size metric %q; available metrics: %s", size, formatMetricNames())
 	}

--- a/cmd/codeviz/scatter_cmd.go
+++ b/cmd/codeviz/scatter_cmd.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"github.com/rotisserie/eris"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/config"
+	"github.com/theunrepentantgeek/code-visualizer/internal/filter"
+	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
+	"github.com/theunrepentantgeek/code-visualizer/internal/provider"
+)
+
+type ScatterCmd struct {
+	TargetPath string `arg:"" help:"Path to directory to scan."`
+	Output     string `help:"Output image file path (png, jpg, jpeg, svg)." required:"true" short:"o"`
+
+	XAxis metric.Name `default:"" help:"Metric for X-axis position; run 'codeviz help-metrics' for available metrics." name:"x-axis" short:"x"` //nolint:revive,nolintlint // kong struct tags require long lines
+	YAxis metric.Name `default:"" help:"Metric for Y-axis position; run 'codeviz help-metrics' for available metrics." name:"y-axis" short:"y"` //nolint:revive,nolintlint // kong struct tags require long lines
+	Size  metric.Name `default:"" help:"Metric for disc size; run 'codeviz help-metrics' for available metrics." short:"s"`        //nolint:revive,nolintlint // kong struct tags require long lines
+
+	Fill   config.MetricSpec `help:"Fill colour: metric[,palette] (e.g. file-type,categorization)." optional:"" short:"f"` //nolint:revive,nolintlint // kong struct tags require long lines
+	Border config.MetricSpec `help:"Border colour: metric[,palette] (e.g. file-lines,foliage)." optional:"" short:"b"`     //nolint:revive,nolintlint // kong struct tags require long lines
+
+	Legend            string `default:"" enum:",top-left,top-center,top-right,center-right,bottom-right,bottom-center,bottom-left,center-left,none" help:"Legend position (default: bottom-right)." optional:""` //nolint:revive,nolintlint // kong struct tags require long lines
+	LegendOrientation string `default:"" enum:",vertical,horizontal" help:"Legend orientation (auto-detected from position if omitted)." name:"legend-orientation" optional:""`                                  //nolint:revive,nolintlint // kong struct tags require long lines
+
+	Width  int `default:"1920" help:"Image width in pixels."`
+	Height int `default:"1080" help:"Image height in pixels."`
+
+	Filter             []string `help:"Filter rule: glob to include, !glob to exclude (repeatable, order-preserved)."`
+	IncludeBinaryFiles bool     `help:"Include binary files in the visualization (excluded by default)." name:"include-binary-files" optional:""` //nolint:revive,nolintlint // kong struct tags require long lines
+}
+
+func (c *ScatterCmd) Validate() error {
+	for _, f := range c.Filter {
+		if _, err := filter.ParseFilterFlag(f); err != nil {
+			return eris.Wrapf(err, "invalid filter %q", f)
+		}
+	}
+
+	return nil
+}
+
+func (*ScatterCmd) validateConfig(cfg *config.Scatter) error {
+	if err := validateScatterAxisMetric("x-axis", cfg.XAxis); err != nil {
+		return err
+	}
+
+	if err := validateScatterAxisMetric("y-axis", cfg.YAxis); err != nil {
+		return err
+	}
+
+	size := ptrString(cfg.Size)
+	d, ok := provider.GetDescriptor(metric.Name(size))
+	if !ok {
+		return eris.Errorf("unknown size metric %q; available metrics: %s", size, formatMetricNames())
+	}
+
+	if d.Kind != metric.Quantity && d.Kind != metric.Measure {
+		return eris.Errorf("size metric must be numeric, got %q (kind: %d)", size, d.Kind)
+	}
+
+	if err := cfg.Fill.Validate("fill"); err != nil {
+		return eris.Wrap(err, "invalid fill spec")
+	}
+
+	if err := cfg.Border.Validate("border"); err != nil {
+		return eris.Wrap(err, "invalid border spec")
+	}
+
+	return nil
+}
+
+func validateScatterAxisMetric(label string, name *string) error {
+	axis := ptrString(name)
+	if _, ok := provider.GetDescriptor(metric.Name(axis)); !ok {
+		return eris.Errorf("unknown %s metric %q; available metrics: %s", label, axis, formatMetricNames())
+	}
+
+	return nil
+}
+
+func (c *ScatterCmd) applyOverrides(cfg *config.Config) {
+	cfg.OverrideWidth(c.Width)
+	cfg.OverrideHeight(c.Height)
+
+	if cfg.Scatter == nil {
+		cfg.Scatter = &config.Scatter{}
+	}
+
+	cfg.Scatter.OverrideXAxis(string(c.XAxis))
+	cfg.Scatter.OverrideYAxis(string(c.YAxis))
+	cfg.Scatter.OverrideSize(string(c.Size))
+	cfg.Scatter.OverrideFill(c.Fill)
+	cfg.Scatter.OverrideBorder(c.Border)
+	cfg.Scatter.OverrideLegend(c.Legend)
+	cfg.Scatter.OverrideLegendOrientation(c.LegendOrientation)
+}

--- a/cmd/codeviz/scatter_cmd.go
+++ b/cmd/codeviz/scatter_cmd.go
@@ -6,7 +6,10 @@ import (
 	"github.com/theunrepentantgeek/code-visualizer/internal/config"
 	"github.com/theunrepentantgeek/code-visualizer/internal/filter"
 	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
+	"github.com/theunrepentantgeek/code-visualizer/internal/pipeline"
 	"github.com/theunrepentantgeek/code-visualizer/internal/provider"
+	scatterviz "github.com/theunrepentantgeek/code-visualizer/internal/scatter"
+	"github.com/theunrepentantgeek/code-visualizer/internal/stages"
 )
 
 type ScatterCmd struct {
@@ -15,7 +18,7 @@ type ScatterCmd struct {
 
 	XAxis metric.Name `default:"" help:"Metric for X-axis position; run 'codeviz help-metrics' for available metrics." name:"x-axis" short:"x"` //nolint:revive,nolintlint // kong struct tags require long lines
 	YAxis metric.Name `default:"" help:"Metric for Y-axis position; run 'codeviz help-metrics' for available metrics." name:"y-axis" short:"y"` //nolint:revive,nolintlint // kong struct tags require long lines
-	Size  metric.Name `default:"" help:"Metric for disc size; run 'codeviz help-metrics' for available metrics." short:"s"`        //nolint:revive,nolintlint // kong struct tags require long lines
+	Size  metric.Name `default:"" help:"Metric for disc size; run 'codeviz help-metrics' for available metrics." short:"s"`                     //nolint:revive,nolintlint // kong struct tags require long lines
 
 	Fill   config.MetricSpec `help:"Fill colour: metric[,palette] (e.g. file-type,categorization)." optional:"" short:"f"` //nolint:revive,nolintlint // kong struct tags require long lines
 	Border config.MetricSpec `help:"Border colour: metric[,palette] (e.g. file-lines,foliage)." optional:"" short:"b"`     //nolint:revive,nolintlint // kong struct tags require long lines
@@ -77,6 +80,56 @@ func validateScatterAxisMetric(label string, name *string) error {
 	}
 
 	return nil
+}
+
+func (c *ScatterCmd) mergeConfigAndValidate(flags *Flags) error {
+	if err := flags.Config.TryAutoLoad(c.Output); err != nil {
+		return eris.Wrap(err, "auto-config load failed")
+	}
+
+	c.applyOverrides(flags.Config)
+
+	return c.validateConfig(flags.Config.Scatter)
+}
+
+func (c *ScatterCmd) Run(flags *Flags) error {
+	if err := c.mergeConfigAndValidate(flags); err != nil {
+		return err
+	}
+
+	state := &scatterviz.State{
+		CommonState: stages.CommonState{
+			TargetPath: c.TargetPath,
+			Output:     c.Output,
+			Flags:      toStagesFlags(flags),
+			RootConfig: flags.Config,
+			CLIFilters: c.Filter,
+		},
+		Config:             flags.Config.Scatter,
+		IncludeBinaryFiles: c.IncludeBinaryFiles,
+	}
+
+	_, err := pipeline.Run[*scatterviz.State](
+		state,
+		stages.ValidatePaths,
+		stages.ExportConfig,
+		stages.BuildFilterRules,
+		scatterviz.ResolveMetrics,
+		stages.ScanFilesystem,
+		stages.CheckGitRequirement,
+		stages.RunProviders,
+		stages.FilterBinaryFiles,
+		stages.ExportData,
+		stages.ResolveDimensions,
+		scatterviz.BuildInksStage,
+		scatterviz.BuildLegendStage,
+		scatterviz.LayoutStage,
+		scatterviz.RenderStage,
+		stages.WriteCanvas,
+		scatterviz.LogResult,
+	)
+
+	return eris.Wrap(err, "scatter pipeline failed")
 }
 
 func (c *ScatterCmd) applyOverrides(cfg *config.Config) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	Radial     *Radial       `yaml:"radial,omitempty"     json:"radial,omitempty"`
 	Bubbletree *Bubbletree   `yaml:"bubbletree,omitempty" json:"bubbletree,omitempty"`
 	Spiral     *Spiral       `yaml:"spiral,omitempty"     json:"spiral,omitempty"`
+	Scatter    *Scatter      `yaml:"scatter,omitempty"    json:"scatter,omitempty"`
 	FileFilter []filter.Rule `yaml:"fileFilter,omitempty" json:"fileFilter,omitempty"`
 
 	// Source is the path of the config file from which this Config was loaded, or nil if it was not loaded from a file.
@@ -54,6 +55,7 @@ func New() *Config {
 		Radial:     &Radial{Labels: new("all")},
 		Bubbletree: &Bubbletree{Labels: new("folders")},
 		Spiral:     &Spiral{Resolution: new("daily"), Labels: new("laps")},
+		Scatter:    &Scatter{},
 		FileFilter: []filter.Rule{
 			{Pattern: ".*", Mode: filter.Exclude},
 		},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -505,3 +505,38 @@ func TestTryAutoLoad_AlreadyLoaded_SkipsAutoLoad(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(*cfg.Width).To(Equal(1600)) // unchanged
 }
+
+func TestNew_ScatterDefaultsSet(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	cfg := New()
+
+	g.Expect(cfg.Scatter).NotTo(BeNil())
+}
+
+func TestLoad_ScatterConfig_ParsesAxesAndSize(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := `scatter:
+  xAxis: file-type
+  yAxis: file-lines
+  size: file-size
+`
+	g.Expect(os.WriteFile(path, []byte(content), 0o600)).To(Succeed())
+
+	cfg := New()
+	err := cfg.Load(path)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(cfg.Scatter).NotTo(BeNil())
+	g.Expect(cfg.Scatter.XAxis).NotTo(BeNil())
+	g.Expect(*cfg.Scatter.XAxis).To(Equal("file-type"))
+	g.Expect(cfg.Scatter.YAxis).NotTo(BeNil())
+	g.Expect(*cfg.Scatter.YAxis).To(Equal("file-lines"))
+	g.Expect(cfg.Scatter.Size).NotTo(BeNil())
+	g.Expect(*cfg.Scatter.Size).To(Equal("file-size"))
+}

--- a/internal/config/scatter.go
+++ b/internal/config/scatter.go
@@ -1,0 +1,36 @@
+//nolint:dupl // Different visualization types will evolve in different ways
+package config
+
+// Scatter holds persistent configuration for scatter plot visualizations.
+// All fields are pointers: nil means the field was not configured, non-nil
+// means it was explicitly set (by a config file or by a CLI flag override).
+type Scatter struct {
+	XAxis             *string     `yaml:"xAxis,omitempty"             json:"xAxis,omitempty"`
+	YAxis             *string     `yaml:"yAxis,omitempty"             json:"yAxis,omitempty"`
+	Size              *string     `yaml:"size,omitempty"              json:"size,omitempty"`
+	Fill              *MetricSpec `yaml:"fill,omitempty"              json:"fill,omitempty"`
+	Border            *MetricSpec `yaml:"border,omitempty"            json:"border,omitempty"`
+	Legend            *string     `yaml:"legend,omitempty"            json:"legend,omitempty"`
+	LegendOrientation *string     `yaml:"legendOrientation,omitempty" json:"legendOrientation,omitempty"`
+}
+
+// OverrideXAxis sets XAxis to v if v is non-empty.
+func (s *Scatter) OverrideXAxis(v string) { overrideString(&s.XAxis, v) }
+
+// OverrideYAxis sets YAxis to v if v is non-empty.
+func (s *Scatter) OverrideYAxis(v string) { overrideString(&s.YAxis, v) }
+
+// OverrideSize sets Size to v if v is non-empty.
+func (s *Scatter) OverrideSize(v string) { overrideString(&s.Size, v) }
+
+// OverrideFill sets Fill to v if v is non-zero.
+func (s *Scatter) OverrideFill(v MetricSpec) { overrideMetricSpec(&s.Fill, v) }
+
+// OverrideBorder sets Border to v if v is non-zero.
+func (s *Scatter) OverrideBorder(v MetricSpec) { overrideMetricSpec(&s.Border, v) }
+
+// OverrideLegend sets Legend to v if v is non-empty.
+func (s *Scatter) OverrideLegend(v string) { overrideString(&s.Legend, v) }
+
+// OverrideLegendOrientation sets LegendOrientation to v if v is non-empty.
+func (s *Scatter) OverrideLegendOrientation(v string) { overrideString(&s.LegendOrientation, v) }

--- a/internal/config/spiral.go
+++ b/internal/config/spiral.go
@@ -1,3 +1,4 @@
+//nolint:dupl // Different visualization types will evolve in different ways
 package config
 
 // Spiral holds persistent configuration for spiral timeline visualizations.

--- a/internal/scatter/axis.go
+++ b/internal/scatter/axis.go
@@ -1,0 +1,58 @@
+package scatter
+
+import "github.com/theunrepentantgeek/code-visualizer/internal/metric"
+
+// AxisSpec identifies the metric and kind used for one scatter axis.
+type AxisSpec struct {
+	Metric metric.Name
+	Kind   metric.Kind
+}
+
+// AxisValue carries one file's resolved value for a scatter axis.
+type AxisValue struct {
+	Numeric  float64
+	Category string
+}
+
+// PlotRect is the drawable chart area after reserving margins.
+type PlotRect struct {
+	X float64
+	Y float64
+	W float64
+	H float64
+}
+
+// AxisTick is a labeled numeric tick at an absolute canvas position.
+type AxisTick struct {
+	Value    float64
+	Label    string
+	Position float64
+}
+
+// AxisBand is a categorical swimlane spanning absolute canvas positions.
+type AxisBand struct {
+	Label  string
+	Start  float64
+	End    float64
+	Center float64
+}
+
+// NumericAxis holds the numeric range and ticks for one axis.
+type NumericAxis struct {
+	Min   float64
+	Max   float64
+	Ticks []AxisTick
+}
+
+// CategoricalAxis holds the categorical swimlanes for one axis.
+type CategoricalAxis struct {
+	Bands []AxisBand
+}
+
+// ResolvedAxis is the layout-ready representation of a scatter axis.
+type ResolvedAxis struct {
+	Spec        AxisSpec
+	Title       string
+	Numeric     *NumericAxis
+	Categorical *CategoricalAxis
+}

--- a/internal/scatter/axis.go
+++ b/internal/scatter/axis.go
@@ -36,23 +36,3 @@ type AxisBand struct {
 	End    float64
 	Center float64
 }
-
-// NumericAxis holds the numeric range and ticks for one axis.
-type NumericAxis struct {
-	Min   float64
-	Max   float64
-	Ticks []AxisTick
-}
-
-// CategoricalAxis holds the categorical swimlanes for one axis.
-type CategoricalAxis struct {
-	Bands []AxisBand
-}
-
-// ResolvedAxis is the layout-ready representation of a scatter axis.
-type ResolvedAxis struct {
-	Spec        AxisSpec
-	Title       string
-	Numeric     *NumericAxis
-	Categorical *CategoricalAxis
-}

--- a/internal/scatter/data.go
+++ b/internal/scatter/data.go
@@ -47,15 +47,19 @@ func CollectDataset(root *model.Directory, xAxis, yAxis AxisSpec, sizeMetric met
 		x, okX := axisValueForFile(file, xAxis)
 		y, okY := axisValueForFile(file, yAxis)
 		size, okSize := numericValueForFile(file, sizeMetric)
+
 		if !okX {
 			dataset.Skipped.MissingX++
 		}
+
 		if !okY {
 			dataset.Skipped.MissingY++
 		}
+
 		if !okSize {
 			dataset.Skipped.MissingSize++
 		}
+
 		if !okX || !okY || !okSize {
 			return
 		}
@@ -81,6 +85,7 @@ func axisValueForFile(file *model.File, axis AxisSpec) (AxisValue, bool) {
 		if value, ok := file.Quantity(axis.Metric); ok {
 			return AxisValue{Numeric: float64(value)}, true
 		}
+
 		if value, ok := file.Measure(axis.Metric); ok {
 			return AxisValue{Numeric: value}, true
 		}
@@ -93,6 +98,7 @@ func numericValueForFile(file *model.File, name metric.Name) (float64, bool) {
 	if value, ok := file.Quantity(name); ok {
 		return float64(value), true
 	}
+
 	if value, ok := file.Measure(name); ok {
 		return value, true
 	}

--- a/internal/scatter/data.go
+++ b/internal/scatter/data.go
@@ -1,0 +1,101 @@
+package scatter
+
+import (
+	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
+	"github.com/theunrepentantgeek/code-visualizer/internal/model"
+)
+
+// PointDatum holds the resolved metric values for one plottable file.
+type PointDatum struct {
+	File *model.File
+	X    AxisValue
+	Y    AxisValue
+	Size float64
+}
+
+// SkipCounts records how many files were excluded for missing required values.
+type SkipCounts struct {
+	MissingX    int
+	MissingY    int
+	MissingSize int
+}
+
+// Dataset is the subset of files that can be plotted, plus skip statistics.
+type Dataset struct {
+	Points  []PointDatum
+	Skipped SkipCounts
+}
+
+// Files returns the plotted files in dataset order.
+func (d Dataset) Files() []*model.File {
+	files := make([]*model.File, 0, len(d.Points))
+	for _, point := range d.Points {
+		files = append(files, point.File)
+	}
+
+	return files
+}
+
+// CollectDataset walks the tree and keeps only files with X, Y, and size values.
+func CollectDataset(root *model.Directory, xAxis, yAxis AxisSpec, sizeMetric metric.Name) Dataset {
+	dataset := Dataset{}
+	if root == nil {
+		return dataset
+	}
+
+	model.WalkFiles(root, func(file *model.File) {
+		x, okX := axisValueForFile(file, xAxis)
+		y, okY := axisValueForFile(file, yAxis)
+		size, okSize := numericValueForFile(file, sizeMetric)
+		if !okX {
+			dataset.Skipped.MissingX++
+		}
+		if !okY {
+			dataset.Skipped.MissingY++
+		}
+		if !okSize {
+			dataset.Skipped.MissingSize++
+		}
+		if !okX || !okY || !okSize {
+			return
+		}
+
+		dataset.Points = append(dataset.Points, PointDatum{
+			File: file,
+			X:    x,
+			Y:    y,
+			Size: size,
+		})
+	})
+
+	return dataset
+}
+
+func axisValueForFile(file *model.File, axis AxisSpec) (AxisValue, bool) {
+	switch axis.Kind {
+	case metric.Classification:
+		if value, ok := file.Classification(axis.Metric); ok {
+			return AxisValue{Category: value}, true
+		}
+	default:
+		if value, ok := file.Quantity(axis.Metric); ok {
+			return AxisValue{Numeric: float64(value)}, true
+		}
+		if value, ok := file.Measure(axis.Metric); ok {
+			return AxisValue{Numeric: value}, true
+		}
+	}
+
+	return AxisValue{}, false
+}
+
+func numericValueForFile(file *model.File, name metric.Name) (float64, bool) {
+	if value, ok := file.Quantity(name); ok {
+		return float64(value), true
+	}
+	if value, ok := file.Measure(name); ok {
+		return value, true
+	}
+
+	return 0, false
+}

--- a/internal/scatter/inks.go
+++ b/internal/scatter/inks.go
@@ -64,28 +64,41 @@ func buildMetricInk(
 	}
 
 	pal := palette.GetPalette(paletteName)
+
 	if descriptor.Kind == metric.Quantity || descriptor.Kind == metric.Measure {
-		values := make([]float64, 0, len(files))
-		for _, file := range files {
-			if value, ok := numericValueForFile(file, name); ok {
-				values = append(values, value)
-			}
-		}
-		if len(values) == 0 {
-			return canvas.FixedInk(fallback)
-		}
-
-		return canvas.NumericInk(name, values, pal)
+		return buildNumericInk(files, name, pal, fallback)
 	}
 
-	seen := map[string]bool{}
-	categories := make([]string, 0, len(files))
+	return buildCategoricalInk(files, name, pal, fallback)
+}
+
+func buildNumericInk(
+	files []*model.File,
+	name metric.Name,
+	pal palette.ColourPalette,
+	fallback color.RGBA,
+) canvas.Ink {
+	values := make([]float64, 0, len(files))
 	for _, file := range files {
-		if value, ok := file.Classification(name); ok && !seen[value] {
-			seen[value] = true
-			categories = append(categories, value)
+		if value, ok := numericValueForFile(file, name); ok {
+			values = append(values, value)
 		}
 	}
+
+	if len(values) == 0 {
+		return canvas.FixedInk(fallback)
+	}
+
+	return canvas.NumericInk(name, values, pal)
+}
+
+func buildCategoricalInk(
+	files []*model.File,
+	name metric.Name,
+	pal palette.ColourPalette,
+	fallback color.RGBA,
+) canvas.Ink {
+	categories := uniqueCategories(files, name)
 	if len(categories) == 0 {
 		return canvas.FixedInk(fallback)
 	}
@@ -93,4 +106,18 @@ func buildMetricInk(
 	slices.Sort(categories)
 
 	return canvas.CategoricalInk(name, categories, pal)
+}
+
+func uniqueCategories(files []*model.File, name metric.Name) []string {
+	seen := map[string]bool{}
+	categories := make([]string, 0, len(files))
+
+	for _, file := range files {
+		if value, ok := file.Classification(name); ok && !seen[value] {
+			seen[value] = true
+			categories = append(categories, value)
+		}
+	}
+
+	return categories
 }

--- a/internal/scatter/inks.go
+++ b/internal/scatter/inks.go
@@ -1,0 +1,96 @@
+package scatter
+
+import (
+	"image/color"
+	"slices"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/canvas"
+	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
+	"github.com/theunrepentantgeek/code-visualizer/internal/model"
+	"github.com/theunrepentantgeek/code-visualizer/internal/palette"
+	"github.com/theunrepentantgeek/code-visualizer/internal/provider"
+)
+
+var (
+	scatterDefaultFill   = color.RGBA{R: 0xCC, G: 0xCC, B: 0xCC, A: 0xFF}
+	scatterDefaultBorder = color.RGBA{R: 0x33, G: 0x33, B: 0x33, A: 0xFF}
+	scatterAxisColour    = color.RGBA{R: 0x77, G: 0x77, B: 0x77, A: 0xFF}
+	scatterGridColour    = color.RGBA{R: 0xDD, G: 0xDD, B: 0xDD, A: 0xFF}
+	scatterLabelColour   = color.RGBA{R: 0x22, G: 0x22, B: 0x22, A: 0xFF}
+	scatterBgColour      = color.RGBA{R: 0xFF, G: 0xFF, B: 0xFF, A: 0xFF}
+)
+
+// Inks holds the fill and border inks for scatter points.
+type Inks struct {
+	Fill            canvas.Ink
+	Border          canvas.Ink
+	HasBorderMetric bool
+}
+
+// BuildInks creates point inks from the plotted dataset.
+func BuildInks(
+	dataset Dataset,
+	fillMetric metric.Name,
+	fillPaletteName palette.PaletteName,
+	borderMetric metric.Name,
+	borderPaletteName palette.PaletteName,
+) Inks {
+	inks := Inks{
+		Fill:   buildMetricInk(dataset.Files(), fillMetric, fillPaletteName, scatterDefaultFill),
+		Border: canvas.FixedInk(scatterDefaultBorder),
+	}
+
+	if borderMetric != "" {
+		inks.Border = buildMetricInk(dataset.Files(), borderMetric, borderPaletteName, scatterDefaultBorder)
+		inks.HasBorderMetric = true
+	}
+
+	return inks
+}
+
+func buildMetricInk(
+	files []*model.File,
+	name metric.Name,
+	paletteName palette.PaletteName,
+	fallback color.RGBA,
+) canvas.Ink {
+	if name == "" {
+		return canvas.FixedInk(fallback)
+	}
+
+	descriptor, ok := provider.GetDescriptor(name)
+	if !ok {
+		return canvas.FixedInk(fallback)
+	}
+
+	pal := palette.GetPalette(paletteName)
+	if descriptor.Kind == metric.Quantity || descriptor.Kind == metric.Measure {
+		values := make([]float64, 0, len(files))
+		for _, file := range files {
+			if value, ok := numericValueForFile(file, name); ok {
+				values = append(values, value)
+			}
+		}
+		if len(values) == 0 {
+			return canvas.FixedInk(fallback)
+		}
+
+		return canvas.NumericInk(name, values, pal)
+	}
+
+	seen := map[string]bool{}
+	categories := make([]string, 0, len(files))
+	for _, file := range files {
+		if value, ok := file.Classification(name); ok && !seen[value] {
+			seen[value] = true
+			categories = append(categories, value)
+		}
+	}
+	if len(categories) == 0 {
+		return canvas.FixedInk(fallback)
+	}
+
+	slices.Sort(categories)
+
+	return canvas.CategoricalInk(name, categories, pal)
+}

--- a/internal/scatter/layout.go
+++ b/internal/scatter/layout.go
@@ -38,6 +38,13 @@ type ScatterLayout struct {
 	Points []ScatterPoint
 }
 
+type axisDirection int
+
+const (
+	horizontalAxis axisDirection = iota
+	verticalAxis
+)
+
 // Layout converts the dataset into absolute plot geometry.
 func Layout(dataset Dataset, width, height int, xAxis, yAxis AxisSpec) ScatterLayout {
 	plot := PlotRect{
@@ -49,8 +56,8 @@ func Layout(dataset Dataset, width, height int, xAxis, yAxis AxisSpec) ScatterLa
 
 	layout := ScatterLayout{
 		Plot:  plot,
-		XAxis: resolveAxis(dataset.Points, plot, xAxis, true),
-		YAxis: resolveAxis(dataset.Points, plot, yAxis, false),
+		XAxis: resolveAxis(dataset.Points, plot, xAxis, horizontalAxis),
+		YAxis: resolveAxis(dataset.Points, plot, yAxis, verticalAxis),
 	}
 
 	minSize, maxSize := sizeExtent(dataset.Points)
@@ -61,8 +68,8 @@ func Layout(dataset Dataset, width, height int, xAxis, yAxis AxisSpec) ScatterLa
 	for _, point := range dataset.Points {
 		layout.Points = append(layout.Points, ScatterPoint{
 			File:   point.File,
-			X:      positionForValue(point.X, layout.XAxis, plot, true),
-			Y:      positionForValue(point.Y, layout.YAxis, plot, false),
+			X:      positionForValue(point.X, layout.XAxis, plot, horizontalAxis),
+			Y:      positionForValue(point.Y, layout.YAxis, plot, verticalAxis),
 			Radius: scaleRadius(point.Size, minSize, maxSize, minRadius, maxRadius),
 			Label:  point.File.Name,
 		})
@@ -83,40 +90,46 @@ func Layout(dataset Dataset, width, height int, xAxis, yAxis AxisSpec) ScatterLa
 func OffsetLayout(layout *ScatterLayout, dx, dy float64) {
 	layout.Plot.X += dx
 	layout.Plot.Y += dy
+
 	for i := range layout.XAxis.NumericTicks() {
 		layout.XAxis.Numeric.Ticks[i].Position += dx
 	}
+
 	for i := range layout.YAxis.NumericTicks() {
 		layout.YAxis.Numeric.Ticks[i].Position += dy
 	}
+
 	for i := range layout.XAxis.CategoricalBands() {
 		layout.XAxis.Categorical.Bands[i].Start += dx
 		layout.XAxis.Categorical.Bands[i].End += dx
 		layout.XAxis.Categorical.Bands[i].Center += dx
 	}
+
 	for i := range layout.YAxis.CategoricalBands() {
 		layout.YAxis.Categorical.Bands[i].Start += dy
 		layout.YAxis.Categorical.Bands[i].End += dy
 		layout.YAxis.Categorical.Bands[i].Center += dy
 	}
+
 	for i := range layout.Points {
 		layout.Points[i].X += dx
 		layout.Points[i].Y += dy
 	}
 }
 
-func resolveAxis(points []PointDatum, plot PlotRect, spec AxisSpec, horizontal bool) ResolvedAxis {
+func resolveAxis(points []PointDatum, plot PlotRect, spec AxisSpec, direction axisDirection) ResolvedAxis {
 	axis := ResolvedAxis{Spec: spec, Title: string(spec.Metric)}
 	if spec.Kind == metric.Classification {
-		axis.Categorical = &CategoricalAxis{Bands: categoricalBands(points, plot, spec, horizontal)}
+		axis.Categorical = &CategoricalAxis{Bands: categoricalBands(points, plot, direction)}
+
 		return axis
 	}
 
-	minValue, maxValue := numericExtent(points, spec, horizontal)
+	minValue, maxValue := numericExtent(points, direction)
 	axis.Numeric = &NumericAxis{
 		Min:   minValue,
 		Max:   maxValue,
-		Ticks: numericTicks(minValue, maxValue, plot, horizontal),
+		Ticks: numericTicks(minValue, maxValue, plot, direction),
 	}
 
 	return axis
@@ -138,19 +151,21 @@ func (a ResolvedAxis) CategoricalBands() []AxisBand {
 	return a.Categorical.Bands
 }
 
-func numericExtent(points []PointDatum, spec AxisSpec, horizontal bool) (float64, float64) {
+func numericExtent(points []PointDatum, direction axisDirection) (minValue, maxValue float64) {
 	if len(points) == 0 {
 		return 0, 0
 	}
 
-	first := axisNumeric(points[0], spec, horizontal)
-	minValue := first
-	maxValue := first
+	first := direction.numericValue(points[0])
+	minValue = first
+	maxValue = first
+
 	for _, point := range points[1:] {
-		value := axisNumeric(point, spec, horizontal)
+		value := direction.numericValue(point)
 		if value < minValue {
 			minValue = value
 		}
+
 		if value > maxValue {
 			maxValue = value
 		}
@@ -159,11 +174,12 @@ func numericExtent(points []PointDatum, spec AxisSpec, horizontal bool) (float64
 	return minValue, maxValue
 }
 
-func categoricalBands(points []PointDatum, plot PlotRect, spec AxisSpec, horizontal bool) []AxisBand {
+func categoricalBands(points []PointDatum, plot PlotRect, direction axisDirection) []AxisBand {
 	labels := make([]string, 0, len(points))
 	seen := map[string]bool{}
+
 	for _, point := range points {
-		label := axisCategory(point, spec, horizontal)
+		label := direction.categoryValue(point)
 		if !seen[label] {
 			seen[label] = true
 			labels = append(labels, label)
@@ -171,18 +187,15 @@ func categoricalBands(points []PointDatum, plot PlotRect, spec AxisSpec, horizon
 	}
 
 	slices.Sort(labels)
+
 	if len(labels) == 0 {
 		return nil
 	}
 
+	origin, span := direction.span(plot)
 	bands := make([]AxisBand, len(labels))
-	span := plot.W
-	origin := plot.X
-	if !horizontal {
-		span = plot.H
-		origin = plot.Y
-	}
 	bandSize := span / float64(len(labels))
+
 	for i, label := range labels {
 		start := origin + float64(i)*bandSize
 		bands[i] = AxisBand{
@@ -196,25 +209,24 @@ func categoricalBands(points []PointDatum, plot PlotRect, spec AxisSpec, horizon
 	return bands
 }
 
-func numericTicks(minValue, maxValue float64, plot PlotRect, horizontal bool) []AxisTick {
+func numericTicks(minValue, maxValue float64, plot PlotRect, direction axisDirection) []AxisTick {
 	if minValue == maxValue {
-		position := plot.X + plot.W/2
-		if !horizontal {
-			position = plot.Y + plot.H/2
-		}
-
-		return []AxisTick{{Value: minValue, Label: formatTick(minValue), Position: position}}
+		return []AxisTick{{
+			Value:    minValue,
+			Label:    formatTick(minValue),
+			Position: direction.center(plot),
+		}}
 	}
 
 	ticks := make([]AxisTick, scatterTickCount)
 	for i := range scatterTickCount {
 		norm := float64(i) / float64(scatterTickCount-1)
 		value := minValue + (maxValue-minValue)*norm
-		position := plot.X + plot.W*norm
-		if !horizontal {
-			position = plot.Y + plot.H*(1-norm)
+		ticks[i] = AxisTick{
+			Value:    value,
+			Label:    formatTick(value),
+			Position: direction.position(plot, norm),
 		}
-		ticks[i] = AxisTick{Value: value, Label: formatTick(value), Position: position}
 	}
 
 	return ticks
@@ -224,49 +236,42 @@ func formatTick(value float64) string {
 	return strconv.FormatFloat(value, 'g', 3, 64)
 }
 
-func positionForValue(value AxisValue, axis ResolvedAxis, plot PlotRect, horizontal bool) float64 {
+func positionForValue(value AxisValue, axis ResolvedAxis, plot PlotRect, direction axisDirection) float64 {
 	if axis.Categorical != nil {
 		for _, band := range axis.Categorical.Bands {
 			if band.Label == value.Category {
 				return band.Center
 			}
 		}
-		if horizontal {
-			return plot.X + plot.W/2
-		}
 
-		return plot.Y + plot.H/2
+		return direction.center(plot)
 	}
 
 	minValue := axis.Numeric.Min
 	maxValue := axis.Numeric.Max
-	if minValue == maxValue {
-		if horizontal {
-			return plot.X + plot.W/2
-		}
 
-		return plot.Y + plot.H/2
+	if minValue == maxValue {
+		return direction.center(plot)
 	}
 
 	norm := (value.Numeric - minValue) / (maxValue - minValue)
-	if horizontal {
-		return plot.X + plot.W*norm
-	}
 
-	return plot.Y + plot.H*(1-norm)
+	return direction.position(plot, norm)
 }
 
-func sizeExtent(points []PointDatum) (float64, float64) {
+func sizeExtent(points []PointDatum) (minSize, maxSize float64) {
 	if len(points) == 0 {
 		return 0, 0
 	}
 
-	minSize := points[0].Size
-	maxSize := points[0].Size
+	minSize = points[0].Size
+	maxSize = points[0].Size
+
 	for _, point := range points[1:] {
 		if point.Size < minSize {
 			minSize = point.Size
 		}
+
 		if point.Size > maxSize {
 			maxSize = point.Size
 		}
@@ -279,6 +284,7 @@ func maxPointRadius(layout ScatterLayout, pointCount int) float64 {
 	cellW := axisSlotSize(layout.XAxis, layout.Plot.W, pointCount)
 	cellH := axisSlotSize(layout.YAxis, layout.Plot.H, pointCount)
 	maxRadius := math.Min(cellW, cellH) * scatterMaxRadiusFactor
+
 	if maxRadius < 4 {
 		return 4
 	}
@@ -300,19 +306,44 @@ func scaleRadius(value, minValue, maxValue, minRadius, maxRadius float64) float6
 	}
 
 	norm := (value - minValue) / (maxValue - minValue)
+
 	return minRadius + (maxRadius-minRadius)*norm
 }
 
-func axisNumeric(point PointDatum, spec AxisSpec, horizontal bool) float64 {
-	if horizontal {
+func (d axisDirection) center(plot PlotRect) float64 {
+	if d == horizontalAxis {
+		return plot.X + plot.W/2
+	}
+
+	return plot.Y + plot.H/2
+}
+
+func (d axisDirection) position(plot PlotRect, norm float64) float64 {
+	if d == horizontalAxis {
+		return plot.X + plot.W*norm
+	}
+
+	return plot.Y + plot.H*(1-norm)
+}
+
+func (d axisDirection) span(plot PlotRect) (origin, span float64) {
+	if d == horizontalAxis {
+		return plot.X, plot.W
+	}
+
+	return plot.Y, plot.H
+}
+
+func (d axisDirection) numericValue(point PointDatum) float64 {
+	if d == horizontalAxis {
 		return point.X.Numeric
 	}
 
 	return point.Y.Numeric
 }
 
-func axisCategory(point PointDatum, spec AxisSpec, horizontal bool) string {
-	if horizontal {
+func (d axisDirection) categoryValue(point PointDatum) string {
+	if d == horizontalAxis {
 		return point.X.Category
 	}
 

--- a/internal/scatter/layout.go
+++ b/internal/scatter/layout.go
@@ -1,0 +1,320 @@
+package scatter
+
+import (
+	"cmp"
+	"math"
+	"slices"
+	"strconv"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
+	"github.com/theunrepentantgeek/code-visualizer/internal/model"
+)
+
+const (
+	scatterPlotTopMargin    = 48.0
+	scatterPlotRightMargin  = 32.0
+	scatterPlotBottomMargin = 96.0
+	scatterPlotLeftMargin   = 96.0
+	scatterMinRadius        = 12.0
+	scatterMaxRadiusFactor  = 0.45
+	scatterMinNumericSlots  = 8.0
+	scatterTickCount        = 5
+)
+
+// ScatterPoint is one fully laid-out disc.
+type ScatterPoint struct {
+	File   *model.File
+	X      float64
+	Y      float64
+	Radius float64
+	Label  string
+}
+
+// ScatterLayout is the rendered geometry for a scatter plot.
+type ScatterLayout struct {
+	Plot   PlotRect
+	XAxis  ResolvedAxis
+	YAxis  ResolvedAxis
+	Points []ScatterPoint
+}
+
+// Layout converts the dataset into absolute plot geometry.
+func Layout(dataset Dataset, width, height int, xAxis, yAxis AxisSpec) ScatterLayout {
+	plot := PlotRect{
+		X: scatterPlotLeftMargin,
+		Y: scatterPlotTopMargin,
+		W: math.Max(1, float64(width)-scatterPlotLeftMargin-scatterPlotRightMargin),
+		H: math.Max(1, float64(height)-scatterPlotTopMargin-scatterPlotBottomMargin),
+	}
+
+	layout := ScatterLayout{
+		Plot:  plot,
+		XAxis: resolveAxis(dataset.Points, plot, xAxis, true),
+		YAxis: resolveAxis(dataset.Points, plot, yAxis, false),
+	}
+
+	minSize, maxSize := sizeExtent(dataset.Points)
+	maxRadius := maxPointRadius(layout, len(dataset.Points))
+	minRadius := math.Min(scatterMinRadius, maxRadius)
+
+	layout.Points = make([]ScatterPoint, 0, len(dataset.Points))
+	for _, point := range dataset.Points {
+		layout.Points = append(layout.Points, ScatterPoint{
+			File:   point.File,
+			X:      positionForValue(point.X, layout.XAxis, plot, true),
+			Y:      positionForValue(point.Y, layout.YAxis, plot, false),
+			Radius: scaleRadius(point.Size, minSize, maxSize, minRadius, maxRadius),
+			Label:  point.File.Name,
+		})
+	}
+
+	slices.SortFunc(layout.Points, func(a, b ScatterPoint) int {
+		if cmp := cmp.Compare(b.Radius, a.Radius); cmp != 0 {
+			return cmp
+		}
+
+		return cmp.Compare(a.Label, b.Label)
+	})
+
+	return layout
+}
+
+// OffsetLayout shifts the layout when legend space has been reserved.
+func OffsetLayout(layout *ScatterLayout, dx, dy float64) {
+	layout.Plot.X += dx
+	layout.Plot.Y += dy
+	for i := range layout.XAxis.NumericTicks() {
+		layout.XAxis.Numeric.Ticks[i].Position += dx
+	}
+	for i := range layout.YAxis.NumericTicks() {
+		layout.YAxis.Numeric.Ticks[i].Position += dy
+	}
+	for i := range layout.XAxis.CategoricalBands() {
+		layout.XAxis.Categorical.Bands[i].Start += dx
+		layout.XAxis.Categorical.Bands[i].End += dx
+		layout.XAxis.Categorical.Bands[i].Center += dx
+	}
+	for i := range layout.YAxis.CategoricalBands() {
+		layout.YAxis.Categorical.Bands[i].Start += dy
+		layout.YAxis.Categorical.Bands[i].End += dy
+		layout.YAxis.Categorical.Bands[i].Center += dy
+	}
+	for i := range layout.Points {
+		layout.Points[i].X += dx
+		layout.Points[i].Y += dy
+	}
+}
+
+func resolveAxis(points []PointDatum, plot PlotRect, spec AxisSpec, horizontal bool) ResolvedAxis {
+	axis := ResolvedAxis{Spec: spec, Title: string(spec.Metric)}
+	if spec.Kind == metric.Classification {
+		axis.Categorical = &CategoricalAxis{Bands: categoricalBands(points, plot, spec, horizontal)}
+		return axis
+	}
+
+	minValue, maxValue := numericExtent(points, spec, horizontal)
+	axis.Numeric = &NumericAxis{
+		Min:   minValue,
+		Max:   maxValue,
+		Ticks: numericTicks(minValue, maxValue, plot, horizontal),
+	}
+
+	return axis
+}
+
+func (a ResolvedAxis) NumericTicks() []AxisTick {
+	if a.Numeric == nil {
+		return nil
+	}
+
+	return a.Numeric.Ticks
+}
+
+func (a ResolvedAxis) CategoricalBands() []AxisBand {
+	if a.Categorical == nil {
+		return nil
+	}
+
+	return a.Categorical.Bands
+}
+
+func numericExtent(points []PointDatum, spec AxisSpec, horizontal bool) (float64, float64) {
+	if len(points) == 0 {
+		return 0, 0
+	}
+
+	first := axisNumeric(points[0], spec, horizontal)
+	minValue := first
+	maxValue := first
+	for _, point := range points[1:] {
+		value := axisNumeric(point, spec, horizontal)
+		if value < minValue {
+			minValue = value
+		}
+		if value > maxValue {
+			maxValue = value
+		}
+	}
+
+	return minValue, maxValue
+}
+
+func categoricalBands(points []PointDatum, plot PlotRect, spec AxisSpec, horizontal bool) []AxisBand {
+	labels := make([]string, 0, len(points))
+	seen := map[string]bool{}
+	for _, point := range points {
+		label := axisCategory(point, spec, horizontal)
+		if !seen[label] {
+			seen[label] = true
+			labels = append(labels, label)
+		}
+	}
+
+	slices.Sort(labels)
+	if len(labels) == 0 {
+		return nil
+	}
+
+	bands := make([]AxisBand, len(labels))
+	span := plot.W
+	origin := plot.X
+	if !horizontal {
+		span = plot.H
+		origin = plot.Y
+	}
+	bandSize := span / float64(len(labels))
+	for i, label := range labels {
+		start := origin + float64(i)*bandSize
+		bands[i] = AxisBand{
+			Label:  label,
+			Start:  start,
+			End:    start + bandSize,
+			Center: start + bandSize/2,
+		}
+	}
+
+	return bands
+}
+
+func numericTicks(minValue, maxValue float64, plot PlotRect, horizontal bool) []AxisTick {
+	if minValue == maxValue {
+		position := plot.X + plot.W/2
+		if !horizontal {
+			position = plot.Y + plot.H/2
+		}
+
+		return []AxisTick{{Value: minValue, Label: formatTick(minValue), Position: position}}
+	}
+
+	ticks := make([]AxisTick, scatterTickCount)
+	for i := range scatterTickCount {
+		norm := float64(i) / float64(scatterTickCount-1)
+		value := minValue + (maxValue-minValue)*norm
+		position := plot.X + plot.W*norm
+		if !horizontal {
+			position = plot.Y + plot.H*(1-norm)
+		}
+		ticks[i] = AxisTick{Value: value, Label: formatTick(value), Position: position}
+	}
+
+	return ticks
+}
+
+func formatTick(value float64) string {
+	return strconv.FormatFloat(value, 'g', 3, 64)
+}
+
+func positionForValue(value AxisValue, axis ResolvedAxis, plot PlotRect, horizontal bool) float64 {
+	if axis.Categorical != nil {
+		for _, band := range axis.Categorical.Bands {
+			if band.Label == value.Category {
+				return band.Center
+			}
+		}
+		if horizontal {
+			return plot.X + plot.W/2
+		}
+
+		return plot.Y + plot.H/2
+	}
+
+	minValue := axis.Numeric.Min
+	maxValue := axis.Numeric.Max
+	if minValue == maxValue {
+		if horizontal {
+			return plot.X + plot.W/2
+		}
+
+		return plot.Y + plot.H/2
+	}
+
+	norm := (value.Numeric - minValue) / (maxValue - minValue)
+	if horizontal {
+		return plot.X + plot.W*norm
+	}
+
+	return plot.Y + plot.H*(1-norm)
+}
+
+func sizeExtent(points []PointDatum) (float64, float64) {
+	if len(points) == 0 {
+		return 0, 0
+	}
+
+	minSize := points[0].Size
+	maxSize := points[0].Size
+	for _, point := range points[1:] {
+		if point.Size < minSize {
+			minSize = point.Size
+		}
+		if point.Size > maxSize {
+			maxSize = point.Size
+		}
+	}
+
+	return minSize, maxSize
+}
+
+func maxPointRadius(layout ScatterLayout, pointCount int) float64 {
+	cellW := axisSlotSize(layout.XAxis, layout.Plot.W, pointCount)
+	cellH := axisSlotSize(layout.YAxis, layout.Plot.H, pointCount)
+	maxRadius := math.Min(cellW, cellH) * scatterMaxRadiusFactor
+	if maxRadius < 4 {
+		return 4
+	}
+
+	return maxRadius
+}
+
+func axisSlotSize(axis ResolvedAxis, span float64, pointCount int) float64 {
+	if axis.Categorical != nil && len(axis.Categorical.Bands) > 0 {
+		return span / float64(len(axis.Categorical.Bands))
+	}
+
+	return span / math.Max(scatterMinNumericSlots, math.Sqrt(float64(max(pointCount, 1))))
+}
+
+func scaleRadius(value, minValue, maxValue, minRadius, maxRadius float64) float64 {
+	if maxRadius <= minRadius || minValue == maxValue {
+		return maxRadius
+	}
+
+	norm := (value - minValue) / (maxValue - minValue)
+	return minRadius + (maxRadius-minRadius)*norm
+}
+
+func axisNumeric(point PointDatum, spec AxisSpec, horizontal bool) float64 {
+	if horizontal {
+		return point.X.Numeric
+	}
+
+	return point.Y.Numeric
+}
+
+func axisCategory(point PointDatum, spec AxisSpec, horizontal bool) string {
+	if horizontal {
+		return point.X.Category
+	}
+
+	return point.Y.Category
+}

--- a/internal/scatter/layout.go
+++ b/internal/scatter/layout.go
@@ -54,8 +54,8 @@ func Layout(dataset Dataset, width, height int, xAxis, yAxis AxisSpec) ScatterLa
 	}
 
 	minSize, maxSize := sizeExtent(dataset.Points)
-	maxRadius := maxPointRadius(layout, len(dataset.Points))
-	minRadius := math.Min(scatterMinRadius, maxRadius)
+	maxRadius := math.Max(scatterMinRadius, maxPointRadius(layout, len(dataset.Points)))
+	minRadius := scatterMinRadius
 
 	layout.Points = make([]ScatterPoint, 0, len(dataset.Points))
 	for _, point := range dataset.Points {

--- a/internal/scatter/layout_test.go
+++ b/internal/scatter/layout_test.go
@@ -1,0 +1,130 @@
+package scatter
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
+	"github.com/theunrepentantgeek/code-visualizer/internal/model"
+	"github.com/theunrepentantgeek/code-visualizer/internal/provider/filesystem"
+)
+
+func scatterTestFile(name string) *model.File {
+	return &model.File{Name: name, Path: name}
+}
+
+func TestCollectDataset_SkipsFilesMissingAxisOrSize(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	keep := scatterTestFile("keep.go")
+	keep.SetClassification(filesystem.FileType, "go")
+	keep.SetQuantity(filesystem.FileLines, 20)
+	keep.SetQuantity(filesystem.FileSize, 100)
+
+	missingX := scatterTestFile("missing-x.go")
+	missingX.SetQuantity(filesystem.FileLines, 10)
+	missingX.SetQuantity(filesystem.FileSize, 80)
+
+	missingY := scatterTestFile("missing-y.go")
+	missingY.SetClassification(filesystem.FileType, "txt")
+	missingY.SetQuantity(filesystem.FileSize, 60)
+
+	missingSize := scatterTestFile("missing-size.go")
+	missingSize.SetClassification(filesystem.FileType, "md")
+	missingSize.SetQuantity(filesystem.FileLines, 40)
+
+	root := &model.Directory{Files: []*model.File{keep, missingX, missingY, missingSize}}
+
+	dataset := CollectDataset(
+		root,
+		AxisSpec{Metric: filesystem.FileType, Kind: metric.Classification},
+		AxisSpec{Metric: filesystem.FileLines, Kind: metric.Quantity},
+		filesystem.FileSize,
+	)
+
+	g.Expect(dataset.Points).To(HaveLen(1))
+	g.Expect(dataset.Points[0].File).To(Equal(keep))
+	g.Expect(dataset.Skipped.MissingX).To(Equal(1))
+	g.Expect(dataset.Skipped.MissingY).To(Equal(1))
+	g.Expect(dataset.Skipped.MissingSize).To(Equal(1))
+}
+
+func TestLayout_CategoricalAxesUseAlphabeticalBands(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	alpha := scatterTestFile("alpha.go")
+	alpha.SetClassification(filesystem.FileType, "alpha")
+	alpha.SetClassification(metric.Name("y-cat"), "beta")
+	alpha.SetQuantity(filesystem.FileSize, 80)
+
+	zeta := scatterTestFile("zeta.go")
+	zeta.SetClassification(filesystem.FileType, "zeta")
+	zeta.SetClassification(metric.Name("y-cat"), "alpha")
+	zeta.SetQuantity(filesystem.FileSize, 40)
+
+	root := &model.Directory{Files: []*model.File{alpha, zeta}}
+	dataset := CollectDataset(
+		root,
+		AxisSpec{Metric: filesystem.FileType, Kind: metric.Classification},
+		AxisSpec{Metric: metric.Name("y-cat"), Kind: metric.Classification},
+		filesystem.FileSize,
+	)
+
+	layout := Layout(
+		dataset,
+		800,
+		600,
+		AxisSpec{Metric: filesystem.FileType, Kind: metric.Classification},
+		AxisSpec{Metric: metric.Name("y-cat"), Kind: metric.Classification},
+	)
+
+	g.Expect(layout.XAxis.Categorical.Bands).To(HaveLen(2))
+	g.Expect(layout.XAxis.Categorical.Bands[0].Label).To(Equal("alpha"))
+	g.Expect(layout.XAxis.Categorical.Bands[1].Label).To(Equal("zeta"))
+	g.Expect(layout.YAxis.Categorical.Bands).To(HaveLen(2))
+	g.Expect(layout.YAxis.Categorical.Bands[0].Label).To(Equal("alpha"))
+	g.Expect(layout.YAxis.Categorical.Bands[1].Label).To(Equal("beta"))
+	g.Expect(layout.Points[0].Radius).To(BeNumerically(">=", layout.Points[1].Radius))
+}
+
+func TestLayout_NumericYAxisPlacesHigherValuesHigherOnCanvas(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	low := scatterTestFile("low.go")
+	low.SetQuantity(filesystem.FileLines, 10)
+	low.SetQuantity(filesystem.FileSize, 20)
+	low.SetClassification(filesystem.FileType, "go")
+
+	high := scatterTestFile("high.go")
+	high.SetQuantity(filesystem.FileLines, 100)
+	high.SetQuantity(filesystem.FileSize, 60)
+	high.SetClassification(filesystem.FileType, "go")
+
+	root := &model.Directory{Files: []*model.File{low, high}}
+	dataset := CollectDataset(
+		root,
+		AxisSpec{Metric: filesystem.FileType, Kind: metric.Classification},
+		AxisSpec{Metric: filesystem.FileLines, Kind: metric.Quantity},
+		filesystem.FileSize,
+	)
+
+	layout := Layout(
+		dataset,
+		800,
+		600,
+		AxisSpec{Metric: filesystem.FileType, Kind: metric.Classification},
+		AxisSpec{Metric: filesystem.FileLines, Kind: metric.Quantity},
+	)
+
+	points := map[string]ScatterPoint{}
+	for _, point := range layout.Points {
+		points[point.File.Name] = point
+	}
+
+	g.Expect(points["high.go"].Y).To(BeNumerically("<", points["low.go"].Y))
+	g.Expect(layout.YAxis.Numeric.Ticks).NotTo(BeEmpty())
+}

--- a/internal/scatter/layout_test.go
+++ b/internal/scatter/layout_test.go
@@ -1,6 +1,7 @@
 package scatter
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -127,4 +128,38 @@ func TestLayout_NumericYAxisPlacesHigherValuesHigherOnCanvas(t *testing.T) {
 
 	g.Expect(points["high.go"].Y).To(BeNumerically("<", points["low.go"].Y))
 	g.Expect(layout.YAxis.Numeric.Ticks).NotTo(BeEmpty())
+}
+
+func TestLayout_CrowdedPlotKeepsMinimumDiscRadius(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	files := make([]*model.File, 0, 500)
+	for i := range 500 {
+		file := scatterTestFile(fmt.Sprintf("file-%03d.go", i))
+		file.SetClassification(filesystem.FileType, "go")
+		file.SetQuantity(filesystem.FileLines, int64(i+1))
+		file.SetQuantity(filesystem.FileSize, int64(i+1))
+		files = append(files, file)
+	}
+
+	root := &model.Directory{Files: files}
+	dataset := CollectDataset(
+		root,
+		AxisSpec{Metric: filesystem.FileType, Kind: metric.Classification},
+		AxisSpec{Metric: filesystem.FileLines, Kind: metric.Quantity},
+		filesystem.FileSize,
+	)
+
+	layout := Layout(
+		dataset,
+		800,
+		600,
+		AxisSpec{Metric: filesystem.FileType, Kind: metric.Classification},
+		AxisSpec{Metric: filesystem.FileLines, Kind: metric.Quantity},
+	)
+
+	for _, point := range layout.Points {
+		g.Expect(point.Radius).To(BeNumerically(">=", scatterMinRadius))
+	}
 }

--- a/internal/scatter/layout_test.go
+++ b/internal/scatter/layout_test.go
@@ -135,6 +135,7 @@ func TestLayout_CrowdedPlotKeepsMinimumDiscRadius(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	files := make([]*model.File, 0, 500)
+
 	for i := range 500 {
 		file := scatterTestFile(fmt.Sprintf("file-%03d.go", i))
 		file.SetClassification(filesystem.FileType, "go")

--- a/internal/scatter/render.go
+++ b/internal/scatter/render.go
@@ -73,48 +73,126 @@ func addScatterPlotBorder(cv *canvas.Canvas, plot PlotRect) {
 func addScatterAxisGuides(cv *canvas.Canvas, layout ScatterLayout) {
 	lineSpec := &canvas.LineSpec{Stroke: canvas.FixedInk(scatterGridColour), StrokeWidth: scatterGridStrokeWidth}
 	for _, tick := range layout.XAxis.NumericTicks() {
-		cv.AddLine(canvas.LayerStructure, canvas.Line{Spec: lineSpec, X1: tick.Position, Y1: layout.Plot.Y, X2: tick.Position, Y2: layout.Plot.Y + layout.Plot.H})
+		cv.AddLine(canvas.LayerStructure, canvas.Line{
+			Spec: lineSpec,
+			X1:   tick.Position,
+			Y1:   layout.Plot.Y,
+			X2:   tick.Position,
+			Y2:   layout.Plot.Y + layout.Plot.H,
+		})
 	}
+
 	for _, tick := range layout.YAxis.NumericTicks() {
-		cv.AddLine(canvas.LayerStructure, canvas.Line{Spec: lineSpec, X1: layout.Plot.X, Y1: tick.Position, X2: layout.Plot.X + layout.Plot.W, Y2: tick.Position})
+		cv.AddLine(canvas.LayerStructure, canvas.Line{
+			Spec: lineSpec,
+			X1:   layout.Plot.X,
+			Y1:   tick.Position,
+			X2:   layout.Plot.X + layout.Plot.W,
+			Y2:   tick.Position,
+		})
 	}
+
 	for _, band := range layout.XAxis.CategoricalBands() {
-		cv.AddLine(canvas.LayerStructure, canvas.Line{Spec: lineSpec, X1: band.Start, Y1: layout.Plot.Y, X2: band.Start, Y2: layout.Plot.Y + layout.Plot.H})
+		cv.AddLine(canvas.LayerStructure, canvas.Line{
+			Spec: lineSpec,
+			X1:   band.Start,
+			Y1:   layout.Plot.Y,
+			X2:   band.Start,
+			Y2:   layout.Plot.Y + layout.Plot.H,
+		})
 	}
+
 	if bands := layout.XAxis.CategoricalBands(); len(bands) > 0 {
 		last := bands[len(bands)-1]
-		cv.AddLine(canvas.LayerStructure, canvas.Line{Spec: lineSpec, X1: last.End, Y1: layout.Plot.Y, X2: last.End, Y2: layout.Plot.Y + layout.Plot.H})
+		cv.AddLine(canvas.LayerStructure, canvas.Line{
+			Spec: lineSpec,
+			X1:   last.End,
+			Y1:   layout.Plot.Y,
+			X2:   last.End,
+			Y2:   layout.Plot.Y + layout.Plot.H,
+		})
 	}
+
 	for _, band := range layout.YAxis.CategoricalBands() {
-		cv.AddLine(canvas.LayerStructure, canvas.Line{Spec: lineSpec, X1: layout.Plot.X, Y1: band.Start, X2: layout.Plot.X + layout.Plot.W, Y2: band.Start})
+		cv.AddLine(canvas.LayerStructure, canvas.Line{
+			Spec: lineSpec,
+			X1:   layout.Plot.X,
+			Y1:   band.Start,
+			X2:   layout.Plot.X + layout.Plot.W,
+			Y2:   band.Start,
+		})
 	}
+
 	if bands := layout.YAxis.CategoricalBands(); len(bands) > 0 {
 		last := bands[len(bands)-1]
-		cv.AddLine(canvas.LayerStructure, canvas.Line{Spec: lineSpec, X1: layout.Plot.X, Y1: last.End, X2: layout.Plot.X + layout.Plot.W, Y2: last.End})
+		cv.AddLine(canvas.LayerStructure, canvas.Line{
+			Spec: lineSpec,
+			X1:   layout.Plot.X,
+			Y1:   last.End,
+			X2:   layout.Plot.X + layout.Plot.W,
+			Y2:   last.End,
+		})
 	}
 }
 
 func addScatterAxisLabels(cv *canvas.Canvas, layout ScatterLayout) {
 	titleSpec := &canvas.TextSpec{Ink: canvas.FixedInk(scatterLabelColour), FontSize: 12, Anchor: canvas.AnchorMiddle}
-	cv.AddText(canvas.LayerOverlay, canvas.Text{Spec: titleSpec, X: layout.Plot.X + layout.Plot.W/2, Y: layout.Plot.Y + layout.Plot.H + 56, Content: layout.XAxis.Title})
+	cv.AddText(canvas.LayerOverlay, canvas.Text{
+		Spec:    titleSpec,
+		X:       layout.Plot.X + layout.Plot.W/2,
+		Y:       layout.Plot.Y + layout.Plot.H + 56,
+		Content: layout.XAxis.Title,
+	})
 
-	yTitleSpec := &canvas.TextSpec{Ink: canvas.FixedInk(scatterLabelColour), FontSize: 12, Anchor: canvas.AnchorMiddle, Rotation: -math.Pi / 2}
-	cv.AddText(canvas.LayerOverlay, canvas.Text{Spec: yTitleSpec, X: layout.Plot.X - 72, Y: layout.Plot.Y + layout.Plot.H/2, Content: layout.YAxis.Title})
+	yTitleSpec := &canvas.TextSpec{
+		Ink:      canvas.FixedInk(scatterLabelColour),
+		FontSize: 12,
+		Anchor:   canvas.AnchorMiddle,
+		Rotation: -math.Pi / 2,
+	}
+	cv.AddText(canvas.LayerOverlay, canvas.Text{
+		Spec:    yTitleSpec,
+		X:       layout.Plot.X - 72,
+		Y:       layout.Plot.Y + layout.Plot.H/2,
+		Content: layout.YAxis.Title,
+	})
 
 	tickSpec := &canvas.TextSpec{Ink: canvas.FixedInk(scatterLabelColour), FontSize: 10, Anchor: canvas.AnchorMiddle}
 	for _, tick := range layout.XAxis.NumericTicks() {
-		cv.AddText(canvas.LayerOverlay, canvas.Text{Spec: tickSpec, X: tick.Position, Y: layout.Plot.Y + layout.Plot.H + 18, Content: tick.Label})
+		cv.AddText(canvas.LayerOverlay, canvas.Text{
+			Spec:    tickSpec,
+			X:       tick.Position,
+			Y:       layout.Plot.Y + layout.Plot.H + 18,
+			Content: tick.Label,
+		})
 	}
+
 	for _, band := range layout.XAxis.CategoricalBands() {
-		cv.AddText(canvas.LayerOverlay, canvas.Text{Spec: tickSpec, X: band.Center, Y: layout.Plot.Y + layout.Plot.H + 18, Content: band.Label})
+		cv.AddText(canvas.LayerOverlay, canvas.Text{
+			Spec:    tickSpec,
+			X:       band.Center,
+			Y:       layout.Plot.Y + layout.Plot.H + 18,
+			Content: band.Label,
+		})
 	}
 
 	yTickSpec := &canvas.TextSpec{Ink: canvas.FixedInk(scatterLabelColour), FontSize: 10, Anchor: canvas.AnchorEnd}
 	for _, tick := range layout.YAxis.NumericTicks() {
-		cv.AddText(canvas.LayerOverlay, canvas.Text{Spec: yTickSpec, X: layout.Plot.X - 8, Y: tick.Position, Content: tick.Label})
+		cv.AddText(canvas.LayerOverlay, canvas.Text{
+			Spec:    yTickSpec,
+			X:       layout.Plot.X - 8,
+			Y:       tick.Position,
+			Content: tick.Label,
+		})
 	}
+
 	for _, band := range layout.YAxis.CategoricalBands() {
-		cv.AddText(canvas.LayerOverlay, canvas.Text{Spec: yTickSpec, X: layout.Plot.X - 8, Y: band.Center, Content: band.Label})
+		cv.AddText(canvas.LayerOverlay, canvas.Text{
+			Spec:    yTickSpec,
+			X:       layout.Plot.X - 8,
+			Y:       band.Center,
+			Content: band.Label,
+		})
 	}
 }
 
@@ -124,30 +202,51 @@ func addScatterPoints(cv *canvas.Canvas, points []ScatterPoint, inks Inks) {
 		borderWidth = scatterMetricBorder
 	}
 
-	discSpec := &canvas.DiscSpec{ShapeStyle: canvas.ShapeStyle{Fill: inks.Fill, Border: inks.Border, BorderWidth: borderWidth}}
+	discSpec := &canvas.DiscSpec{
+		ShapeStyle: canvas.ShapeStyle{Fill: inks.Fill, Border: inks.Border, BorderWidth: borderWidth},
+	}
 	for _, point := range points {
 		fillValue := pkginks.MetricValueForFile(point.File, inks.Fill)
 		borderValue := pkginks.MetricValueForFile(point.File, inks.Border)
-		cv.AddDisc(canvas.LayerContent, canvas.Disc{Spec: discSpec, X: point.X, Y: point.Y, Radius: point.Radius, Fill: fillValue, Border: borderValue})
+		cv.AddDisc(canvas.LayerContent, canvas.Disc{
+			Spec:   discSpec,
+			X:      point.X,
+			Y:      point.Y,
+			Radius: point.Radius,
+			Fill:   fillValue,
+			Border: borderValue,
+		})
 
 		label, fontSize := scatterLabel(point.Label, point.Radius)
 		labelColour := canvas.TextColourFor(inks.Fill.Dip(fillValue))
-		labelSpec := &canvas.TextSpec{Ink: canvas.FixedInk(labelColour), FontSize: fontSize, Anchor: canvas.AnchorMiddle}
-		cv.AddText(canvas.LayerOverlay, canvas.Text{Spec: labelSpec, X: point.X, Y: point.Y, Content: label})
+		labelSpec := &canvas.TextSpec{
+			Ink:      canvas.FixedInk(labelColour),
+			FontSize: fontSize,
+			Anchor:   canvas.AnchorMiddle,
+		}
+		cv.AddText(canvas.LayerOverlay, canvas.Text{
+			Spec:    labelSpec,
+			X:       point.X,
+			Y:       point.Y,
+			Content: label,
+		})
 	}
 }
 
 func scatterLabel(label string, radius float64) (string, float64) {
 	fontSize := min(scatterLabelMaxFont, max(scatterLabelMinFont, radius*0.6))
+
 	maxChars := int((2 * radius * 0.85) / (fontSize * 0.6))
 	if maxChars <= 0 {
 		maxChars = 1
 	}
+
 	if utf8.RuneCountInString(label) <= maxChars {
 		return label, fontSize
 	}
 
 	runes := []rune(label)
+
 	if maxChars == 1 {
 		return string(runes[:1]), fontSize
 	}

--- a/internal/scatter/render.go
+++ b/internal/scatter/render.go
@@ -1,0 +1,156 @@
+package scatter
+
+import (
+	"math"
+	"unicode/utf8"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/canvas"
+	canvasmodel "github.com/theunrepentantgeek/code-visualizer/internal/canvas/model"
+	pkginks "github.com/theunrepentantgeek/code-visualizer/internal/inks"
+)
+
+const (
+	scatterAxisStrokeWidth = 1.5
+	scatterGridStrokeWidth = 1.0
+	scatterBorderWidth     = 1.0
+	scatterMetricBorder    = 2.0
+	scatterLabelMinFont    = 8.0
+	scatterLabelMaxFont    = 14.0
+)
+
+// RenderToCanvas converts a scatter layout into a populated canvas.
+func RenderToCanvas(layout ScatterLayout, width, height int, inks Inks) *canvas.Canvas {
+	cv := canvas.NewCanvas(width, height)
+	addScatterBackground(cv, width, height)
+	addScatterStructure(cv, layout)
+	addScatterPoints(cv, layout.Points, inks)
+
+	return cv
+}
+
+func addScatterBackground(cv *canvas.Canvas, width, height int) {
+	bgSpec := &canvas.RectangleSpec{
+		ShapeStyle: canvas.ShapeStyle{
+			Fill:        canvas.FixedInk(scatterBgColour),
+			Border:      canvas.FixedInk(scatterBgColour),
+			BorderWidth: 0,
+		},
+	}
+
+	cv.AddRectangle(canvas.LayerBackground, canvas.Rectangle{
+		Spec:  bgSpec,
+		W:     float64(width),
+		H:     float64(height),
+		Focus: canvasmodel.Point{X: 0.5, Y: 0.5},
+	})
+}
+
+func addScatterStructure(cv *canvas.Canvas, layout ScatterLayout) {
+	addScatterPlotBorder(cv, layout.Plot)
+	addScatterAxisGuides(cv, layout)
+	addScatterAxisLabels(cv, layout)
+}
+
+func addScatterPlotBorder(cv *canvas.Canvas, plot PlotRect) {
+	plotSpec := &canvas.RectangleSpec{
+		ShapeStyle: canvas.ShapeStyle{
+			Fill:        canvas.FixedInk(scatterBgColour),
+			Border:      canvas.FixedInk(scatterAxisColour),
+			BorderWidth: scatterAxisStrokeWidth,
+		},
+	}
+
+	cv.AddRectangle(canvas.LayerStructure, canvas.Rectangle{
+		Spec:  plotSpec,
+		X:     plot.X,
+		Y:     plot.Y,
+		W:     plot.W,
+		H:     plot.H,
+		Focus: canvasmodel.Point{X: 0.5, Y: 0.5},
+	})
+}
+
+func addScatterAxisGuides(cv *canvas.Canvas, layout ScatterLayout) {
+	lineSpec := &canvas.LineSpec{Stroke: canvas.FixedInk(scatterGridColour), StrokeWidth: scatterGridStrokeWidth}
+	for _, tick := range layout.XAxis.NumericTicks() {
+		cv.AddLine(canvas.LayerStructure, canvas.Line{Spec: lineSpec, X1: tick.Position, Y1: layout.Plot.Y, X2: tick.Position, Y2: layout.Plot.Y + layout.Plot.H})
+	}
+	for _, tick := range layout.YAxis.NumericTicks() {
+		cv.AddLine(canvas.LayerStructure, canvas.Line{Spec: lineSpec, X1: layout.Plot.X, Y1: tick.Position, X2: layout.Plot.X + layout.Plot.W, Y2: tick.Position})
+	}
+	for _, band := range layout.XAxis.CategoricalBands() {
+		cv.AddLine(canvas.LayerStructure, canvas.Line{Spec: lineSpec, X1: band.Start, Y1: layout.Plot.Y, X2: band.Start, Y2: layout.Plot.Y + layout.Plot.H})
+	}
+	if bands := layout.XAxis.CategoricalBands(); len(bands) > 0 {
+		last := bands[len(bands)-1]
+		cv.AddLine(canvas.LayerStructure, canvas.Line{Spec: lineSpec, X1: last.End, Y1: layout.Plot.Y, X2: last.End, Y2: layout.Plot.Y + layout.Plot.H})
+	}
+	for _, band := range layout.YAxis.CategoricalBands() {
+		cv.AddLine(canvas.LayerStructure, canvas.Line{Spec: lineSpec, X1: layout.Plot.X, Y1: band.Start, X2: layout.Plot.X + layout.Plot.W, Y2: band.Start})
+	}
+	if bands := layout.YAxis.CategoricalBands(); len(bands) > 0 {
+		last := bands[len(bands)-1]
+		cv.AddLine(canvas.LayerStructure, canvas.Line{Spec: lineSpec, X1: layout.Plot.X, Y1: last.End, X2: layout.Plot.X + layout.Plot.W, Y2: last.End})
+	}
+}
+
+func addScatterAxisLabels(cv *canvas.Canvas, layout ScatterLayout) {
+	titleSpec := &canvas.TextSpec{Ink: canvas.FixedInk(scatterLabelColour), FontSize: 12, Anchor: canvas.AnchorMiddle}
+	cv.AddText(canvas.LayerOverlay, canvas.Text{Spec: titleSpec, X: layout.Plot.X + layout.Plot.W/2, Y: layout.Plot.Y + layout.Plot.H + 56, Content: layout.XAxis.Title})
+
+	yTitleSpec := &canvas.TextSpec{Ink: canvas.FixedInk(scatterLabelColour), FontSize: 12, Anchor: canvas.AnchorMiddle, Rotation: -math.Pi / 2}
+	cv.AddText(canvas.LayerOverlay, canvas.Text{Spec: yTitleSpec, X: layout.Plot.X - 72, Y: layout.Plot.Y + layout.Plot.H/2, Content: layout.YAxis.Title})
+
+	tickSpec := &canvas.TextSpec{Ink: canvas.FixedInk(scatterLabelColour), FontSize: 10, Anchor: canvas.AnchorMiddle}
+	for _, tick := range layout.XAxis.NumericTicks() {
+		cv.AddText(canvas.LayerOverlay, canvas.Text{Spec: tickSpec, X: tick.Position, Y: layout.Plot.Y + layout.Plot.H + 18, Content: tick.Label})
+	}
+	for _, band := range layout.XAxis.CategoricalBands() {
+		cv.AddText(canvas.LayerOverlay, canvas.Text{Spec: tickSpec, X: band.Center, Y: layout.Plot.Y + layout.Plot.H + 18, Content: band.Label})
+	}
+
+	yTickSpec := &canvas.TextSpec{Ink: canvas.FixedInk(scatterLabelColour), FontSize: 10, Anchor: canvas.AnchorEnd}
+	for _, tick := range layout.YAxis.NumericTicks() {
+		cv.AddText(canvas.LayerOverlay, canvas.Text{Spec: yTickSpec, X: layout.Plot.X - 8, Y: tick.Position, Content: tick.Label})
+	}
+	for _, band := range layout.YAxis.CategoricalBands() {
+		cv.AddText(canvas.LayerOverlay, canvas.Text{Spec: yTickSpec, X: layout.Plot.X - 8, Y: band.Center, Content: band.Label})
+	}
+}
+
+func addScatterPoints(cv *canvas.Canvas, points []ScatterPoint, inks Inks) {
+	borderWidth := scatterBorderWidth
+	if inks.HasBorderMetric {
+		borderWidth = scatterMetricBorder
+	}
+
+	discSpec := &canvas.DiscSpec{ShapeStyle: canvas.ShapeStyle{Fill: inks.Fill, Border: inks.Border, BorderWidth: borderWidth}}
+	for _, point := range points {
+		fillValue := pkginks.MetricValueForFile(point.File, inks.Fill)
+		borderValue := pkginks.MetricValueForFile(point.File, inks.Border)
+		cv.AddDisc(canvas.LayerContent, canvas.Disc{Spec: discSpec, X: point.X, Y: point.Y, Radius: point.Radius, Fill: fillValue, Border: borderValue})
+
+		label, fontSize := scatterLabel(point.Label, point.Radius)
+		labelColour := canvas.TextColourFor(inks.Fill.Dip(fillValue))
+		labelSpec := &canvas.TextSpec{Ink: canvas.FixedInk(labelColour), FontSize: fontSize, Anchor: canvas.AnchorMiddle}
+		cv.AddText(canvas.LayerOverlay, canvas.Text{Spec: labelSpec, X: point.X, Y: point.Y, Content: label})
+	}
+}
+
+func scatterLabel(label string, radius float64) (string, float64) {
+	fontSize := min(scatterLabelMaxFont, max(scatterLabelMinFont, radius*0.6))
+	maxChars := int((2 * radius * 0.85) / (fontSize * 0.6))
+	if maxChars <= 0 {
+		maxChars = 1
+	}
+	if utf8.RuneCountInString(label) <= maxChars {
+		return label, fontSize
+	}
+
+	runes := []rune(label)
+	if maxChars == 1 {
+		return string(runes[:1]), fontSize
+	}
+
+	return string(runes[:maxChars-1]) + "…", fontSize
+}

--- a/internal/scatter/render_test.go
+++ b/internal/scatter/render_test.go
@@ -55,6 +55,7 @@ func TestRenderToCanvas_PNG(t *testing.T) {
 
 	f, err := os.Open(out)
 	g.Expect(err).NotTo(HaveOccurred())
+
 	defer f.Close()
 
 	_, format, err := image.DecodeConfig(f)
@@ -96,7 +97,9 @@ func TestRenderToCanvas_SVGIncludesAxisTitlesAndLabels(t *testing.T) {
 	g.Expect(bytes.Contains(data, []byte("main"))).To(BeTrue())
 
 	dec := xml.NewDecoder(bytes.NewReader(data))
+
 	var rootElement string
+
 	for {
 		tok, xmlErr := dec.Token()
 		if xmlErr != nil {
@@ -105,6 +108,7 @@ func TestRenderToCanvas_SVGIncludesAxisTitlesAndLabels(t *testing.T) {
 
 		if se, ok := tok.(xml.StartElement); ok {
 			rootElement = se.Name.Local
+
 			break
 		}
 	}

--- a/internal/scatter/render_test.go
+++ b/internal/scatter/render_test.go
@@ -1,0 +1,113 @@
+package scatter
+
+import (
+	"bytes"
+	"encoding/xml"
+	"image"
+	_ "image/png"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
+	"github.com/theunrepentantgeek/code-visualizer/internal/model"
+	"github.com/theunrepentantgeek/code-visualizer/internal/palette"
+	"github.com/theunrepentantgeek/code-visualizer/internal/provider/filesystem"
+)
+
+func renderScatterFile(name, category string, lines, size int64) *model.File {
+	f := &model.File{Name: name, Path: name}
+	f.SetClassification(filesystem.FileType, category)
+	f.SetQuantity(filesystem.FileLines, lines)
+	f.SetQuantity(filesystem.FileSize, size)
+
+	return f
+}
+
+func TestRenderToCanvas_PNG(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := &model.Directory{Files: []*model.File{
+		renderScatterFile("main.go", "go", 120, 100),
+		renderScatterFile("readme.md", "md", 40, 60),
+	}}
+	dataset := CollectDataset(
+		root,
+		AxisSpec{Metric: filesystem.FileType, Kind: metric.Classification},
+		AxisSpec{Metric: filesystem.FileLines, Kind: metric.Quantity},
+		filesystem.FileSize,
+	)
+	layout := Layout(
+		dataset,
+		800,
+		600,
+		AxisSpec{Metric: filesystem.FileType, Kind: metric.Classification},
+		AxisSpec{Metric: filesystem.FileLines, Kind: metric.Quantity},
+	)
+	inks := BuildInks(dataset, filesystem.FileSize, palette.Temperature, "", "")
+	cv := RenderToCanvas(layout, 800, 600, inks)
+
+	out := filepath.Join(t.TempDir(), "scatter.png")
+	g.Expect(cv.Render(out)).To(Succeed())
+
+	f, err := os.Open(out)
+	g.Expect(err).NotTo(HaveOccurred())
+	defer f.Close()
+
+	_, format, err := image.DecodeConfig(f)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(format).To(Equal("png"))
+}
+
+func TestRenderToCanvas_SVGIncludesAxisTitlesAndLabels(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := &model.Directory{Files: []*model.File{
+		renderScatterFile("main.go", "go", 120, 100),
+		renderScatterFile("readme.md", "md", 40, 60),
+	}}
+	dataset := CollectDataset(
+		root,
+		AxisSpec{Metric: filesystem.FileType, Kind: metric.Classification},
+		AxisSpec{Metric: filesystem.FileLines, Kind: metric.Quantity},
+		filesystem.FileSize,
+	)
+	layout := Layout(
+		dataset,
+		800,
+		600,
+		AxisSpec{Metric: filesystem.FileType, Kind: metric.Classification},
+		AxisSpec{Metric: filesystem.FileLines, Kind: metric.Quantity},
+	)
+	inks := BuildInks(dataset, filesystem.FileSize, palette.Temperature, "", "")
+	cv := RenderToCanvas(layout, 800, 600, inks)
+
+	out := filepath.Join(t.TempDir(), "scatter.svg")
+	g.Expect(cv.Render(out)).To(Succeed())
+
+	data, err := os.ReadFile(out)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(bytes.Contains(data, []byte("file-type"))).To(BeTrue())
+	g.Expect(bytes.Contains(data, []byte("file-lines"))).To(BeTrue())
+	g.Expect(bytes.Contains(data, []byte("main"))).To(BeTrue())
+
+	dec := xml.NewDecoder(bytes.NewReader(data))
+	var rootElement string
+	for {
+		tok, xmlErr := dec.Token()
+		if xmlErr != nil {
+			break
+		}
+
+		if se, ok := tok.(xml.StartElement); ok {
+			rootElement = se.Name.Local
+			break
+		}
+	}
+
+	g.Expect(rootElement).To(Equal("svg"))
+}

--- a/internal/scatter/resolved_axis.go
+++ b/internal/scatter/resolved_axis.go
@@ -1,0 +1,21 @@
+package scatter
+
+// NumericAxis holds the numeric range and ticks for one axis.
+type NumericAxis struct {
+	Min   float64
+	Max   float64
+	Ticks []AxisTick
+}
+
+// CategoricalAxis holds the categorical swimlanes for one axis.
+type CategoricalAxis struct {
+	Bands []AxisBand
+}
+
+// ResolvedAxis is the layout-ready representation of a scatter axis.
+type ResolvedAxis struct {
+	Spec        AxisSpec
+	Title       string
+	Numeric     *NumericAxis
+	Categorical *CategoricalAxis
+}

--- a/internal/scatter/stages.go
+++ b/internal/scatter/stages.go
@@ -21,6 +21,7 @@ func ResolveMetrics(s *State) error {
 	if err != nil {
 		return err
 	}
+
 	yAxis, err := resolveAxisSpec(cfg.YAxis)
 	if err != nil {
 		return err
@@ -45,6 +46,7 @@ func ResolveMetrics(s *State) error {
 func resolveAxisSpec(name *string) (AxisSpec, error) {
 	metricName := metric.Name(stages.PtrString(name))
 	descriptor, ok := provider.GetDescriptor(metricName)
+
 	if !ok {
 		return AxisSpec{}, eris.Errorf("unknown axis metric %q", metricName)
 	}
@@ -63,10 +65,12 @@ func resolveFillMetric(cfg *config.Scatter, size metric.Name) metric.Name {
 func collectRequestedMetrics(xAxis, yAxis, size metric.Name, fill, border *config.MetricSpec) []metric.Name {
 	seen := map[metric.Name]bool{}
 	names := make([]metric.Name, 0, 5)
+
 	for _, name := range []metric.Name{xAxis, yAxis, size, fill.MetricName(), border.MetricName()} {
 		if name == "" || seen[name] {
 			continue
 		}
+
 		seen[name] = true
 		names = append(names, name)
 	}

--- a/internal/scatter/stages.go
+++ b/internal/scatter/stages.go
@@ -20,6 +20,7 @@ func ResolveMetrics(s *State) error {
 	if stages.PtrString(cfg.XAxis) == "" {
 		return eris.New("x-axis metric is required")
 	}
+
 	xAxis, err := resolveAxisSpec(cfg.XAxis)
 	if err != nil {
 		return eris.Wrap(err, "invalid x-axis metric")
@@ -28,6 +29,7 @@ func ResolveMetrics(s *State) error {
 	if stages.PtrString(cfg.YAxis) == "" {
 		return eris.New("y-axis metric is required")
 	}
+
 	yAxis, err := resolveAxisSpec(cfg.YAxis)
 	if err != nil {
 		return eris.Wrap(err, "invalid y-axis metric")

--- a/internal/scatter/stages.go
+++ b/internal/scatter/stages.go
@@ -17,14 +17,20 @@ import (
 func ResolveMetrics(s *State) error {
 	cfg := s.Config
 
+	if stages.PtrString(cfg.XAxis) == "" {
+		return eris.New("x-axis metric is required")
+	}
 	xAxis, err := resolveAxisSpec(cfg.XAxis)
 	if err != nil {
-		return err
+		return eris.Wrap(err, "invalid x-axis metric")
 	}
 
+	if stages.PtrString(cfg.YAxis) == "" {
+		return eris.New("y-axis metric is required")
+	}
 	yAxis, err := resolveAxisSpec(cfg.YAxis)
 	if err != nil {
-		return err
+		return eris.Wrap(err, "invalid y-axis metric")
 	}
 
 	size := metric.Name(stages.PtrString(cfg.Size))

--- a/internal/scatter/stages.go
+++ b/internal/scatter/stages.go
@@ -1,0 +1,176 @@
+package scatter
+
+import (
+	"log/slog"
+
+	"github.com/rotisserie/eris"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/config"
+	"github.com/theunrepentantgeek/code-visualizer/internal/legend"
+	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
+	"github.com/theunrepentantgeek/code-visualizer/internal/pipeline"
+	"github.com/theunrepentantgeek/code-visualizer/internal/provider"
+	"github.com/theunrepentantgeek/code-visualizer/internal/stages"
+)
+
+// ResolveMetrics resolves scatter axes, size, fill, and border settings.
+func ResolveMetrics(s *State) error {
+	cfg := s.Config
+
+	xAxis, err := resolveAxisSpec(cfg.XAxis)
+	if err != nil {
+		return err
+	}
+	yAxis, err := resolveAxisSpec(cfg.YAxis)
+	if err != nil {
+		return err
+	}
+
+	size := metric.Name(stages.PtrString(cfg.Size))
+	if size == "" {
+		return eris.New("size metric is required")
+	}
+
+	s.XAxis = xAxis
+	s.YAxis = yAxis
+	s.Size = size
+	s.FillMetric = resolveFillMetric(cfg, size)
+	s.FillPalette = stages.ResolveFillPalette(cfg.Fill, s.FillMetric)
+	s.BorderMetric, s.BorderPalette = stages.ResolveBorderMetricAndPalette(cfg.Border)
+	s.Common().Requested = collectRequestedMetrics(xAxis.Metric, yAxis.Metric, size, cfg.Fill, cfg.Border)
+
+	return nil
+}
+
+func resolveAxisSpec(name *string) (AxisSpec, error) {
+	metricName := metric.Name(stages.PtrString(name))
+	descriptor, ok := provider.GetDescriptor(metricName)
+	if !ok {
+		return AxisSpec{}, eris.Errorf("unknown axis metric %q", metricName)
+	}
+
+	return AxisSpec{Metric: metricName, Kind: descriptor.Kind}, nil
+}
+
+func resolveFillMetric(cfg *config.Scatter, size metric.Name) metric.Name {
+	if fill := cfg.Fill.MetricName(); fill != "" {
+		return fill
+	}
+
+	return size
+}
+
+func collectRequestedMetrics(xAxis, yAxis, size metric.Name, fill, border *config.MetricSpec) []metric.Name {
+	seen := map[metric.Name]bool{}
+	names := make([]metric.Name, 0, 5)
+	for _, name := range []metric.Name{xAxis, yAxis, size, fill.MetricName(), border.MetricName()} {
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+
+	return names
+}
+
+// BuildInksStage collects plottable files and creates point inks.
+func BuildInksStage(s *State) error {
+	c := s.Common()
+
+	s.Dataset = CollectDataset(c.Root, s.XAxis, s.YAxis, s.Size)
+	s.Inks = BuildInks(s.Dataset, s.FillMetric, s.FillPalette, s.BorderMetric, s.BorderPalette)
+
+	slog.Info("Rendering image", "output", c.Output, "width", c.Width, "height", c.Height)
+
+	return nil
+}
+
+// BuildLegendStage builds the legend config from the resolved inks.
+func BuildLegendStage(s *State) error {
+	pos, orient := legend.ResolveOptions(
+		stages.PtrString(s.Config.Legend),
+		stages.PtrString(s.Config.LegendOrientation),
+	)
+
+	s.LegendConfig = legend.Build(
+		pos,
+		orient,
+		s.Inks.Fill,
+		s.FillMetric,
+		s.Inks.Border,
+		s.BorderMetric,
+		s.Size,
+	)
+
+	return nil
+}
+
+// LayoutStage positions scatter points within the drawable plot area.
+func LayoutStage(s *State) error {
+	c := s.Common()
+	layoutW, layoutH := legend.ReserveAndLayout(s.LegendConfig, c.Width, c.Height)
+
+	layout := Layout(s.Dataset, layoutW, layoutH, s.XAxis, s.YAxis)
+	if layoutW < c.Width || layoutH < c.Height {
+		if s.LegendConfig != nil {
+			wReduce, hReduce := s.LegendConfig.ReserveSpace()
+			dx, dy := legend.LayoutOffset(s.LegendConfig, wReduce, hReduce)
+			OffsetLayout(&layout, dx, dy)
+		}
+	}
+
+	s.Layout = layout
+
+	return nil
+}
+
+// RenderStage renders the scatter plot to a canvas.
+func RenderStage(s *State) error {
+	c := s.Common()
+
+	cv := RenderToCanvas(s.Layout, c.Width, c.Height, s.Inks)
+	if s.LegendConfig != nil {
+		cv.SetLegend(*s.LegendConfig)
+	}
+
+	c.Canvas = cv
+
+	return nil
+}
+
+// LogResult logs the final scatter summary.
+func LogResult(s *State) error {
+	c := s.Common()
+	skipped := s.Dataset.Skipped.MissingX + s.Dataset.Skipped.MissingY + s.Dataset.Skipped.MissingSize
+
+	slog.Info(
+		"Rendered scatter plot",
+		"files", len(s.Dataset.Points),
+		"skipped_missing_x", s.Dataset.Skipped.MissingX,
+		"skipped_missing_y", s.Dataset.Skipped.MissingY,
+		"skipped_missing_size", s.Dataset.Skipped.MissingSize,
+		"skipped_total", skipped,
+		"output", c.Output,
+		"width", c.Width,
+		"height", c.Height,
+		"x_axis", string(s.XAxis.Metric),
+		"y_axis", string(s.YAxis.Metric),
+		"size_metric", string(s.Size),
+		"fill_metric", string(s.FillMetric),
+		"fill_palette", string(s.FillPalette),
+		"border_metric", string(s.BorderMetric),
+		"border_palette", string(s.BorderPalette),
+	)
+
+	return nil
+}
+
+var (
+	_ pipeline.Stage[*State] = ResolveMetrics
+	_ pipeline.Stage[*State] = BuildInksStage
+	_ pipeline.Stage[*State] = BuildLegendStage
+	_ pipeline.Stage[*State] = LayoutStage
+	_ pipeline.Stage[*State] = RenderStage
+	_ pipeline.Stage[*State] = LogResult
+)

--- a/internal/scatter/stages_test.go
+++ b/internal/scatter/stages_test.go
@@ -1,0 +1,63 @@
+package scatter
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/config"
+	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
+	"github.com/theunrepentantgeek/code-visualizer/internal/provider/filesystem"
+)
+
+func TestResolveMetrics_FillDefaultsToSize(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	s := &State{
+		Config: &config.Scatter{
+			XAxis: new("file-type"),
+			YAxis: new("file-lines"),
+			Size:  new("file-size"),
+		},
+	}
+
+	err := ResolveMetrics(s)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(s.XAxis).To(Equal(AxisSpec{Metric: filesystem.FileType, Kind: metric.Classification}))
+	g.Expect(s.YAxis).To(Equal(AxisSpec{Metric: filesystem.FileLines, Kind: metric.Quantity}))
+	g.Expect(s.Size).To(Equal(metric.Name(filesystem.FileSize)))
+	g.Expect(s.FillMetric).To(Equal(metric.Name(filesystem.FileSize)))
+	g.Expect(s.Common().Requested).To(Equal([]metric.Name{
+		filesystem.FileType,
+		filesystem.FileLines,
+		filesystem.FileSize,
+	}))
+}
+
+func TestResolveMetrics_FillAndBorderOverrideDefaults(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	s := &State{
+		Config: &config.Scatter{
+			XAxis: new("file-lines"),
+			YAxis: new("file-size"),
+			Size:  new("file-size"),
+			Fill:  &config.MetricSpec{Metric: filesystem.FileType},
+			Border: &config.MetricSpec{
+				Metric: filesystem.FileLines,
+			},
+		},
+	}
+
+	err := ResolveMetrics(s)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(s.FillMetric).To(Equal(metric.Name(filesystem.FileType)))
+	g.Expect(s.BorderMetric).To(Equal(metric.Name(filesystem.FileLines)))
+	g.Expect(s.Common().Requested).To(Equal([]metric.Name{
+		filesystem.FileLines,
+		filesystem.FileSize,
+		filesystem.FileType,
+	}))
+}

--- a/internal/scatter/stages_test.go
+++ b/internal/scatter/stages_test.go
@@ -26,8 +26,8 @@ func TestResolveMetrics_FillDefaultsToSize(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(s.XAxis).To(Equal(AxisSpec{Metric: filesystem.FileType, Kind: metric.Classification}))
 	g.Expect(s.YAxis).To(Equal(AxisSpec{Metric: filesystem.FileLines, Kind: metric.Quantity}))
-	g.Expect(s.Size).To(Equal(metric.Name(filesystem.FileSize)))
-	g.Expect(s.FillMetric).To(Equal(metric.Name(filesystem.FileSize)))
+	g.Expect(s.Size).To(Equal(filesystem.FileSize))
+	g.Expect(s.FillMetric).To(Equal(filesystem.FileSize))
 	g.Expect(s.Common().Requested).To(Equal([]metric.Name{
 		filesystem.FileType,
 		filesystem.FileLines,
@@ -53,8 +53,8 @@ func TestResolveMetrics_FillAndBorderOverrideDefaults(t *testing.T) {
 
 	err := ResolveMetrics(s)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(s.FillMetric).To(Equal(metric.Name(filesystem.FileType)))
-	g.Expect(s.BorderMetric).To(Equal(metric.Name(filesystem.FileLines)))
+	g.Expect(s.FillMetric).To(Equal(filesystem.FileType))
+	g.Expect(s.BorderMetric).To(Equal(filesystem.FileLines))
 	g.Expect(s.Common().Requested).To(Equal([]metric.Name{
 		filesystem.FileLines,
 		filesystem.FileSize,

--- a/internal/scatter/state.go
+++ b/internal/scatter/state.go
@@ -1,0 +1,36 @@
+package scatter
+
+import (
+	"github.com/theunrepentantgeek/code-visualizer/internal/canvas"
+	"github.com/theunrepentantgeek/code-visualizer/internal/config"
+	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
+	"github.com/theunrepentantgeek/code-visualizer/internal/palette"
+	"github.com/theunrepentantgeek/code-visualizer/internal/stages"
+)
+
+// State is the pipeline state for the scatter visualization.
+type State struct {
+	stages.CommonState
+
+	Config             *config.Scatter
+	IncludeBinaryFiles bool
+
+	XAxis         AxisSpec
+	YAxis         AxisSpec
+	Size          metric.Name
+	FillMetric    metric.Name
+	FillPalette   palette.PaletteName
+	BorderMetric  metric.Name
+	BorderPalette palette.PaletteName
+
+	Dataset      Dataset
+	Inks         Inks
+	Layout       ScatterLayout
+	LegendConfig *canvas.LegendConfig
+}
+
+// Common exposes the embedded CommonState so shared stages can mutate it.
+func (s *State) Common() *stages.CommonState { return &s.CommonState }
+
+// IncludeBinary lets State satisfy stages.BinaryFilterToggler.
+func (s *State) IncludeBinary() bool { return s.IncludeBinaryFiles }

--- a/internal/scatter/test_main_test.go
+++ b/internal/scatter/test_main_test.go
@@ -1,7 +1,6 @@
 package scatter
 
 import (
-	"os"
 	"testing"
 
 	"github.com/theunrepentantgeek/code-visualizer/internal/provider/filesystem"
@@ -11,5 +10,5 @@ import (
 func TestMain(m *testing.M) {
 	filesystem.Register()
 	git.Register()
-	os.Exit(m.Run())
+	m.Run()
 }

--- a/internal/scatter/test_main_test.go
+++ b/internal/scatter/test_main_test.go
@@ -1,0 +1,15 @@
+package scatter
+
+import (
+	"os"
+	"testing"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/provider/filesystem"
+	"github.com/theunrepentantgeek/code-visualizer/internal/provider/git"
+)
+
+func TestMain(m *testing.M) {
+	filesystem.Register()
+	git.Register()
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
Fixes #301

## Summary
- add a new scatter visualization pipeline with dedicated config and CLI wiring
- support numeric and categorical axes, axis labels/ticks, point labels, and deterministic largest-first rendering
- skip files missing required scatter metrics and enforce a readable minimum point size in crowded plots

## Test Plan
- task build
- task test