### PR TITLE
Add treemap labels (#257)

### DIFF
--- a/cmd/codeviz/main.go
+++ b/cmd/codeviz/main.go
@@ -16,12 +16,12 @@ import (
 )
 
 type CLI struct {
-	Quiet   bool   `help:"Suppress all non-essential output; only warnings and errors are shown." short:"q" xor:"verbosity"` //nolint:revive // kong struct tags require long lines
+	Quiet   bool   `help:"Suppress all non-essential output; only warnings and errors are shown." short:"q" xor:"verbosity"` //nolint:revive,nolintlint // kong struct tags require long lines
 	Verbose bool   `help:"Show detailed progress during scanning and metric calculation." short:"v" xor:"verbosity"`
 	Debug   bool   `help:"Show per-directory scan progress (implies verbose output)." xor:"verbosity"`
 	Config  string `help:"Path to configuration file (.yaml, .yml, or .json)." name:"config" optional:""`
 
-	//nolint:revive // Long help text is more important than minimizing line length, and annotations can't be wrapped
+	//nolint:revive,nolintlint // Long help text is more important than minimizing line length, and annotations can't be wrapped
 	ExportConfig string `help:"Write effective configuration to file (.yaml, .yml, or .json)." name:"export-config" optional:""`
 	ExportData   string `help:"Write computed metrics to file (.json or .yaml/.yml)." name:"export-data" optional:""`
 

--- a/cmd/codeviz/main_test.go
+++ b/cmd/codeviz/main_test.go
@@ -321,6 +321,31 @@ func TestTreemapCmd_MissingSizeEverywhere_NilAfterMerge(t *testing.T) {
 	g.Expect(cfg.Treemap.Size).To(BeNil())
 }
 
+func TestTreemapCmd_Run_WritesFileLabelsIntoSVG(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "alpha.go")
+	g.Expect(os.WriteFile(filePath, []byte("package main\n\nfunc main() {}\n"), 0o600)).To(Succeed())
+
+	out := filepath.Join(dir, "treemap.svg")
+	cmd := &TreemapCmd{
+		TargetPath: dir,
+		Output:     out,
+		Size:       filesystem.FileLines,
+		Width:      320,
+		Height:     240,
+	}
+
+	flags := &Flags{Config: config.New()}
+	g.Expect(cmd.Run(flags)).To(Succeed())
+
+	data, err := os.ReadFile(out)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(string(data)).To(ContainSubstring("alpha.go"))
+}
+
 // validateConfig validates the merged config (single source of truth).
 
 func TestTreemapCmd_ValidateConfig_ConfigSuppliesFillAndPalette(t *testing.T) {

--- a/cmd/codeviz/treemap_cmd.go
+++ b/cmd/codeviz/treemap_cmd.go
@@ -126,6 +126,8 @@ func (c *TreemapCmd) Run(flags *Flags) error {
 		treemap.BuildLegendStage,
 		treemap.LayoutStage,
 		treemap.RenderStage,
+		treemap.LabelStage,
+		stages.ApplyCanvasBlockLabels[*treemap.State],
 		stages.WriteCanvas,
 		treemap.LogResult,
 	)

--- a/internal/canvas/block_label.go
+++ b/internal/canvas/block_label.go
@@ -26,22 +26,23 @@ func (c *Canvas) AddBlockLabel(layer Layer, label BlockLabel, format ImageFormat
 		return
 	}
 
-	fontSize, widths, lineHeight, totalHeight, ok := fitBlockLabel(lines, label.W, label.H)
+	layout, ok := fitBlockLabel(lines, label.W, label.H)
 	if !ok {
 		return
 	}
 
 	if format != FormatSVG {
 		switch {
-		case lineHeight <= omittedLineHeight:
+		case layout.lineHeight <= omittedLineHeight:
 			return
-		case lineHeight <= greekedLineHeight:
-			c.addGreekedBlockLabel(layer, label, widths, lineHeight, totalHeight)
+		case layout.lineHeight <= greekedLineHeight:
+			c.addGreekedBlockLabel(layer, label, layout.widths, layout.lineHeight, layout.totalHeight)
+
 			return
 		}
 	}
 
-	c.addTextBlockLabel(layer, label, lines, fontSize, lineHeight, totalHeight)
+	c.addTextBlockLabel(layer, label, lines, layout.fontSize, layout.lineHeight, layout.totalHeight)
 }
 
 func compactLabelLines(lines []string) []string {
@@ -55,54 +56,61 @@ func compactLabelLines(lines []string) []string {
 	return compact
 }
 
-func fitBlockLabel(lines []string, maxWidth, maxHeight float64) (
-	fontSize float64,
-	widths []float64,
-	lineHeight float64,
-	totalHeight float64,
-	ok bool,
-) {
+type fittedBlockLabel struct {
+	fontSize    float64
+	widths      []float64
+	lineHeight  float64
+	totalHeight float64
+}
+
+func fitBlockLabel(lines []string, maxWidth, maxHeight float64) (fittedBlockLabel, bool) {
 	upper := min(maxWidth, maxHeight/float64(len(lines)))
 	if upper <= 0 {
-		return 0, nil, 0, 0, false
+		return fittedBlockLabel{}, false
 	}
 
 	low := 0.0
 	high := upper
+	best := fittedBlockLabel{}
+
 	for range 14 {
 		mid := (low + high) / 2.0
 		if mid <= 0 {
 			break
 		}
 
-		candidateWidths, candidateLineHeight, candidateTotalHeight := measureBlockLabel(lines, mid)
-		if candidateTotalHeight <= maxHeight && slices.Max(candidateWidths) <= maxWidth {
+		candidate := measureBlockLabel(lines, mid)
+		if candidate.totalHeight <= maxHeight && slices.Max(candidate.widths) <= maxWidth {
 			low = mid
-			widths = candidateWidths
-			lineHeight = candidateLineHeight
-			totalHeight = candidateTotalHeight
+			candidate.fontSize = mid
+			best = candidate
 		} else {
 			high = mid
 		}
 	}
 
 	if low <= 0 {
-		return 0, nil, 0, 0, false
+		return fittedBlockLabel{}, false
 	}
 
-	return low, widths, lineHeight, totalHeight, true
+	return best, true
 }
 
-func measureBlockLabel(lines []string, fontSize float64) ([]float64, float64, float64) {
+func measureBlockLabel(lines []string, fontSize float64) fittedBlockLabel {
 	widths := make([]float64, len(lines))
 	lineHeight := 0.0
+
 	for i, line := range lines {
 		width, measuredLineHeight := textlayout.MeasureString(line, fontSize)
 		widths[i] = width
 		lineHeight = max(lineHeight, measuredLineHeight)
 	}
 
-	return widths, lineHeight, lineHeight * float64(len(lines))
+	return fittedBlockLabel{
+		widths:      widths,
+		lineHeight:  lineHeight,
+		totalHeight: lineHeight * float64(len(lines)),
+	}
 }
 
 func (c *Canvas) addTextBlockLabel(

--- a/internal/canvas/block_label.go
+++ b/internal/canvas/block_label.go
@@ -1,0 +1,156 @@
+package canvas
+
+import (
+	"image/color"
+	"slices"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/canvas/textlayout"
+)
+
+const (
+	greekedLineHeight = 5.0
+	omittedLineHeight = 2.0
+)
+
+// BlockLabel is a centered multi-line label constrained to a rectangular area.
+type BlockLabel struct {
+	X, Y, W, H float64
+	Lines      []string
+	Ink        color.RGBA
+}
+
+// AddBlockLabel adds a centered multi-line label sized to fit the given bounds.
+func (c *Canvas) AddBlockLabel(layer Layer, label BlockLabel, format ImageFormat) {
+	lines := compactLabelLines(label.Lines)
+	if len(lines) == 0 || label.W <= 0 || label.H <= 0 {
+		return
+	}
+
+	fontSize, widths, lineHeight, totalHeight, ok := fitBlockLabel(lines, label.W, label.H)
+	if !ok {
+		return
+	}
+
+	if format != FormatSVG {
+		switch {
+		case lineHeight <= omittedLineHeight:
+			return
+		case lineHeight <= greekedLineHeight:
+			c.addGreekedBlockLabel(layer, label, widths, lineHeight, totalHeight)
+			return
+		}
+	}
+
+	c.addTextBlockLabel(layer, label, lines, fontSize, lineHeight, totalHeight)
+}
+
+func compactLabelLines(lines []string) []string {
+	compact := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if line != "" {
+			compact = append(compact, line)
+		}
+	}
+
+	return compact
+}
+
+func fitBlockLabel(lines []string, maxWidth, maxHeight float64) (
+	fontSize float64,
+	widths []float64,
+	lineHeight float64,
+	totalHeight float64,
+	ok bool,
+) {
+	upper := min(maxWidth, maxHeight/float64(len(lines)))
+	if upper <= 0 {
+		return 0, nil, 0, 0, false
+	}
+
+	low := 0.0
+	high := upper
+	for range 14 {
+		mid := (low + high) / 2.0
+		if mid <= 0 {
+			break
+		}
+
+		candidateWidths, candidateLineHeight, candidateTotalHeight := measureBlockLabel(lines, mid)
+		if candidateTotalHeight <= maxHeight && slices.Max(candidateWidths) <= maxWidth {
+			low = mid
+			widths = candidateWidths
+			lineHeight = candidateLineHeight
+			totalHeight = candidateTotalHeight
+		} else {
+			high = mid
+		}
+	}
+
+	if low <= 0 {
+		return 0, nil, 0, 0, false
+	}
+
+	return low, widths, lineHeight, totalHeight, true
+}
+
+func measureBlockLabel(lines []string, fontSize float64) ([]float64, float64, float64) {
+	widths := make([]float64, len(lines))
+	lineHeight := 0.0
+	for i, line := range lines {
+		width, measuredLineHeight := textlayout.MeasureString(line, fontSize)
+		widths[i] = width
+		lineHeight = max(lineHeight, measuredLineHeight)
+	}
+
+	return widths, lineHeight, lineHeight * float64(len(lines))
+}
+
+func (c *Canvas) addTextBlockLabel(
+	layer Layer,
+	label BlockLabel,
+	lines []string,
+	fontSize, lineHeight, totalHeight float64,
+) {
+	spec := &TextSpec{
+		Ink:      FixedInk(label.Ink),
+		FontSize: fontSize,
+		Anchor:   AnchorMiddle,
+	}
+	centerX := label.X + label.W/2.0
+	top := label.Y + (label.H-totalHeight)/2.0
+
+	for i, line := range lines {
+		c.AddText(layer, Text{
+			Spec:    spec,
+			X:       centerX,
+			Y:       top + lineHeight*(float64(i)+0.5),
+			Content: line,
+		})
+	}
+}
+
+func (c *Canvas) addGreekedBlockLabel(
+	layer Layer,
+	label BlockLabel,
+	widths []float64,
+	lineHeight, totalHeight float64,
+) {
+	spec := &LineSpec{
+		Stroke:      FixedInk(label.Ink),
+		StrokeWidth: max(1.0, lineHeight/2.0),
+	}
+	centerX := label.X + label.W/2.0
+	top := label.Y + (label.H-totalHeight)/2.0
+
+	for i, width := range widths {
+		lineWidth := min(label.W, max(width, lineHeight*4.0))
+		y := top + lineHeight*(float64(i)+0.5)
+		c.AddLine(layer, Line{
+			Spec: spec,
+			X1:   centerX - lineWidth/2.0,
+			Y1:   y,
+			X2:   centerX + lineWidth/2.0,
+			Y2:   y,
+		})
+	}
+}

--- a/internal/canvas/block_label_test.go
+++ b/internal/canvas/block_label_test.go
@@ -1,0 +1,103 @@
+package canvas
+
+import (
+	"image/color"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestCanvas_AddBlockLabel_CentersMultilineText(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	c := NewCanvas(200, 120)
+	c.AddBlockLabel(LayerOverlay, BlockLabel{
+		X:     20,
+		Y:     30,
+		W:     160,
+		H:     60,
+		Lines: []string{"alpha.go", "128"},
+		Ink:   color.RGBA{A: 255},
+	}, FormatSVG)
+
+	mb := newMockBackend()
+	err := c.RenderTo(mb)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(mb.calls).To(HaveLen(2))
+	g.Expect(mb.calls[0].method).To(Equal("DrawText"))
+	g.Expect(mb.calls[1].method).To(Equal("DrawText"))
+	g.Expect(mb.calls[0].text).To(Equal("alpha.go"))
+	g.Expect(mb.calls[1].text).To(Equal("128"))
+	g.Expect(mb.calls[0].pos.X).To(BeNumerically("~", 100.0, 0.01))
+	g.Expect(mb.calls[1].pos.X).To(BeNumerically("~", 100.0, 0.01))
+	g.Expect((mb.calls[0].pos.Y + mb.calls[1].pos.Y) / 2).To(BeNumerically("~", 60.0, 0.01))
+	g.Expect(mb.calls[0].fontSize).To(BeNumerically(">", 0.0))
+	g.Expect(mb.calls[0].fontSize).To(Equal(mb.calls[1].fontSize))
+	g.Expect(mb.calls[0].anchor).To(Equal(AnchorMiddle))
+	g.Expect(mb.calls[1].anchor).To(Equal(AnchorMiddle))
+}
+
+func TestCanvas_AddBlockLabel_GreeksTinyRasterLabels(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	c := NewCanvas(40, 20)
+	c.AddBlockLabel(LayerOverlay, BlockLabel{
+		X:     5,
+		Y:     5,
+		W:     30,
+		H:     8,
+		Lines: []string{"a.go", "42"},
+		Ink:   color.RGBA{A: 255},
+	}, FormatPNG)
+
+	mb := newMockBackend()
+	err := c.RenderTo(mb)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(mb.calls).To(HaveLen(2))
+	g.Expect(mb.calls[0].method).To(Equal("DrawLine"))
+	g.Expect(mb.calls[1].method).To(Equal("DrawLine"))
+}
+
+func TestCanvas_AddBlockLabel_OmitsUnreadableRasterLabels(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	c := NewCanvas(20, 10)
+	c.AddBlockLabel(LayerOverlay, BlockLabel{
+		X:     2,
+		Y:     2,
+		W:     16,
+		H:     1.5,
+		Lines: []string{"a.go"},
+		Ink:   color.RGBA{A: 255},
+	}, FormatPNG)
+
+	mb := newMockBackend()
+	err := c.RenderTo(mb)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(mb.calls).To(BeEmpty())
+}
+
+func TestCanvas_AddBlockLabel_KeepsTinySVGLabelsVisible(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	c := NewCanvas(40, 20)
+	c.AddBlockLabel(LayerOverlay, BlockLabel{
+		X:     5,
+		Y:     5,
+		W:     30,
+		H:     8,
+		Lines: []string{"a.go", "42"},
+		Ink:   color.RGBA{A: 255},
+	}, FormatSVG)
+
+	mb := newMockBackend()
+	err := c.RenderTo(mb)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(mb.calls).To(HaveLen(2))
+	g.Expect(mb.calls[0].method).To(Equal("DrawText"))
+	g.Expect(mb.calls[1].method).To(Equal("DrawText"))
+}

--- a/internal/canvas/mock_backend_test.go
+++ b/internal/canvas/mock_backend_test.go
@@ -8,14 +8,18 @@ import (
 
 // drawCall records a single drawing operation dispatched to the mock backend.
 type drawCall struct {
-	method    string
-	pos       Position
-	size      Size
-	fill      color.RGBA
-	border    color.RGBA
-	rawFill   model.Fill
-	rawBorder model.Fill
-	text      string
+	method      string
+	pos         Position
+	size        Size
+	fill        color.RGBA
+	border      color.RGBA
+	rawFill     model.Fill
+	rawBorder   model.Fill
+	text        string
+	fontSize    float64
+	anchor      TextAnchor
+	rotation    float64
+	strokeWidth float64
 }
 
 // mockBackend records all drawing calls for test assertions.
@@ -52,10 +56,12 @@ func (m *mockBackend) DrawDisc(center Position, _ float64, fill, border model.Fi
 	})
 }
 
-func (m *mockBackend) DrawLine(from, _ Position, _ color.RGBA, _ float64) {
+func (m *mockBackend) DrawLine(from, _ Position, stroke color.RGBA, strokeWidth float64) {
 	m.calls = append(m.calls, drawCall{
-		method: "DrawLine",
-		pos:    from,
+		method:      "DrawLine",
+		pos:         from,
+		fill:        stroke,
+		strokeWidth: strokeWidth,
 	})
 }
 
@@ -66,13 +72,16 @@ func (m *mockBackend) DrawPath(_ []Position, _ color.RGBA, _ float64) {
 }
 
 func (m *mockBackend) DrawText(
-	pos Position, text string, ink color.RGBA, _ float64, _ TextAnchor, _ float64,
+	pos Position, text string, ink color.RGBA, fontSize float64, anchor TextAnchor, rotation float64,
 ) {
 	m.calls = append(m.calls, drawCall{
-		method: "DrawText",
-		pos:    pos,
-		text:   text,
-		fill:   ink,
+		method:   "DrawText",
+		pos:      pos,
+		text:     text,
+		fill:     ink,
+		fontSize: fontSize,
+		anchor:   anchor,
+		rotation: rotation,
 	})
 }
 

--- a/internal/canvas/raster/backend.go
+++ b/internal/canvas/raster/backend.go
@@ -195,7 +195,12 @@ func (r *rasterBackend) DrawText(
 		fontSize = defaultFontSize
 	}
 
-	r.dc.SetFontFace(textlayout.FontFace(fontSize))
+	face := textlayout.FontFace(fontSize)
+	if closer, ok := face.(interface{ Close() error }); ok {
+		defer func() { _ = closer.Close() }()
+	}
+
+	r.dc.SetFontFace(face)
 	r.dc.SetColor(nrgba(ink))
 
 	ax := anchorX(anchor)

--- a/internal/canvas/raster/backend.go
+++ b/internal/canvas/raster/backend.go
@@ -12,12 +12,10 @@ import (
 	"strings"
 
 	"github.com/fogleman/gg"
-	"github.com/golang/freetype/truetype"
 	"github.com/rotisserie/eris"
-	"golang.org/x/image/font"
-	"golang.org/x/image/font/gofont/goregular"
 
 	"github.com/theunrepentantgeek/code-visualizer/internal/canvas/model"
+	"github.com/theunrepentantgeek/code-visualizer/internal/canvas/textlayout"
 )
 
 const jpegQuality = 95
@@ -25,27 +23,6 @@ const jpegQuality = 95
 // defaultFontSize is the font size used when callers pass fontSize <= 0,
 // indicating "use the backend's default".
 const defaultFontSize = 12.0
-
-// goFont is the parsed Go Regular TrueType font, used to create
-// font faces at arbitrary point sizes.
-//
-//nolint:gochecknoglobals // parsed once, read-only after init
-var goFont *truetype.Font
-
-func init() {
-	var err error
-
-	goFont, err = truetype.Parse(goregular.TTF)
-	if err != nil {
-		panic("raster: failed to parse Go Regular font: " + err.Error())
-	}
-}
-
-// fontFaceForSize returns a font.Face for the Go Regular font at the given
-// point size.
-func fontFaceForSize(points float64) font.Face {
-	return truetype.NewFace(goFont, &truetype.Options{Size: points})
-}
 
 type rasterBackend struct {
 	dc *gg.Context
@@ -218,7 +195,7 @@ func (r *rasterBackend) DrawText(
 		fontSize = defaultFontSize
 	}
 
-	r.dc.SetFontFace(fontFaceForSize(fontSize))
+	r.dc.SetFontFace(textlayout.FontFace(fontSize))
 	r.dc.SetColor(nrgba(ink))
 
 	ax := anchorX(anchor)
@@ -249,7 +226,7 @@ func (r *rasterBackend) DrawArcText(
 		fontSize = defaultFontSize
 	}
 
-	r.dc.SetFontFace(fontFaceForSize(fontSize))
+	r.dc.SetFontFace(textlayout.FontFace(fontSize))
 	r.dc.SetColor(nrgba(ink))
 
 	arcRadius := radius - 14.0

--- a/internal/canvas/textlayout/textlayout.go
+++ b/internal/canvas/textlayout/textlayout.go
@@ -1,0 +1,39 @@
+package textlayout
+
+import (
+	"github.com/golang/freetype/truetype"
+	"golang.org/x/image/font"
+	"golang.org/x/image/font/gofont/goregular"
+)
+
+//nolint:gochecknoglobals // parsed once, read-only after init
+var goFont = mustParseGoFont()
+
+func mustParseGoFont() *truetype.Font {
+	parsed, err := truetype.Parse(goregular.TTF)
+	if err != nil {
+		panic("textlayout: failed to parse Go Regular font: " + err.Error())
+	}
+
+	return parsed
+}
+
+// FontFace returns a Go Regular font face for the requested point size.
+func FontFace(points float64) font.Face {
+	return truetype.NewFace(goFont, &truetype.Options{Size: points})
+}
+
+// MeasureString returns the rendered width and line height for text at the given size.
+func MeasureString(s string, points float64) (width, height float64) {
+	face := FontFace(points)
+	defer func() {
+		if closer, ok := face.(interface{ Close() error }); ok {
+			_ = closer.Close()
+		}
+	}()
+
+	drawer := &font.Drawer{Face: face}
+	advance := drawer.MeasureString(s)
+
+	return float64(advance >> 6), float64(face.Metrics().Height >> 6)
+}

--- a/internal/canvas/textlayout/textlayout_test.go
+++ b/internal/canvas/textlayout/textlayout_test.go
@@ -1,0 +1,26 @@
+package textlayout
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestMeasureString_ReturnsPositiveDimensionsForNonEmptyText(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	width, height := MeasureString("hello", 12)
+	g.Expect(width).To(BeNumerically(">", 0.0))
+	g.Expect(height).To(BeNumerically(">", 0.0))
+}
+
+func TestMeasureString_GrowsWithFontSize(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	smallWidth, smallHeight := MeasureString("hello", 10)
+	largeWidth, largeHeight := MeasureString("hello", 20)
+	g.Expect(largeWidth).To(BeNumerically(">", smallWidth))
+	g.Expect(largeHeight).To(BeNumerically(">", smallHeight))
+}

--- a/internal/stages/labels.go
+++ b/internal/stages/labels.go
@@ -1,0 +1,36 @@
+package stages
+
+import (
+	"github.com/rotisserie/eris"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/canvas"
+	"github.com/theunrepentantgeek/code-visualizer/internal/pipeline"
+)
+
+// CanvasLabelledState extends VizState with interior labels to add after the
+// visualization canvas has been populated with its base shapes.
+type CanvasLabelledState interface {
+	VizState
+	CanvasLabels() []canvas.BlockLabel
+}
+
+// ApplyCanvasBlockLabels fits and adds the state's block labels to Common().Canvas.
+func ApplyCanvasBlockLabels[S CanvasLabelledState](s S) error {
+	c := s.Common()
+	if c.Canvas == nil {
+		return nil
+	}
+
+	format, err := canvas.FormatFromPath(c.Output)
+	if err != nil {
+		return eris.Wrap(err, "resolve canvas label format")
+	}
+
+	for _, label := range s.CanvasLabels() {
+		c.Canvas.AddBlockLabel(canvas.LayerOverlay, label, format)
+	}
+
+	return nil
+}
+
+var _ pipeline.Stage[CanvasLabelledState] = ApplyCanvasBlockLabels[CanvasLabelledState]

--- a/internal/stages/labels_test.go
+++ b/internal/stages/labels_test.go
@@ -1,0 +1,51 @@
+package stages
+
+import (
+	"image/color"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/canvas"
+)
+
+type fakeLabelState struct {
+	CommonState
+	labels []canvas.BlockLabel
+}
+
+func (s *fakeLabelState) Common() *CommonState { return &s.CommonState }
+
+func (s *fakeLabelState) CanvasLabels() []canvas.BlockLabel { return s.labels }
+
+func TestApplyCanvasBlockLabels_AddsLabelsToCanvas(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	out := filepath.Join(t.TempDir(), "labels.svg")
+	state := &fakeLabelState{
+		CommonState: CommonState{
+			Output: out,
+			Canvas: canvas.NewCanvas(120, 80),
+		},
+		labels: []canvas.BlockLabel{{
+			X:     10,
+			Y:     10,
+			W:     100,
+			H:     40,
+			Lines: []string{"hello", "42"},
+			Ink:   color.RGBA{A: 255},
+		}},
+	}
+
+	err := ApplyCanvasBlockLabels[*fakeLabelState](state)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(state.Canvas.Render(out)).To(Succeed())
+
+	data, err := os.ReadFile(out)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(string(data)).To(ContainSubstring("hello"))
+	g.Expect(string(data)).To(ContainSubstring("42"))
+}

--- a/internal/treemap/labels.go
+++ b/internal/treemap/labels.go
@@ -24,36 +24,63 @@ func buildBlockLabels(
 	fillInk canvas.Ink,
 	metrics LabelMetrics,
 ) []canvas.BlockLabel {
-	if dir == nil {
-		return nil
-	}
-
 	labels := make([]canvas.BlockLabel, 0)
-	if !rect.IsDirectory {
+	if dir == nil || !rect.IsDirectory {
 		return labels
 	}
 
 	fileIdx := 0
 	dirIdx := 0
+
 	for i := range rect.Children {
 		child := rect.Children[i]
-		if child.IsDirectory && dirIdx < len(dir.Dirs) {
-			labels = append(labels, buildBlockLabels(child, dir.Dirs[dirIdx], fillInk, metrics)...)
-			dirIdx++
+		if child.IsDirectory {
+			labels, dirIdx = appendDirectoryLabels(labels, child, dir, dirIdx, fillInk, metrics)
+
 			continue
 		}
 
-		if child.IsDirectory || fileIdx >= len(dir.Files) {
-			continue
-		}
-
-		if label, ok := buildFileLabel(child, dir.Files[fileIdx], fillInk, metrics); ok {
-			labels = append(labels, label)
-		}
-		fileIdx++
+		labels, fileIdx = appendFileLabels(labels, child, dir, fileIdx, fillInk, metrics)
 	}
 
 	return labels
+}
+
+func appendDirectoryLabels(
+	labels []canvas.BlockLabel,
+	child TreemapRectangle,
+	dir *model.Directory,
+	dirIdx int,
+	fillInk canvas.Ink,
+	metrics LabelMetrics,
+) ([]canvas.BlockLabel, int) {
+	if dirIdx >= len(dir.Dirs) {
+		return labels, dirIdx
+	}
+
+	labels = append(labels, buildBlockLabels(child, dir.Dirs[dirIdx], fillInk, metrics)...)
+
+	return labels, dirIdx + 1
+}
+
+func appendFileLabels(
+	labels []canvas.BlockLabel,
+	child TreemapRectangle,
+	dir *model.Directory,
+	fileIdx int,
+	fillInk canvas.Ink,
+	metrics LabelMetrics,
+) ([]canvas.BlockLabel, int) {
+	if fileIdx >= len(dir.Files) {
+		return labels, fileIdx
+	}
+
+	file := dir.Files[fileIdx]
+	if label, ok := buildFileLabel(child, file, fillInk, metrics); ok {
+		labels = append(labels, label)
+	}
+
+	return labels, fileIdx + 1
 }
 
 func buildFileLabel(
@@ -66,46 +93,55 @@ func buildFileLabel(
 		return canvas.BlockLabel{}, false
 	}
 
-	x, y, w, h, ok := insetLabelBounds(rect, blockLabelPadding)
+	bounds, ok := insetLabelBounds(rect, blockLabelPadding)
 	if !ok {
 		return canvas.BlockLabel{}, false
 	}
 
 	lines := []string{rect.Label}
-	if line, ok := formatMetricValue(file, metrics.Size); ok {
-		lines = append(lines, line)
-	}
-	if metrics.Fill != "" {
-		if line, ok := formatMetricValue(file, metrics.Fill); ok {
-			lines = append(lines, line)
-		}
-	}
-	if metrics.Border != "" {
-		if line, ok := formatMetricValue(file, metrics.Border); ok {
-			lines = append(lines, line)
-		}
-	}
+	lines = appendMetricLine(lines, file, metrics.Size)
+	lines = appendMetricLine(lines, file, metrics.Fill)
+	lines = appendMetricLine(lines, file, metrics.Border)
 
 	fillColour := fillInk.Dip(pkginks.MetricValueForFile(file, fillInk))
 
 	return canvas.BlockLabel{
-		X:     x,
-		Y:     y,
-		W:     w,
-		H:     h,
+		X:     bounds.x,
+		Y:     bounds.y,
+		W:     bounds.w,
+		H:     bounds.h,
 		Lines: lines,
 		Ink:   canvas.TextColourFor(fillColour),
 	}, true
 }
 
-func insetLabelBounds(rect TreemapRectangle, padding float64) (x, y, w, h float64, ok bool) {
-	w = rect.W - 2*padding
-	h = rect.H - 2*padding
-	if w <= 0 || h <= 0 {
-		return 0, 0, 0, 0, false
+type labelBounds struct {
+	x float64
+	y float64
+	w float64
+	h float64
+}
+
+func insetLabelBounds(rect TreemapRectangle, padding float64) (labelBounds, bool) {
+	bounds := labelBounds{
+		x: rect.X + padding,
+		y: rect.Y + padding,
+		w: rect.W - 2*padding,
+		h: rect.H - 2*padding,
+	}
+	if bounds.w <= 0 || bounds.h <= 0 {
+		return labelBounds{}, false
 	}
 
-	return rect.X + padding, rect.Y + padding, w, h, true
+	return bounds, true
+}
+
+func appendMetricLine(lines []string, file *model.File, name metric.Name) []string {
+	if line, ok := formatMetricValue(file, name); ok {
+		return append(lines, line)
+	}
+
+	return lines
 }
 
 func formatMetricValue(file *model.File, name metric.Name) (string, bool) {
@@ -116,9 +152,11 @@ func formatMetricValue(file *model.File, name metric.Name) (string, bool) {
 	if value, ok := file.Quantity(name); ok {
 		return strconv.FormatInt(value, 10), true
 	}
+
 	if value, ok := file.Measure(name); ok {
 		return strconv.FormatFloat(value, 'f', -1, 64), true
 	}
+
 	if value, ok := file.Classification(name); ok {
 		return value, true
 	}

--- a/internal/treemap/labels.go
+++ b/internal/treemap/labels.go
@@ -1,0 +1,127 @@
+package treemap
+
+import (
+	"strconv"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/canvas"
+	pkginks "github.com/theunrepentantgeek/code-visualizer/internal/inks"
+	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
+	"github.com/theunrepentantgeek/code-visualizer/internal/model"
+)
+
+const blockLabelPadding = 4.0
+
+// LabelMetrics identifies which metric values should appear in each file label.
+type LabelMetrics struct {
+	Size   metric.Name
+	Fill   metric.Name
+	Border metric.Name
+}
+
+func buildBlockLabels(
+	rect TreemapRectangle,
+	dir *model.Directory,
+	fillInk canvas.Ink,
+	metrics LabelMetrics,
+) []canvas.BlockLabel {
+	if dir == nil {
+		return nil
+	}
+
+	labels := make([]canvas.BlockLabel, 0)
+	if !rect.IsDirectory {
+		return labels
+	}
+
+	fileIdx := 0
+	dirIdx := 0
+	for i := range rect.Children {
+		child := rect.Children[i]
+		if child.IsDirectory && dirIdx < len(dir.Dirs) {
+			labels = append(labels, buildBlockLabels(child, dir.Dirs[dirIdx], fillInk, metrics)...)
+			dirIdx++
+			continue
+		}
+
+		if child.IsDirectory || fileIdx >= len(dir.Files) {
+			continue
+		}
+
+		if label, ok := buildFileLabel(child, dir.Files[fileIdx], fillInk, metrics); ok {
+			labels = append(labels, label)
+		}
+		fileIdx++
+	}
+
+	return labels
+}
+
+func buildFileLabel(
+	rect TreemapRectangle,
+	file *model.File,
+	fillInk canvas.Ink,
+	metrics LabelMetrics,
+) (canvas.BlockLabel, bool) {
+	if file == nil {
+		return canvas.BlockLabel{}, false
+	}
+
+	x, y, w, h, ok := insetLabelBounds(rect, blockLabelPadding)
+	if !ok {
+		return canvas.BlockLabel{}, false
+	}
+
+	lines := []string{rect.Label}
+	if line, ok := formatMetricValue(file, metrics.Size); ok {
+		lines = append(lines, line)
+	}
+	if metrics.Fill != "" {
+		if line, ok := formatMetricValue(file, metrics.Fill); ok {
+			lines = append(lines, line)
+		}
+	}
+	if metrics.Border != "" {
+		if line, ok := formatMetricValue(file, metrics.Border); ok {
+			lines = append(lines, line)
+		}
+	}
+
+	fillColour := fillInk.Dip(pkginks.MetricValueForFile(file, fillInk))
+
+	return canvas.BlockLabel{
+		X:     x,
+		Y:     y,
+		W:     w,
+		H:     h,
+		Lines: lines,
+		Ink:   canvas.TextColourFor(fillColour),
+	}, true
+}
+
+func insetLabelBounds(rect TreemapRectangle, padding float64) (x, y, w, h float64, ok bool) {
+	w = rect.W - 2*padding
+	h = rect.H - 2*padding
+	if w <= 0 || h <= 0 {
+		return 0, 0, 0, 0, false
+	}
+
+	return rect.X + padding, rect.Y + padding, w, h, true
+}
+
+func formatMetricValue(file *model.File, name metric.Name) (string, bool) {
+	if name == "" || file == nil {
+		return "", false
+	}
+
+	if value, ok := file.Quantity(name); ok {
+		return strconv.FormatInt(value, 10), true
+	}
+	if value, ok := file.Measure(name); ok {
+		return strconv.FormatFloat(value, 'f', -1, 64), true
+	}
+	if value, ok := file.Classification(name); ok {
+		return value, true
+	}
+
+	return "", false
+}

--- a/internal/treemap/labels_test.go
+++ b/internal/treemap/labels_test.go
@@ -1,0 +1,69 @@
+package treemap
+
+import (
+	"image/color"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/canvas"
+	"github.com/theunrepentantgeek/code-visualizer/internal/model"
+	"github.com/theunrepentantgeek/code-visualizer/internal/provider/filesystem"
+)
+
+func TestBuildBlockLabels_IncludesOnlyConfiguredMetricLines(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	file := &model.File{Name: "alpha.go", Extension: "go"}
+	file.SetQuantity(filesystem.FileSize, 128)
+	file.SetClassification(filesystem.FileType, "go")
+	file.SetQuantity(filesystem.FileLines, 12)
+
+	root := &model.Directory{Name: "root", Files: []*model.File{file}}
+	rects := TreemapRectangle{
+		Label:       "root",
+		IsDirectory: true,
+		Children: []TreemapRectangle{{
+			X:     10,
+			Y:     20,
+			W:     120,
+			H:     60,
+			Label: "alpha.go",
+		}},
+	}
+
+	labels := buildBlockLabels(rects, root, canvas.FixedInk(color.RGBA{R: 255, G: 255, B: 255, A: 255}), LabelMetrics{
+		Size:   filesystem.FileSize,
+		Fill:   filesystem.FileType,
+		Border: filesystem.FileLines,
+	})
+	g.Expect(labels).To(HaveLen(1))
+	g.Expect(labels[0].Lines).To(Equal([]string{"alpha.go", "128", "go", "12"}))
+}
+
+func TestBuildBlockLabels_OmitsUnconfiguredMetrics(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	file := &model.File{Name: "beta.go", Extension: "go"}
+	file.SetQuantity(filesystem.FileSize, 64)
+	file.SetClassification(filesystem.FileType, "go")
+
+	root := &model.Directory{Name: "root", Files: []*model.File{file}}
+	rects := TreemapRectangle{
+		Label:       "root",
+		IsDirectory: true,
+		Children: []TreemapRectangle{{
+			X:     0,
+			Y:     0,
+			W:     100,
+			H:     40,
+			Label: "beta.go",
+		}},
+	}
+
+	labels := buildBlockLabels(rects, root, canvas.FixedInk(color.RGBA{A: 255}), LabelMetrics{Size: filesystem.FileSize})
+	g.Expect(labels).To(HaveLen(1))
+	g.Expect(labels[0].Lines).To(Equal([]string{"beta.go", "64"}))
+}

--- a/internal/treemap/labels_test.go
+++ b/internal/treemap/labels_test.go
@@ -39,6 +39,11 @@ func TestBuildBlockLabels_IncludesOnlyConfiguredMetricLines(t *testing.T) {
 		Border: filesystem.FileLines,
 	})
 	g.Expect(labels).To(HaveLen(1))
+
+	if len(labels) == 0 {
+		return
+	}
+
 	g.Expect(labels[0].Lines).To(Equal([]string{"alpha.go", "128", "go", "12"}))
 }
 
@@ -63,7 +68,17 @@ func TestBuildBlockLabels_OmitsUnconfiguredMetrics(t *testing.T) {
 		}},
 	}
 
-	labels := buildBlockLabels(rects, root, canvas.FixedInk(color.RGBA{A: 255}), LabelMetrics{Size: filesystem.FileSize})
+	labels := buildBlockLabels(
+		rects,
+		root,
+		canvas.FixedInk(color.RGBA{A: 255}),
+		LabelMetrics{Size: filesystem.FileSize},
+	)
 	g.Expect(labels).To(HaveLen(1))
+
+	if len(labels) == 0 {
+		return
+	}
+
 	g.Expect(labels[0].Lines).To(Equal([]string{"beta.go", "64"}))
 }

--- a/internal/treemap/render.go
+++ b/internal/treemap/render.go
@@ -165,23 +165,6 @@ func addFileRectForFile(
 		Border: borderMV,
 		Focus:  focus,
 	})
-
-	if rect.Label != "" && rect.W >= 40 && rect.H >= 16 {
-		fillColour := inks.Fill.Dip(fillMV)
-		labelColour := canvas.TextColourFor(fillColour)
-
-		labelSpec := &canvas.TextSpec{
-			Ink:      canvas.FixedInk(labelColour),
-			FontSize: 0,
-			Anchor:   canvas.AnchorMiddle,
-		}
-		cv.AddText(canvas.LayerOverlay, canvas.Text{
-			Spec:    labelSpec,
-			X:       rect.X + rect.W/2,
-			Y:       rect.Y + rect.H/2,
-			Content: rect.Label,
-		})
-	}
 }
 
 func computeFocus(fileRect, dirRect TreemapRectangle, weightFraction float64) canvasmodel.Point {

--- a/internal/treemap/stages.go
+++ b/internal/treemap/stages.go
@@ -102,6 +102,17 @@ func RenderStage(s *State) error {
 	return nil
 }
 
+// LabelStage builds the reusable block labels for treemap file rectangles.
+func LabelStage(s *State) error {
+	s.BlockLabels = buildBlockLabels(s.Root, s.Common().Root, s.Inks.Fill, LabelMetrics{
+		Size:   s.Size,
+		Fill:   s.Config.Fill.MetricName(),
+		Border: s.Config.Border.MetricName(),
+	})
+
+	return nil
+}
+
 // LogResult logs the final summary.
 func LogResult(s *State) error {
 	c := s.Common()
@@ -131,5 +142,6 @@ var (
 	_ pipeline.Stage[*State] = BuildLegendStage
 	_ pipeline.Stage[*State] = LayoutStage
 	_ pipeline.Stage[*State] = RenderStage
+	_ pipeline.Stage[*State] = LabelStage
 	_ pipeline.Stage[*State] = LogResult
 )

--- a/internal/treemap/state.go
+++ b/internal/treemap/state.go
@@ -25,10 +25,14 @@ type State struct {
 	Inks          Inks
 	Root          TreemapRectangle
 	LegendConfig  *canvas.LegendConfig
+	BlockLabels   []canvas.BlockLabel
 }
 
 // Common exposes the embedded CommonState so shared stages can mutate it.
 func (s *State) Common() *stages.CommonState { return &s.CommonState }
+
+// CanvasLabels exposes the block labels staged for later canvas overlay.
+func (s *State) CanvasLabels() []canvas.BlockLabel { return s.BlockLabels }
 
 // IncludeBinary lets State satisfy stages.BinaryFilterToggler.
 func (s *State) IncludeBinary() bool { return s.IncludeBinaryFiles }


### PR DESCRIPTION
## Summary
- add reusable canvas block label primitives and a shared stage for applying centered multiline labels
- build treemap file labels from filename plus configured size/fill/border metrics, omitting missing lines
- wire treemap rendering to apply fitted labels with raster greek/omit behavior and SVG text rendering

## Test Plan
- task ci

Fixes #257