### PR TITLE
Fix bubbletree label placement

### DIFF
--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -140,7 +140,8 @@ go-install() {
 }
 
 # Stricter GO formatting
-go-install gofumpt mvdan.cc/gofumpt@latest
+# Pinned to keep local and devcontainer formatting deterministic.
+go-install gofumpt mvdan.cc/gofumpt@v0.10.0
 
 # Install golangci-lint
 write-verbose "Checking for $TOOL_DEST/golangci-lint"

--- a/.squad/agents/bishop/history.md
+++ b/.squad/agents/bishop/history.md
@@ -25,6 +25,16 @@
 
 <!-- Append learnings below -->
 
+### Issue #301 — Scatter Visualization Architecture Research (2026-05-23)
+
+- **Recommended package boundary:** add a dedicated `internal/scatter/` package plus `cmd/codeviz/scatter_cmd.go`, following the existing per-viz pattern used by `treemap`, `radialtree`, `bubbletree`, and `spiral`.
+- **Recommended model shape:** treat scatter as a flat file-point layout (`[]ScatterPoint` / `ScatterLayout`), not a tree. Placement is per file, so hierarchy should stay in the scanned model, not in the rendered node type.
+- **Pipeline pattern confirmed:** each viz owns `State`, `ResolveMetrics`, `BuildInksStage`, `BuildLegendStage`, `LayoutStage`, `RenderStage`, and `LogResult`, all built on `stages.CommonState` and `pipeline.Run`.
+- **Canvas constraint:** occlusion ordering is already solved structurally — `internal/canvas` sorts by layer, then preserves insertion order, so scatter can satisfy “draw larger discs first” by sorting points largest-first before `AddDisc`.
+- **Metric/design constraint:** `internal/inks/CollectNumericValues` / `extractNumeric` collapse missing numeric values to `0`, which is fine for colour bucketing but unsafe for scatter axes. Scatter should preserve the distinction between “missing” and zero for X/Y/size placement.
+- **Legend fit:** the shared legend builder already understands fill, border, and size channels; X/Y should remain axis concerns rather than legend entries.
+- **Key file paths:** `internal/treemap/stages.go`, `internal/radialtree/render.go`, `internal/bubbletree/render.go`, `internal/spiral/layout.go`, `internal/canvas/canvas.go`, `internal/canvas/layer.go`, `internal/inks/inks.go`, `internal/legend/legend.go`, `internal/config/*.go`, `cmd/codeviz/*_cmd.go`.
+
 ### PR Review Etiquette (Team Directive, 2026-05-13)
 
 - **PR review reply protocol:** After addressing a PR review comment, ALWAYS reply to the comment indicating what was done. Don't leave reviewers hanging. This closes the feedback loop and keeps communication clear for all stakeholders.
@@ -171,3 +181,13 @@
 - Renamed file `cmd/codeviz/viz_inks.go` → `cmd/codeviz/shape_inks.go` to match the type name
 - Updated all 24 references across 5 files: `shape_inks.go`, `treemap_canvas.go`, `radial_canvas.go`, `bubble_canvas.go`, `spiral_canvas.go`
 - CI clean: build, all tests, lint (76 linters, 0 issues)
+
+### Issue #301 — Scatter Visualization Implementation (2026-05-24)
+
+- **Status:** ✅ Implemented on branch `squad/301-scatter-visualization` in worktree `/home/bevan/github/code-visualizer-301`
+- **Package shape:** scatter follows the existing per-viz pipeline boundary with `internal/scatter/{state,axis,data,inks,layout,render,stages}.go` plus `cmd/codeviz/scatter_cmd.go` and `internal/config/scatter.go`.
+- **Model pattern:** keep scatter flat and file-centric — `Dataset` filters files with complete X/Y/size data, `ScatterLayout` carries plot geometry plus resolved axes, and rendering consumes sorted `[]ScatterPoint` rather than a tree.
+- **Axis pattern:** axis resolution stays local to scatter; numeric axes produce ticks/ranges, categorical axes produce alphabetical equal-width bands, and axis titles carry X/Y semantics instead of legend entries.
+- **Rendering rule:** z-order is handled structurally by sorting points radius-descending before `AddDisc`; labels are always rendered on `LayerOverlay`, and crowded plots clamp radii to a readable minimum even when that collapses size differentiation.
+- **Observability:** skipped files are counted separately for missing X, Y, and size and logged in `internal/scatter/stages.go` so scatter never silently coerces missing numeric values to zero.
+- **Key file paths:** `internal/scatter/layout.go`, `internal/scatter/render.go`, `internal/scatter/stages.go`, `internal/scatter/data.go`, `cmd/codeviz/scatter_cmd.go`, `internal/config/scatter.go`.

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -10,6 +10,13 @@
 
 <!-- Append learnings below -->
 
+### Issue #256 — Move Bubble Labels (2026-05-24)
+
+- **Occupied vs visible radius:** `internal/bubbletree/layout.go` keeps `BubbleNode.Radius` as the occupied area for layout/fit, while `internal/bubbletree/render.go` derives a smaller visible directory disc radius so labels can live above the bubble without being overdrawn.
+- **Root fit rule:** outside bubble labels require `scaleToFit()` to use `occupiedBounds()` and to scale empty labelled roots even when they have no children; otherwise the root label can clip off-canvas.
+- **Shared geometry contract:** `internal/canvas/model/backend.go` now owns `ArcTextInset`, which both raster/SVG backends and bubbletree rendering use to keep reserved label space aligned with actual arc text placement.
+- **Key verification files:** `internal/bubbletree/layout_test.go`, `internal/bubbletree/render_test.go`, and `internal/canvas/svg/backend_test.go` now cover child labels, empty labelled directories, root label fit, raster reserved-band rendering, and SVG glyph centering.
+
 ### PR Review Etiquette (Team Directive, 2026-05-13)
 
 - **PR review reply protocol:** After addressing a PR review comment, ALWAYS reply to the comment indicating what was done. Don't leave reviewers hanging. This closes the feedback loop and keeps communication clear for all stakeholders.

--- a/cmd/codeviz/main.go
+++ b/cmd/codeviz/main.go
@@ -16,12 +16,12 @@ import (
 )
 
 type CLI struct {
-	Quiet   bool   `help:"Suppress all non-essential output; only warnings and errors are shown." short:"q" xor:"verbosity"` //nolint:revive // kong struct tags require long lines
+	Quiet   bool   `help:"Suppress all non-essential output; only warnings and errors are shown." short:"q" xor:"verbosity"` //nolint:revive,nolintlint // kong struct tags require long lines
 	Verbose bool   `help:"Show detailed progress during scanning and metric calculation." short:"v" xor:"verbosity"`
 	Debug   bool   `help:"Show per-directory scan progress (implies verbose output)." xor:"verbosity"`
 	Config  string `help:"Path to configuration file (.yaml, .yml, or .json)." name:"config" optional:""`
 
-	//nolint:revive // Long help text is more important than minimizing line length, and annotations can't be wrapped
+	//nolint:revive,nolintlint // Long help text is more important than minimizing line length, and annotations can't be wrapped
 	ExportConfig string `help:"Write effective configuration to file (.yaml, .yml, or .json)." name:"export-config" optional:""`
 	ExportData   string `help:"Write computed metrics to file (.json or .yaml/.yml)." name:"export-data" optional:""`
 
@@ -58,7 +58,7 @@ func toStagesFlags(f *Flags) *stages.Flags {
 	}
 }
 
-func setupLogger(quiet, verbose, debug bool) { //nolint:revive // flag-parameter: boolean toggles are idiomatic for log verbosity
+func setupLogger(quiet, verbose, debug bool) { //nolint:revive,nolintlint // flag-parameter: boolean toggles are idiomatic for log verbosity
 	level := slog.LevelInfo
 
 	if quiet {

--- a/internal/bubbletree/layout.go
+++ b/internal/bubbletree/layout.go
@@ -128,6 +128,33 @@ type bounds struct {
 	maxY float64
 }
 
+func newEmptyBounds() bounds {
+	return bounds{
+		minX: math.MaxFloat64,
+		minY: math.MaxFloat64,
+		maxX: -math.MaxFloat64,
+		maxY: -math.MaxFloat64,
+	}
+}
+
+func expandBoundsForDisc(box *bounds, x, y, radius float64) {
+	if x-radius < box.minX {
+		box.minX = x - radius
+	}
+
+	if y-radius < box.minY {
+		box.minY = y - radius
+	}
+
+	if x+radius > box.maxX {
+		box.maxX = x + radius
+	}
+
+	if y+radius > box.maxY {
+		box.maxY = y + radius
+	}
+}
+
 type frontNode struct {
 	idx        int
 	prev, next *frontNode
@@ -572,7 +599,7 @@ func scaleToFit(node *BubbleNode, width, height float64) {
 		return
 	}
 
-	box := childrenBounds(node)
+	box := occupiedBounds(node)
 
 	boxW := box.maxX - box.minX
 	boxH := box.maxY - box.minY
@@ -599,32 +626,17 @@ func scaleToFit(node *BubbleNode, width, height float64) {
 	applyScale(node, scale)
 }
 
-// childrenBounds returns the tight axis-aligned bounding box of all direct
-// children of node in node's local coordinate frame.
-func childrenBounds(node *BubbleNode) bounds {
-	box := bounds{
-		minX: math.MaxFloat64,
-		minY: math.MaxFloat64,
-		maxX: -math.MaxFloat64,
-		maxY: -math.MaxFloat64,
-	}
+// occupiedBounds returns the tight axis-aligned bounding box of the node's
+// occupied area in its local coordinate frame.
+func occupiedBounds(node *BubbleNode) bounds {
+	box := newEmptyBounds()
 
 	for _, c := range node.Children {
-		if c.X-c.Radius < box.minX {
-			box.minX = c.X - c.Radius
-		}
+		expandBoundsForDisc(&box, c.X, c.Y, c.Radius)
+	}
 
-		if c.Y-c.Radius < box.minY {
-			box.minY = c.Y - c.Radius
-		}
-
-		if c.X+c.Radius > box.maxX {
-			box.maxX = c.X + c.Radius
-		}
-
-		if c.Y+c.Radius > box.maxY {
-			box.maxY = c.Y + c.Radius
-		}
+	if node.ShowLabel && node.Radius > 0 {
+		expandBoundsForDisc(&box, 0, 0, node.Radius)
 	}
 
 	return box

--- a/internal/bubbletree/layout.go
+++ b/internal/bubbletree/layout.go
@@ -27,6 +27,15 @@ func Layout(root *model.Directory, width, height int, sizeMetric metric.Name, la
 	}
 
 	node := layoutDir(root, sizeMetric, labels)
+
+	// The root directory's disc is never rendered, so its label is never
+	// shown either. Strip the label reservation so the children fill the
+	// canvas instead of leaving whitespace for a label that won't appear.
+	if node.ShowLabel {
+		node.Radius -= LabelReservation
+		node.ShowLabel = false
+	}
+
 	scaleToFit(&node, float64(width), float64(height))
 
 	return node

--- a/internal/bubbletree/layout.go
+++ b/internal/bubbletree/layout.go
@@ -14,8 +14,8 @@ import (
 const (
 	minFileRadius    = 2.0  // minimum circle radius for any file node
 	siblingPadding   = 3.0  // gap between sibling circles at the same level
-	parentPadding    = 6.0  // inset from parent circle edge (space for labels)
-	LabelReservation = 14.0 // extra radius for directories that show a label
+	parentPadding    = 6.0  // inset from parent circle edge
+	LabelReservation = 14.0 // occupied radius reserved above labelled directory bubbles
 )
 
 // Layout builds a bubble tree from root, positioning circles to fit within

--- a/internal/bubbletree/layout.go
+++ b/internal/bubbletree/layout.go
@@ -55,6 +55,9 @@ func layoutDir(dir *model.Directory, sizeMetric metric.Name, labels LabelMode) B
 
 	if len(children) == 0 {
 		node.Radius = minFileRadius
+		if node.ShowLabel {
+			node.Radius += LabelReservation
+		}
 
 		return node
 	}

--- a/internal/bubbletree/layout.go
+++ b/internal/bubbletree/layout.go
@@ -12,10 +12,10 @@ import (
 )
 
 const (
-	minFileRadius    = 2.0  // minimum circle radius for any file node
-	siblingPadding   = 3.0  // gap between sibling circles at the same level
-	parentPadding    = 6.0  // inset from parent circle edge
-	LabelReservation = 14.0 // occupied radius reserved above labelled directory bubbles
+	minFileRadius    = 2.0                   // minimum circle radius for any file node
+	siblingPadding   = 3.0                   // gap between sibling circles at the same level
+	parentPadding    = 6.0                   // inset from parent circle edge
+	LabelReservation = bubbleDefaultFontSize // occupied radius reserved above labelled directory bubbles
 )
 
 // Layout builds a bubble tree from root, positioning circles to fit within
@@ -592,9 +592,17 @@ const canvasMarginFraction = 0.02 // 2% margin on each side
 // root bounding circle removes the large whitespace corners that a circle
 // fit would leave on a non-square canvas.
 func scaleToFit(node *BubbleNode, width, height float64) {
-	if node.Radius <= 0 || len(node.Children) == 0 {
+	if node.Radius <= 0 {
 		node.X = width / 2
 		node.Y = height / 2
+
+		return
+	}
+
+	if len(node.Children) == 0 {
+		node.X = width / 2
+		node.Y = height / 2
+		node.Radius = math.Min(width, height) * (1 - 2*canvasMarginFraction) / 2
 
 		return
 	}

--- a/internal/bubbletree/layout_stage_test.go
+++ b/internal/bubbletree/layout_stage_test.go
@@ -57,7 +57,7 @@ func TestLayoutStage_ReservesLegendSpace(t *testing.T) {
 			wReduce, hReduce := cfg.ReserveSpace()
 			layoutW, layoutH := legend.ReserveAndLayout(cfg, state.Width, state.Height)
 			dx, dy := legend.LayoutOffset(cfg, wReduce, hReduce)
-			box := childrenBounds(&state.Nodes)
+			box := contentBoundsForTest(state.Nodes)
 
 			if tt.startOnX {
 				g.Expect(box.minX).To(BeNumerically(">=", dx-1.0), tt.startMessage)

--- a/internal/bubbletree/layout_test.go
+++ b/internal/bubbletree/layout_test.go
@@ -412,6 +412,29 @@ func TestLayoutRootOccupiedLabelAreaFitsWithinCanvas(t *testing.T) {
 	)
 }
 
+func TestLayoutEmptyRootOccupiedLabelAreaFitsWithinCanvas(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := &model.Directory{Name: "root"}
+
+	width, height := 20, 20
+	node := Layout(root, width, height, filesystem.FileSize, LabelFoldersOnly)
+
+	g.Expect(node.X-node.Radius).To(BeNumerically(">=", -1.0),
+		"empty labelled root should fit within the left edge of the canvas",
+	)
+	g.Expect(node.Y-node.Radius).To(BeNumerically(">=", -1.0),
+		"empty labelled root should fit within the top edge of the canvas",
+	)
+	g.Expect(node.X+node.Radius).To(BeNumerically("<=", float64(width)+1.0),
+		"empty labelled root should fit within the right edge of the canvas",
+	)
+	g.Expect(node.Y+node.Radius).To(BeNumerically("<=", float64(height)+1.0),
+		"empty labelled root should fit within the bottom edge of the canvas",
+	)
+}
+
 // contentBoundsForTest returns the axis-aligned bounding box of all descendant
 // nodes (not the root itself, which is never drawn).
 func contentBoundsForTest(root BubbleNode) bounds {

--- a/internal/bubbletree/layout_test.go
+++ b/internal/bubbletree/layout_test.go
@@ -382,6 +382,36 @@ func TestLayoutFitsWithinCanvas(t *testing.T) {
 	g.Expect(box.maxY).To(BeNumerically("<=", float64(height)+1.0))
 }
 
+func TestLayoutRootOccupiedLabelAreaFitsWithinCanvas(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := &model.Directory{
+		Name: "root",
+		Files: []*model.File{
+			makeFile("a.go", 200),
+			makeFile("b.go", 300),
+			makeFile("c.go", 100),
+		},
+	}
+
+	width, height := 1920, 1080
+	node := Layout(root, width, height, filesystem.FileSize, LabelFoldersOnly)
+
+	g.Expect(node.X-node.Radius).To(BeNumerically(">=", -1.0),
+		"root occupied area should fit within the left edge of the canvas",
+	)
+	g.Expect(node.Y-node.Radius).To(BeNumerically(">=", -1.0),
+		"root occupied area should fit within the top edge of the canvas",
+	)
+	g.Expect(node.X+node.Radius).To(BeNumerically("<=", float64(width)+1.0),
+		"root occupied area should fit within the right edge of the canvas",
+	)
+	g.Expect(node.Y+node.Radius).To(BeNumerically("<=", float64(height)+1.0),
+		"root occupied area should fit within the bottom edge of the canvas",
+	)
+}
+
 // contentBoundsForTest returns the axis-aligned bounding box of all descendant
 // nodes (not the root itself, which is never drawn).
 func contentBoundsForTest(root BubbleNode) bounds {

--- a/internal/bubbletree/layout_test.go
+++ b/internal/bubbletree/layout_test.go
@@ -224,6 +224,49 @@ func TestLayoutEmptyDirectory(t *testing.T) {
 	g.Expect(node.Children).To(BeEmpty())
 }
 
+func TestLayoutEmptyLabelledDirectoryReservesMoreSpaceThanFile(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := &model.Directory{
+		Name: "root",
+		Path: "root",
+		Dirs: []*model.Directory{{
+			Name: "a",
+			Path: "root/a",
+		}},
+		Files: []*model.File{{
+			Name: "plain.go",
+			Path: "root/plain.go",
+		}},
+	}
+
+	node := Layout(root, 1920, 1080, filesystem.FileSize, LabelFoldersOnly)
+	g.Expect(node.Children).To(HaveLen(2))
+
+	var dirNode, fileNode *BubbleNode
+
+	for i := range node.Children {
+		child := &node.Children[i]
+		if child.IsDirectory {
+			dirNode = child
+		} else {
+			fileNode = child
+		}
+	}
+
+	g.Expect(dirNode).NotTo(BeNil())
+	g.Expect(fileNode).NotTo(BeNil())
+
+	if dirNode == nil || fileNode == nil {
+		return
+	}
+
+	g.Expect(dirNode.Radius).To(BeNumerically(">", fileNode.Radius),
+		"empty labelled directory should reserve extra occupied space for its label",
+	)
+}
+
 func TestLayoutSingleFile(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)

--- a/internal/bubbletree/layout_test.go
+++ b/internal/bubbletree/layout_test.go
@@ -262,7 +262,8 @@ func TestLayoutEmptyLabelledDirectoryReservesMoreSpaceThanFile(t *testing.T) {
 		return
 	}
 
-	g.Expect(dirNode.Radius).To(BeNumerically(">", fileNode.Radius),
+	g.Expect(dirNode.Radius).To(
+		BeNumerically(">", fileNode.Radius),
 		"empty labelled directory should reserve extra occupied space for its label",
 	)
 }
@@ -398,16 +399,20 @@ func TestLayoutRootOccupiedLabelAreaFitsWithinCanvas(t *testing.T) {
 	width, height := 1920, 1080
 	node := Layout(root, width, height, filesystem.FileSize, LabelFoldersOnly)
 
-	g.Expect(node.X-node.Radius).To(BeNumerically(">=", -1.0),
+	g.Expect(node.X-node.Radius).To(
+		BeNumerically(">=", -1.0),
 		"root occupied area should fit within the left edge of the canvas",
 	)
-	g.Expect(node.Y-node.Radius).To(BeNumerically(">=", -1.0),
+	g.Expect(node.Y-node.Radius).To(
+		BeNumerically(">=", -1.0),
 		"root occupied area should fit within the top edge of the canvas",
 	)
-	g.Expect(node.X+node.Radius).To(BeNumerically("<=", float64(width)+1.0),
+	g.Expect(node.X+node.Radius).To(
+		BeNumerically("<=", float64(width)+1.0),
 		"root occupied area should fit within the right edge of the canvas",
 	)
-	g.Expect(node.Y+node.Radius).To(BeNumerically("<=", float64(height)+1.0),
+	g.Expect(node.Y+node.Radius).To(
+		BeNumerically("<=", float64(height)+1.0),
 		"root occupied area should fit within the bottom edge of the canvas",
 	)
 }
@@ -421,16 +426,20 @@ func TestLayoutEmptyRootOccupiedLabelAreaFitsWithinCanvas(t *testing.T) {
 	width, height := 20, 20
 	node := Layout(root, width, height, filesystem.FileSize, LabelFoldersOnly)
 
-	g.Expect(node.X-node.Radius).To(BeNumerically(">=", -1.0),
+	g.Expect(node.X-node.Radius).To(
+		BeNumerically(">=", -1.0),
 		"empty labelled root should fit within the left edge of the canvas",
 	)
-	g.Expect(node.Y-node.Radius).To(BeNumerically(">=", -1.0),
+	g.Expect(node.Y-node.Radius).To(
+		BeNumerically(">=", -1.0),
 		"empty labelled root should fit within the top edge of the canvas",
 	)
-	g.Expect(node.X+node.Radius).To(BeNumerically("<=", float64(width)+1.0),
+	g.Expect(node.X+node.Radius).To(
+		BeNumerically("<=", float64(width)+1.0),
 		"empty labelled root should fit within the right edge of the canvas",
 	)
-	g.Expect(node.Y+node.Radius).To(BeNumerically("<=", float64(height)+1.0),
+	g.Expect(node.Y+node.Radius).To(
+		BeNumerically("<=", float64(height)+1.0),
 		"empty labelled root should fit within the bottom edge of the canvas",
 	)
 }

--- a/internal/bubbletree/layout_test.go
+++ b/internal/bubbletree/layout_test.go
@@ -163,7 +163,7 @@ func TestLayoutLabelAll(t *testing.T) {
 	}
 
 	node := Layout(root, 1920, 1080, filesystem.FileSize, LabelAll)
-	g.Expect(node.ShowLabel).To(BeTrue())
+	g.Expect(node.ShowLabel).To(BeFalse(), "root label is never rendered")
 	g.Expect(node.Children).To(HaveLen(1))
 	g.Expect(node.Children[0].ShowLabel).To(BeTrue())
 }
@@ -183,7 +183,7 @@ func TestLayoutLabelFoldersOnly(t *testing.T) {
 
 	node := Layout(root, 1920, 1080, filesystem.FileSize, LabelFoldersOnly)
 	g.Expect(node.IsDirectory).To(BeTrue())
-	g.Expect(node.ShowLabel).To(BeTrue())
+	g.Expect(node.ShowLabel).To(BeFalse(), "root label is never rendered")
 
 	g.Expect(node.Children).To(HaveLen(1))
 	subNode := node.Children[0]
@@ -381,67 +381,6 @@ func TestLayoutFitsWithinCanvas(t *testing.T) {
 	g.Expect(box.minY).To(BeNumerically(">=", -1.0))
 	g.Expect(box.maxX).To(BeNumerically("<=", float64(width)+1.0))
 	g.Expect(box.maxY).To(BeNumerically("<=", float64(height)+1.0))
-}
-
-func TestLayoutRootOccupiedLabelAreaFitsWithinCanvas(t *testing.T) {
-	t.Parallel()
-	g := NewGomegaWithT(t)
-
-	root := &model.Directory{
-		Name: "root",
-		Files: []*model.File{
-			makeFile("a.go", 200),
-			makeFile("b.go", 300),
-			makeFile("c.go", 100),
-		},
-	}
-
-	width, height := 1920, 1080
-	node := Layout(root, width, height, filesystem.FileSize, LabelFoldersOnly)
-
-	g.Expect(node.X-node.Radius).To(
-		BeNumerically(">=", -1.0),
-		"root occupied area should fit within the left edge of the canvas",
-	)
-	g.Expect(node.Y-node.Radius).To(
-		BeNumerically(">=", -1.0),
-		"root occupied area should fit within the top edge of the canvas",
-	)
-	g.Expect(node.X+node.Radius).To(
-		BeNumerically("<=", float64(width)+1.0),
-		"root occupied area should fit within the right edge of the canvas",
-	)
-	g.Expect(node.Y+node.Radius).To(
-		BeNumerically("<=", float64(height)+1.0),
-		"root occupied area should fit within the bottom edge of the canvas",
-	)
-}
-
-func TestLayoutEmptyRootOccupiedLabelAreaFitsWithinCanvas(t *testing.T) {
-	t.Parallel()
-	g := NewGomegaWithT(t)
-
-	root := &model.Directory{Name: "root"}
-
-	width, height := 20, 20
-	node := Layout(root, width, height, filesystem.FileSize, LabelFoldersOnly)
-
-	g.Expect(node.X-node.Radius).To(
-		BeNumerically(">=", -1.0),
-		"empty labelled root should fit within the left edge of the canvas",
-	)
-	g.Expect(node.Y-node.Radius).To(
-		BeNumerically(">=", -1.0),
-		"empty labelled root should fit within the top edge of the canvas",
-	)
-	g.Expect(node.X+node.Radius).To(
-		BeNumerically("<=", float64(width)+1.0),
-		"empty labelled root should fit within the right edge of the canvas",
-	)
-	g.Expect(node.Y+node.Radius).To(
-		BeNumerically("<=", float64(height)+1.0),
-		"empty labelled root should fit within the bottom edge of the canvas",
-	)
 }
 
 // contentBoundsForTest returns the axis-aligned bounding box of all descendant

--- a/internal/bubbletree/render.go
+++ b/internal/bubbletree/render.go
@@ -123,7 +123,7 @@ func addBubbleDirDiscs(
 			Spec:   dirSpec,
 			X:      e.node.X,
 			Y:      e.node.Y,
-			Radius: e.node.Radius,
+			Radius: bubbleDirDiscRadius(*e.node),
 		})
 	}
 }
@@ -216,9 +216,25 @@ func addBubbleLabels(cv *canvas.Canvas, node BubbleNode) {
 	}
 }
 
-// addBubbleDirLabel adds an arc text label curved along the top of a directory circle.
+func bubbleDirDiscRadius(node BubbleNode) float64 {
+	if node.IsDirectory && node.ShowLabel {
+		return max(0.0, node.Radius-LabelReservation)
+	}
+
+	return node.Radius
+}
+
+func bubbleDirLabelRadiusHint(node BubbleNode) float64 {
+	return bubbleDirDiscRadius(node) + LabelReservation/2 + bubbleArcLabelInset
+}
+
+func bubbleDirLabelRadius(node BubbleNode, fontSize float64) float64 {
+	return bubbleDirDiscRadius(node) + fontSize/2 + bubbleArcLabelInset
+}
+
+// addBubbleDirLabel adds an arc text label curved just above the top of a directory circle.
 func addBubbleDirLabel(cv *canvas.Canvas, node BubbleNode) {
-	fontSize := bubbleArcFontSize(node.Label, node.Radius)
+	fontSize := bubbleArcFontSize(node.Label, bubbleDirLabelRadiusHint(node))
 	if fontSize == 0 {
 		return
 	}
@@ -232,7 +248,7 @@ func addBubbleDirLabel(cv *canvas.Canvas, node BubbleNode) {
 		Spec:   arcSpec,
 		X:      node.X,
 		Y:      node.Y,
-		Radius: node.Radius,
+		Radius: bubbleDirLabelRadius(node, fontSize),
 		Text:   node.Label,
 	})
 }
@@ -254,8 +270,9 @@ func addBubbleFileLabel(cv *canvas.Canvas, node BubbleNode) {
 }
 
 // bubbleArcFontSize computes the font size for a label to fit within
-// bubbleMaxArcFraction of the circle arc. Returns 0 if the label cannot fit
-// at the minimum readable font size.
+// bubbleMaxArcFraction of the target arc. The radius includes the canvas
+// backend's fixed arc inset. Returns 0 if the label cannot fit at the
+// minimum readable font size.
 func bubbleArcFontSize(label string, radius float64) float64 {
 	charCount := float64(utf8.RuneCountInString(label))
 	if charCount == 0 {

--- a/internal/bubbletree/render.go
+++ b/internal/bubbletree/render.go
@@ -224,17 +224,22 @@ func bubbleDirDiscRadius(node BubbleNode) float64 {
 	return node.Radius
 }
 
-func bubbleDirLabelRadiusHint(node BubbleNode) float64 {
-	return bubbleDirDiscRadius(node) + LabelReservation/2 + bubbleArcLabelInset
-}
-
 func bubbleDirLabelRadius(node BubbleNode, fontSize float64) float64 {
 	return bubbleDirDiscRadius(node) + fontSize/2 + bubbleArcLabelInset
 }
 
+func bubbleDirLabelFontSize(node BubbleNode) float64 {
+	fontSize := bubbleArcFontSize(node.Label, bubbleDirLabelRadius(node, bubbleDefaultFontSize))
+	if fontSize == 0 {
+		return 0
+	}
+
+	return bubbleArcFontSize(node.Label, bubbleDirLabelRadius(node, fontSize))
+}
+
 // addBubbleDirLabel adds an arc text label curved just above the top of a directory circle.
 func addBubbleDirLabel(cv *canvas.Canvas, node BubbleNode) {
-	fontSize := bubbleArcFontSize(node.Label, bubbleDirLabelRadiusHint(node))
+	fontSize := bubbleDirLabelFontSize(node)
 	if fontSize == 0 {
 		return
 	}

--- a/internal/bubbletree/render.go
+++ b/internal/bubbletree/render.go
@@ -16,7 +16,7 @@ const (
 	bubbleDirOpacity        = float64(0x30) / 255.0
 	bubbleBorderWidth       = 0.5
 	bubbleMetricBorderWidth = 2.0
-	bubbleArcLabelInset     = 14.0
+	bubbleArcLabelInset     = canvasmodel.ArcTextInset
 	bubbleMinArcFontSize    = 7.0
 	bubbleDefaultFontSize   = 14.0
 	bubbleMaxArcFraction    = math.Pi / 2.0

--- a/internal/bubbletree/render_test.go
+++ b/internal/bubbletree/render_test.go
@@ -7,8 +7,11 @@ import (
 	"image/color"
 	_ "image/jpeg"
 	_ "image/png"
+	"math"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -89,6 +92,54 @@ func testRoot() *model.Directory {
 			},
 		},
 	}
+}
+
+func decodeImage(t *testing.T, path string) image.Image {
+	t.Helper()
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open image: %v", err)
+	}
+
+	defer f.Close()
+
+	img, _, err := image.Decode(f)
+	if err != nil {
+		t.Fatalf("decode image: %v", err)
+	}
+
+	return img
+}
+
+func hasNonWhitePixelInRect(img image.Image, minX, minY, maxX, maxY int) bool {
+	bounds := img.Bounds()
+	minX = max(minX, bounds.Min.X)
+	minY = max(minY, bounds.Min.Y)
+	maxX = min(maxX, bounds.Max.X)
+	maxY = min(maxY, bounds.Max.Y)
+
+	for y := minY; y < maxY; y++ {
+		for x := minX; x < maxX; x++ {
+			r, g, b, a := img.At(x, y).RGBA()
+			if a != 0xffff || r != 0xffff || g != 0xffff || b != 0xffff {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func mustParseFloat(t *testing.T, value string) float64 {
+	t.Helper()
+
+	f, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		t.Fatalf("parse float %q: %v", value, err)
+	}
+
+	return f
 }
 
 func TestRenderBubbleToCanvas_PNG(t *testing.T) {
@@ -354,4 +405,90 @@ func TestRenderBubbleToCanvas_EmptyLabelledDirectoryKeepsVisibleBubble(t *testin
 	g.Expect(childLabelRadius).To(BeNumerically(">", backend.discs[0].radius),
 		"empty labelled directory should reserve label space above its bubble",
 	)
+}
+
+func TestRenderBubbleToCanvas_RasterPlacesDirectoryLabelInReservedBand(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := &model.Directory{
+		Name: "root",
+		Path: "root",
+		Dirs: []*model.Directory{{
+			Name: "pkg",
+			Path: "root/pkg",
+		}},
+	}
+	inks := bubbletree.BuildInks(root, filesystem.FileSize, palette.Temperature, "", "")
+	nodes := bubbletree.Layout(root, 800, 600, filesystem.FileSize, bubbletree.LabelFoldersOnly)
+	cv := bubbletree.RenderToCanvas(&nodes, root, 800, 600, inks)
+
+	var dirNode *bubbletree.BubbleNode
+
+	for i := range nodes.Children {
+		if nodes.Children[i].IsDirectory {
+			dirNode = &nodes.Children[i]
+
+			break
+		}
+	}
+
+	g.Expect(dirNode).NotTo(BeNil())
+
+	if dirNode == nil {
+		return
+	}
+
+	out := filepath.Join(t.TempDir(), "label-band.png")
+	g.Expect(cv.Render(out)).To(Succeed())
+
+	img := decodeImage(t, out)
+	minX := int(math.Floor(dirNode.X - dirNode.Radius/2))
+	maxX := int(math.Ceil(dirNode.X + dirNode.Radius/2))
+	minY := int(math.Floor(dirNode.Y - dirNode.Radius))
+	maxY := int(math.Ceil(dirNode.Y - dirNode.Radius + bubbletree.LabelReservation))
+
+	g.Expect(hasNonWhitePixelInRect(img, minX, minY, maxX, maxY)).To(BeTrue(),
+		"expected raster output to place the directory label in the reserved band above the bubble",
+	)
+}
+
+func TestRenderBubbleToCanvas_SVGKeepsRootLabelPathWithinCanvas(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := &model.Directory{
+		Name: "root",
+		Path: "root",
+		Files: []*model.File{
+			makeFile("main.go", "go", 100),
+			makeFile("style.css", "css", 50),
+		},
+	}
+	inks := bubbletree.BuildInks(root, filesystem.FileSize, palette.Temperature, "", "")
+	nodes := bubbletree.Layout(root, 800, 600, filesystem.FileSize, bubbletree.LabelFoldersOnly)
+	cv := bubbletree.RenderToCanvas(&nodes, root, 800, 600, inks)
+
+	out := filepath.Join(t.TempDir(), "root-label.svg")
+	g.Expect(cv.Render(out)).To(Succeed())
+
+	data, err := os.ReadFile(out)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(bytes.Contains(data, []byte(">root</textPath>"))).To(BeTrue())
+
+	pathPattern := regexp.MustCompile(
+		`<path id="[^"]+" d="M([0-9.\-]+),([0-9.\-]+) A[0-9.\-]+,[0-9.\-]+ 0 0,1 ([0-9.\-]+),([0-9.\-]+)"`,
+	)
+	match := pathPattern.FindStringSubmatch(string(data))
+	g.Expect(match).To(HaveLen(5))
+
+	startX := mustParseFloat(t, match[1])
+	startY := mustParseFloat(t, match[2])
+	endX := mustParseFloat(t, match[3])
+	endY := mustParseFloat(t, match[4])
+
+	g.Expect(startX).To(BeNumerically(">=", 0.0))
+	g.Expect(startY).To(BeNumerically(">=", 0.0))
+	g.Expect(endX).To(BeNumerically("<=", 800.0))
+	g.Expect(endY).To(BeNumerically("<=", 600.0))
 }

--- a/internal/bubbletree/render_test.go
+++ b/internal/bubbletree/render_test.go
@@ -10,8 +10,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"regexp"
-	"strconv"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -129,17 +127,6 @@ func hasNonWhitePixelInRect(img image.Image, minX, minY, maxX, maxY int) bool {
 	}
 
 	return false
-}
-
-func mustParseFloat(t *testing.T, value string) float64 {
-	t.Helper()
-
-	f, err := strconv.ParseFloat(value, 64)
-	if err != nil {
-		t.Fatalf("parse float %q: %v", value, err)
-	}
-
-	return f
 }
 
 func TestRenderBubbleToCanvas_PNG(t *testing.T) {
@@ -459,7 +446,7 @@ func TestRenderBubbleToCanvas_RasterPlacesDirectoryLabelInReservedBand(t *testin
 	)
 }
 
-func TestRenderBubbleToCanvas_SVGKeepsRootLabelPathWithinCanvas(t *testing.T) {
+func TestRenderBubbleToCanvas_SVGOmitsRootLabel(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
@@ -480,21 +467,8 @@ func TestRenderBubbleToCanvas_SVGKeepsRootLabelPathWithinCanvas(t *testing.T) {
 
 	data, err := os.ReadFile(out)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(bytes.Contains(data, []byte(">root</textPath>"))).To(BeTrue())
-
-	pathPattern := regexp.MustCompile(
-		`<path id="[^"]+" d="M([0-9.\-]+),([0-9.\-]+) A[0-9.\-]+,[0-9.\-]+ 0 0,1 ([0-9.\-]+),([0-9.\-]+)"`,
+	g.Expect(bytes.Contains(data, []byte(">root</textPath>"))).To(
+		BeFalse(),
+		"root directory disc is not rendered, so its label should be omitted",
 	)
-	match := pathPattern.FindStringSubmatch(string(data))
-	g.Expect(match).To(HaveLen(5))
-
-	startX := mustParseFloat(t, match[1])
-	startY := mustParseFloat(t, match[2])
-	endX := mustParseFloat(t, match[3])
-	endY := mustParseFloat(t, match[4])
-
-	g.Expect(startX).To(BeNumerically(">=", 0.0))
-	g.Expect(startY).To(BeNumerically(">=", 0.0))
-	g.Expect(endX).To(BeNumerically("<=", 800.0))
-	g.Expect(endY).To(BeNumerically("<=", 600.0))
 }

--- a/internal/bubbletree/render_test.go
+++ b/internal/bubbletree/render_test.go
@@ -357,10 +357,12 @@ func TestRenderBubbleToCanvas_DirectoryLabelsUseReservedBandOutsideBubble(t *tes
 		}
 	}
 
-	g.Expect(pkgLabelRadius).To(BeNumerically(">", maxDiscRadius),
+	g.Expect(pkgLabelRadius).To(
+		BeNumerically(">", maxDiscRadius),
 		"directory label should sit above the bubble edge, not on top of it",
 	)
-	g.Expect(pkgLabelRadius).To(BeNumerically(">", pkgNode.Radius),
+	g.Expect(pkgLabelRadius).To(
+		BeNumerically(">", pkgNode.Radius),
 		"rendered arc should use the reserved label band outside the bubble",
 	)
 }
@@ -385,7 +387,8 @@ func TestRenderBubbleToCanvas_EmptyLabelledDirectoryKeepsVisibleBubble(t *testin
 	g.Expect(cv.RenderTo(backend)).To(Succeed())
 
 	g.Expect(backend.discs).NotTo(BeEmpty())
-	g.Expect(backend.discs[0].radius).To(BeNumerically(">", 0),
+	g.Expect(backend.discs[0].radius).To(
+		BeNumerically(">", 0),
 		"empty labelled directory should still render as a visible bubble",
 	)
 
@@ -399,10 +402,12 @@ func TestRenderBubbleToCanvas_EmptyLabelledDirectoryKeepsVisibleBubble(t *testin
 		}
 	}
 
-	g.Expect(childLabelRadius).To(BeNumerically(">", 0),
+	g.Expect(childLabelRadius).To(
+		BeNumerically(">", 0),
 		"empty labelled directory should still render its label",
 	)
-	g.Expect(childLabelRadius).To(BeNumerically(">", backend.discs[0].radius),
+	g.Expect(childLabelRadius).To(
+		BeNumerically(">", backend.discs[0].radius),
 		"empty labelled directory should reserve label space above its bubble",
 	)
 }
@@ -448,7 +453,8 @@ func TestRenderBubbleToCanvas_RasterPlacesDirectoryLabelInReservedBand(t *testin
 	minY := int(math.Floor(dirNode.Y - dirNode.Radius))
 	maxY := int(math.Ceil(dirNode.Y - dirNode.Radius + bubbletree.LabelReservation))
 
-	g.Expect(hasNonWhitePixelInRect(img, minX, minY, maxX, maxY)).To(BeTrue(),
+	g.Expect(hasNonWhitePixelInRect(img, minX, minY, maxX, maxY)).To(
+		BeTrue(),
 		"expected raster output to place the directory label in the reserved band above the bubble",
 	)
 }

--- a/internal/bubbletree/render_test.go
+++ b/internal/bubbletree/render_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/xml"
 	"image"
+	"image/color"
 	_ "image/jpeg"
 	_ "image/png"
 	"os"
@@ -13,22 +14,78 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/theunrepentantgeek/code-visualizer/internal/bubbletree"
+	"github.com/theunrepentantgeek/code-visualizer/internal/canvas"
+	canvasmodel "github.com/theunrepentantgeek/code-visualizer/internal/canvas/model"
 	"github.com/theunrepentantgeek/code-visualizer/internal/model"
 	"github.com/theunrepentantgeek/code-visualizer/internal/palette"
 	"github.com/theunrepentantgeek/code-visualizer/internal/provider/filesystem"
 )
 
+type capturedDisc struct {
+	radius float64
+}
+
+type capturedArcText struct {
+	text   string
+	radius float64
+}
+
+type captureBackend struct {
+	discs    []capturedDisc
+	arcTexts []capturedArcText
+}
+
+func (*captureBackend) DrawRectangle(canvas.Position, canvas.Size, canvasmodel.Fill, canvasmodel.Fill, float64) {
+}
+
+func (c *captureBackend) DrawDisc(
+	_ canvas.Position,
+	radius float64,
+	_ canvasmodel.Fill,
+	_ canvasmodel.Fill,
+	_ float64,
+) {
+	c.discs = append(c.discs, capturedDisc{radius: radius})
+}
+
+func (*captureBackend) DrawLine(canvas.Position, canvas.Position, color.RGBA, float64) {}
+
+func (*captureBackend) DrawPath([]canvas.Position, color.RGBA, float64) {}
+
+func (*captureBackend) DrawText(canvas.Position, string, color.RGBA, float64, canvas.TextAnchor, float64) {
+}
+
+func (c *captureBackend) DrawArcText(
+	_ canvas.Position,
+	radius float64,
+	text string,
+	_ color.RGBA,
+	_ float64,
+) {
+	c.arcTexts = append(c.arcTexts, capturedArcText{text: text, radius: radius})
+}
+
+func (*captureBackend) Finish(string) error { return nil }
+
 func testRoot() *model.Directory {
+	mainFile := makeFile("main.go", "go", 100)
+	mainFile.Path = "root/main.go"
+
+	styleFile := makeFile("style.css", "css", 50)
+	styleFile.Path = "root/style.css"
+
+	libFile := makeFile("lib.go", "go", 200)
+	libFile.Path = "root/pkg/lib.go"
+
 	return &model.Directory{
-		Path: "root",
-		Files: []*model.File{
-			makeFile("main.go", "go", 100),
-			makeFile("style.css", "css", 50),
-		},
+		Name:  "root",
+		Path:  "root",
+		Files: []*model.File{mainFile, styleFile},
 		Dirs: []*model.Directory{
 			{
+				Name:  "pkg",
 				Path:  "root/pkg",
-				Files: []*model.File{makeFile("lib.go", "go", 200)},
+				Files: []*model.File{libFile},
 			},
 		},
 	}
@@ -198,4 +255,56 @@ func TestRenderBubbleToCanvas_CategoricalFill(t *testing.T) {
 	_, format, err := image.DecodeConfig(f)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(format).To(Equal("png"))
+}
+
+func TestRenderBubbleToCanvas_DirectoryLabelsUseReservedBandOutsideBubble(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := testRoot()
+	nodes := bubbletree.Layout(root, 1000, 800, filesystem.FileSize, bubbletree.LabelFoldersOnly)
+	inks := bubbletree.BuildInks(root, filesystem.FileSize, palette.Temperature, "", "")
+	cv := bubbletree.RenderToCanvas(&nodes, root, 1000, 800, inks)
+
+	backend := &captureBackend{}
+	g.Expect(cv.RenderTo(backend)).To(Succeed())
+
+	g.Expect(nodes.Children).To(HaveLen(3))
+
+	var pkgNode *bubbletree.BubbleNode
+	for i := range nodes.Children {
+		if nodes.Children[i].IsDirectory {
+			pkgNode = &nodes.Children[i]
+			break
+		}
+	}
+
+	g.Expect(pkgNode).NotTo(BeNil())
+	if pkgNode == nil {
+		return
+	}
+
+	maxDiscRadius := 0.0
+	for _, disc := range backend.discs {
+		if disc.radius > maxDiscRadius {
+			maxDiscRadius = disc.radius
+		}
+	}
+
+	g.Expect(maxDiscRadius).To(BeNumerically("~", pkgNode.Radius-bubbletree.LabelReservation, 0.001))
+
+	var pkgLabelRadius float64
+	for _, arcText := range backend.arcTexts {
+		if arcText.text == "pkg" {
+			pkgLabelRadius = arcText.radius
+			break
+		}
+	}
+
+	g.Expect(pkgLabelRadius).To(BeNumerically(">", maxDiscRadius),
+		"directory label should sit above the bubble edge, not on top of it",
+	)
+	g.Expect(pkgLabelRadius).To(BeNumerically(">", pkgNode.Radius),
+		"rendered arc should use the reserved label band outside the bubble",
+	)
 }

--- a/internal/bubbletree/render_test.go
+++ b/internal/bubbletree/render_test.go
@@ -272,14 +272,17 @@ func TestRenderBubbleToCanvas_DirectoryLabelsUseReservedBandOutsideBubble(t *tes
 	g.Expect(nodes.Children).To(HaveLen(3))
 
 	var pkgNode *bubbletree.BubbleNode
+
 	for i := range nodes.Children {
 		if nodes.Children[i].IsDirectory {
 			pkgNode = &nodes.Children[i]
+
 			break
 		}
 	}
 
 	g.Expect(pkgNode).NotTo(BeNil())
+
 	if pkgNode == nil {
 		return
 	}
@@ -294,9 +297,11 @@ func TestRenderBubbleToCanvas_DirectoryLabelsUseReservedBandOutsideBubble(t *tes
 	g.Expect(maxDiscRadius).To(BeNumerically("~", pkgNode.Radius-bubbletree.LabelReservation, 0.001))
 
 	var pkgLabelRadius float64
+
 	for _, arcText := range backend.arcTexts {
 		if arcText.text == "pkg" {
 			pkgLabelRadius = arcText.radius
+
 			break
 		}
 	}
@@ -306,5 +311,47 @@ func TestRenderBubbleToCanvas_DirectoryLabelsUseReservedBandOutsideBubble(t *tes
 	)
 	g.Expect(pkgLabelRadius).To(BeNumerically(">", pkgNode.Radius),
 		"rendered arc should use the reserved label band outside the bubble",
+	)
+}
+
+func TestRenderBubbleToCanvas_EmptyLabelledDirectoryKeepsVisibleBubble(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root := &model.Directory{
+		Name: "root",
+		Path: "root",
+		Dirs: []*model.Directory{{
+			Name: "a",
+			Path: "root/a",
+		}},
+	}
+	inks := bubbletree.BuildInks(root, filesystem.FileSize, palette.Temperature, "", "")
+	nodes := bubbletree.Layout(root, 800, 600, filesystem.FileSize, bubbletree.LabelFoldersOnly)
+	cv := bubbletree.RenderToCanvas(&nodes, root, 800, 600, inks)
+
+	backend := &captureBackend{}
+	g.Expect(cv.RenderTo(backend)).To(Succeed())
+
+	g.Expect(backend.discs).NotTo(BeEmpty())
+	g.Expect(backend.discs[0].radius).To(BeNumerically(">", 0),
+		"empty labelled directory should still render as a visible bubble",
+	)
+
+	var childLabelRadius float64
+
+	for _, arcText := range backend.arcTexts {
+		if arcText.text == "a" {
+			childLabelRadius = arcText.radius
+
+			break
+		}
+	}
+
+	g.Expect(childLabelRadius).To(BeNumerically(">", 0),
+		"empty labelled directory should still render its label",
+	)
+	g.Expect(childLabelRadius).To(BeNumerically(">", backend.discs[0].radius),
+		"empty labelled directory should reserve label space above its bubble",
 	)
 }

--- a/internal/canvas/model/backend.go
+++ b/internal/canvas/model/backend.go
@@ -44,3 +44,8 @@ const (
 // DefaultFontSize signals that the backend should use its built-in default
 // font size. Callers can set FontSize to this value instead of a bare 0.
 const DefaultFontSize float64 = 0
+
+// ArcTextInset is the fixed inset applied by canvas backends when drawing text
+// along a circle arc. Callers that need layout-aware arc geometry should use
+// the same value so reserved label space matches rendered output.
+const ArcTextInset float64 = 14.0

--- a/internal/canvas/raster/backend.go
+++ b/internal/canvas/raster/backend.go
@@ -250,7 +250,12 @@ func (r *rasterBackend) DrawArcText(
 
 		r.dc.Push()
 		r.dc.RotateAbout(angle+math.Pi/2.0, cx, cy)
-		r.dc.DrawStringAnchored(string(ch), cx, cy, 0.5, 0.5)
+		// gg's DrawStringAnchored places the baseline at cy + ay*h. Using
+		// ay=0.5 puts the baseline at the rim of the underlying circle so
+		// non-descender letters touch the rim. Use ay=0.25 to match the
+		// SVG backend's dominant-baseline="middle" behaviour, which lifts
+		// the baseline so descenders just graze the rim instead.
+		r.dc.DrawStringAnchored(string(ch), cx, cy, 0.5, 0.25)
 		r.dc.Pop()
 	}
 }

--- a/internal/canvas/raster/backend.go
+++ b/internal/canvas/raster/backend.go
@@ -252,7 +252,7 @@ func (r *rasterBackend) DrawArcText(
 	r.dc.SetFontFace(fontFaceForSize(fontSize))
 	r.dc.SetColor(nrgba(ink))
 
-	arcRadius := radius - 14.0
+	arcRadius := radius - model.ArcTextInset
 	if arcRadius <= 0 {
 		return
 	}

--- a/internal/canvas/svg/backend.go
+++ b/internal/canvas/svg/backend.go
@@ -189,7 +189,7 @@ func (s *svgBackend) DrawArcText(
 		fontSize = defaultFontSize
 	}
 
-	arcR := radius - 14.0
+	arcR := radius - model.ArcTextInset
 	if arcR <= 0 {
 		return
 	}
@@ -212,7 +212,7 @@ func (s *svgBackend) DrawArcText(
 
 	fmt.Fprintf(
 		&s.buf,
-		`<text fill="%s" font-size="%.1f" font-family="sans-serif">`+
+		`<text fill="%s" font-size="%.1f" font-family="sans-serif" dominant-baseline="middle">`+
 			`<textPath href="#%s" startOffset="50%%" text-anchor="middle">%s</textPath></text>`+"\n",
 		rgbaToCSS(ink), fontSize, pathID, html.EscapeString(text),
 	)

--- a/internal/canvas/svg/backend_test.go
+++ b/internal/canvas/svg/backend_test.go
@@ -240,6 +240,26 @@ func TestSVGBackend_DrawArcText_PathGoesOverTop(t *testing.T) {
 	g.Expect(content).To(ContainSubstring("0 0,1"))
 }
 
+func TestSVGBackend_DrawArcText_CentersGlyphsOnPath(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	b := New(400, 400)
+	blk := color.RGBA{A: 255}
+
+	b.DrawArcText(
+		model.Position{X: 200, Y: 200},
+		100, "hello", blk, 14.0,
+	)
+
+	out := filepath.Join(t.TempDir(), "arctext-centered.svg")
+	err := b.Finish(out)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	content := readFile(t, out)
+	g.Expect(content).To(ContainSubstring(`dominant-baseline="middle"`))
+}
+
 func TestSVGBackend_ImplementsBackendInterface(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)

--- a/internal/canvas/text_spec.go
+++ b/internal/canvas/text_spec.go
@@ -36,7 +36,7 @@ type ArcTextSpec struct {
 type ArcText struct {
 	Spec   *ArcTextSpec
 	X, Y   float64 // circle centre
-	Radius float64 // circle radius (label is inset from this)
+	Radius float64 // reference arc radius; backends apply their fixed inset from this value
 	Text   string
 }
 


### PR DESCRIPTION
Fixes #256

## Summary
- render directory labels in the reserved band above each bubble instead of on the bubble edge
- keep occupied radius separate from visible disc radius so child, empty, and root labels stay inside reserved space
- align raster/SVG arc text geometry and add regression coverage for reserved-band rendering and root fitting