### PR TITLE
refactor(scan): decompose scanner.go into separate collaborators (#326)

### DIFF
--- a/internal/scan/collaborators_test.go
+++ b/internal/scan/collaborators_test.go
@@ -7,9 +7,19 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"github.com/theunrepentantgeek/code-visualizer/internal/filter"
 	"github.com/theunrepentantgeek/code-visualizer/internal/model"
 	"github.com/theunrepentantgeek/code-visualizer/internal/provider/filesystem"
 )
+
+type progressCall struct {
+	path      string
+	fileCount int
+}
+
+type recordingProgress struct {
+	calls []progressCall
+}
 
 type stubDirEntry struct {
 	name string
@@ -46,6 +56,25 @@ func mustStatFile(t *testing.T, path string) os.FileInfo {
 	return info
 }
 
+func (r *recordingProgress) OnDirectoryScanned(path string, fileCount int) {
+	r.calls = append(r.calls, progressCall{path: path, fileCount: fileCount})
+}
+
+func TestFilterPolicyIncludesUsesRelativePath(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root, err := filepath.Abs(filepath.Join("testdata", "with-dotfiles"))
+	g.Expect(err).NotTo(HaveOccurred())
+
+	policy := newFilterPolicy(root, []filter.Rule{{Pattern: ".*", Mode: filter.Exclude}})
+
+	included, relPath, err := policy.includes(filepath.Join(root, ".hidden"))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(relPath).To(Equal(".hidden"))
+	g.Expect(included).To(BeFalse())
+}
+
 func TestNodeBuilderProcessFileAddsMetadata(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
@@ -53,6 +82,7 @@ func TestNodeBuilderProcessFileAddsMetadata(t *testing.T) {
 	dir := filepath.Join("testdata", "flat")
 	entry := stubDirEntry{name: "small.txt"}
 	entryPath := filepath.Join(dir, entry.Name())
+
 	info := mustStatFile(t, entryPath)
 
 	node := &model.Directory{Path: dir, Name: "flat"}
@@ -78,4 +108,23 @@ func TestNodeBuilderProcessFileAddsMetadata(t *testing.T) {
 	fileType, ok := file.Classification(filesystem.FileType)
 	g.Expect(ok).To(BeTrue())
 	g.Expect(fileType).To(Equal("txt"))
+}
+
+func TestWalkerScanDirReportsProgressPerDirectory(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	root, err := filepath.Abs(filepath.Join("testdata", "nested"))
+	g.Expect(err).NotTo(HaveOccurred())
+
+	progress := &recordingProgress{}
+	walker := newWalker(root, nil, progress)
+
+	_, err = walker.scanDir(root)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(progress.calls).To(ConsistOf(
+		progressCall{path: root, fileCount: 1},
+		progressCall{path: filepath.Join(root, "sub"), fileCount: 1},
+		progressCall{path: filepath.Join(root, "sub", "deep"), fileCount: 1},
+	))
 }

--- a/internal/scan/collaborators_test.go
+++ b/internal/scan/collaborators_test.go
@@ -1,0 +1,81 @@
+package scan
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/model"
+	"github.com/theunrepentantgeek/code-visualizer/internal/provider/filesystem"
+)
+
+type stubDirEntry struct {
+	name string
+}
+
+func (e stubDirEntry) Name() string {
+	return e.name
+}
+
+func (stubDirEntry) IsDir() bool {
+	return false
+}
+
+func (stubDirEntry) Type() os.FileMode {
+	return 0
+}
+
+func (stubDirEntry) Info() (os.FileInfo, error) {
+	return nil, os.ErrInvalid
+}
+
+func mustStatFile(t *testing.T, path string) os.FileInfo {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+
+	if info == nil {
+		t.Fatalf("stat %s returned nil info", path)
+	}
+
+	return info
+}
+
+func TestNodeBuilderProcessFileAddsMetadata(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir := filepath.Join("testdata", "flat")
+	entry := stubDirEntry{name: "small.txt"}
+	entryPath := filepath.Join(dir, entry.Name())
+	info := mustStatFile(t, entryPath)
+
+	node := &model.Directory{Path: dir, Name: "flat"}
+	builder := newNodeBuilder(func(path string) (bool, error) {
+		g.Expect(path).To(Equal(entryPath))
+
+		return true, nil
+	})
+
+	builder.processFile(node, entry, info, entryPath)
+
+	g.Expect(node.Files).To(HaveLen(1))
+	file := node.Files[0]
+	g.Expect(file.Name).To(Equal("small.txt"))
+	g.Expect(file.Path).To(Equal(entryPath))
+	g.Expect(file.Extension).To(Equal("txt"))
+	g.Expect(file.IsBinary).To(BeTrue())
+
+	size, ok := file.Quantity(filesystem.FileSize)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(size).To(Equal(int64(5)))
+
+	fileType, ok := file.Classification(filesystem.FileType)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(fileType).To(Equal("txt"))
+}

--- a/internal/scan/filter_policy.go
+++ b/internal/scan/filter_policy.go
@@ -1,0 +1,30 @@
+package scan
+
+import (
+	"path/filepath"
+
+	"github.com/rotisserie/eris"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/filter"
+)
+
+type filterPolicy struct {
+	rootPath string
+	rules    []filter.Rule
+}
+
+func newFilterPolicy(rootPath string, rules []filter.Rule) filterPolicy {
+	return filterPolicy{
+		rootPath: rootPath,
+		rules:    rules,
+	}
+}
+
+func (p filterPolicy) includes(path string) (bool, string, error) {
+	relPath, err := filepath.Rel(p.rootPath, path)
+	if err != nil {
+		return false, "", eris.Wrapf(err, "failed to compute relative path for %s", path)
+	}
+
+	return filter.IsIncluded(relPath, p.rules), relPath, nil
+}

--- a/internal/scan/node_builder.go
+++ b/internal/scan/node_builder.go
@@ -1,0 +1,90 @@
+package scan
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/model"
+	"github.com/theunrepentantgeek/code-visualizer/internal/provider/filesystem"
+)
+
+type binaryProbe func(path string) (bool, error)
+
+type nodeBuilder struct {
+	probe binaryProbe
+}
+
+func newNodeBuilder(probe binaryProbe) nodeBuilder {
+	if probe == nil {
+		probe = IsBinaryFile
+	}
+
+	return nodeBuilder{probe: probe}
+}
+
+func (b nodeBuilder) processFile(node *model.Directory, entry os.DirEntry, info os.FileInfo, entryPath string) {
+	ext := strings.TrimPrefix(filepath.Ext(entry.Name()), ".")
+
+	fileType := ext
+	if fileType == "" {
+		fileType = "no-extension"
+	}
+
+	binary, err := b.probe(entryPath)
+	if err != nil {
+		slog.Warn("binary probe failed, assuming text", "path", entryPath, "error", err)
+	}
+
+	file := &model.File{
+		Path:      entryPath,
+		Name:      entry.Name(),
+		Extension: ext,
+		IsBinary:  binary,
+	}
+
+	file.SetQuantity(filesystem.FileSize, info.Size())
+	file.SetClassification(filesystem.FileType, fileType)
+
+	node.Files = append(node.Files, file)
+}
+
+func processFile(node *model.Directory, entry os.DirEntry, info os.FileInfo, entryPath string) {
+	newNodeBuilder(IsBinaryFile).processFile(node, entry, info, entryPath)
+}
+
+func hasFiles(node *model.Directory) bool {
+	if len(node.Files) > 0 {
+		return true
+	}
+
+	return slices.ContainsFunc(node.Dirs, hasFiles)
+}
+
+func FilterBinaryFiles(node *model.Directory) *model.Directory {
+	result := &model.Directory{
+		Path: node.Path,
+		Name: node.Name,
+	}
+
+	for _, file := range node.Files {
+		if file.IsBinary {
+			slog.Debug("excluding binary file", "path", file.Path)
+
+			continue
+		}
+
+		result.Files = append(result.Files, file)
+	}
+
+	for _, dir := range node.Dirs {
+		filtered := FilterBinaryFiles(dir)
+		if len(filtered.Files) > 0 || len(filtered.Dirs) > 0 {
+			result.Dirs = append(result.Dirs, filtered)
+		}
+	}
+
+	return result
+}

--- a/internal/scan/node_builder.go
+++ b/internal/scan/node_builder.go
@@ -51,10 +51,6 @@ func (b nodeBuilder) processFile(node *model.Directory, entry os.DirEntry, info 
 	node.Files = append(node.Files, file)
 }
 
-func processFile(node *model.Directory, entry os.DirEntry, info os.FileInfo, entryPath string) {
-	newNodeBuilder(IsBinaryFile).processFile(node, entry, info, entryPath)
-}
-
 func hasFiles(node *model.Directory) bool {
 	if len(node.Files) > 0 {
 		return true

--- a/internal/scan/scanner.go
+++ b/internal/scan/scanner.go
@@ -7,14 +7,11 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"slices"
-	"strings"
 
 	"github.com/rotisserie/eris"
 
 	"github.com/theunrepentantgeek/code-visualizer/internal/filter"
 	"github.com/theunrepentantgeek/code-visualizer/internal/model"
-	"github.com/theunrepentantgeek/code-visualizer/internal/provider/filesystem"
 )
 
 // Progress receives notifications as directories are scanned.
@@ -189,71 +186,6 @@ func processDir(
 	return nil
 }
 
-func processFile(node *model.Directory, entry os.DirEntry, info os.FileInfo, entryPath string) {
-	ext := strings.TrimPrefix(filepath.Ext(entry.Name()), ".")
-
-	fileType := ext
-	if fileType == "" {
-		fileType = "no-extension"
-	}
-
-	binary, err := IsBinaryFile(entryPath)
-	if err != nil {
-		slog.Warn("binary probe failed, assuming text", "path", entryPath, "error", err)
-	}
-
-	f := &model.File{
-		Path:      entryPath,
-		Name:      entry.Name(),
-		Extension: ext,
-		IsBinary:  binary,
-	}
-
-	f.SetQuantity(filesystem.FileSize, info.Size())
-	f.SetClassification(filesystem.FileType, fileType)
-
-	node.Files = append(node.Files, f)
-}
-
 func isSymlink(entry os.DirEntry) bool {
 	return entry.Type()&os.ModeSymlink != 0
-}
-
-// hasFiles reports whether the directory tree rooted at node contains at least
-// one file. It returns true as soon as the first file is found, avoiding a full
-// traversal of large trees.
-func hasFiles(node *model.Directory) bool {
-	if len(node.Files) > 0 {
-		return true
-	}
-
-	return slices.ContainsFunc(node.Dirs, hasFiles)
-}
-
-// FilterBinaryFiles returns a copy of the directory tree with binary files removed.
-// Directories that become empty after removal are also pruned.
-func FilterBinaryFiles(node *model.Directory) *model.Directory {
-	result := &model.Directory{
-		Path: node.Path,
-		Name: node.Name,
-	}
-
-	for _, f := range node.Files {
-		if f.IsBinary {
-			slog.Debug("excluding binary file", "path", f.Path)
-
-			continue
-		}
-
-		result.Files = append(result.Files, f)
-	}
-
-	for _, d := range node.Dirs {
-		filtered := FilterBinaryFiles(d)
-		if len(filtered.Files) > 0 || len(filtered.Dirs) > 0 {
-			result.Dirs = append(result.Dirs, filtered)
-		}
-	}
-
-	return result
 }

--- a/internal/scan/scanner.go
+++ b/internal/scan/scanner.go
@@ -3,9 +3,7 @@ package scan
 
 import (
 	"errors"
-	"io/fs"
 	"log/slog"
-	"os"
 	"path/filepath"
 
 	"github.com/rotisserie/eris"
@@ -31,7 +29,7 @@ func Scan(path string, rules []filter.Rule, progress Progress) (*model.Directory
 		return nil, eris.Wrap(err, "failed to resolve absolute path")
 	}
 
-	root, err := scanDir(absPath, absPath, rules, progress)
+	root, err := newWalker(absPath, rules, progress).scanDir(absPath)
 	if err != nil {
 		return nil, err
 	}
@@ -43,149 +41,4 @@ func Scan(path string, rules []filter.Rule, progress Progress) (*model.Directory
 	slog.Info("Scan complete", "files", model.CountFiles(root), "directories", model.CountDirs(root))
 
 	return root, nil
-}
-
-func scanDir(dirPath, rootPath string, rules []filter.Rule, progress Progress) (*model.Directory, error) {
-	entries, err := os.ReadDir(dirPath)
-	if err != nil {
-		return nil, eris.Wrapf(err, "failed to read directory %s", dirPath)
-	}
-
-	node := &model.Directory{
-		Path: dirPath,
-		Name: filepath.Base(dirPath),
-	}
-
-	for _, entry := range entries {
-		entryPath := filepath.Join(dirPath, entry.Name())
-
-		if err := processEntry(node, entry, entryPath, rootPath, rules, progress); err != nil {
-			return nil, err
-		}
-	}
-
-	if progress != nil {
-		progress.OnDirectoryScanned(dirPath, len(node.Files))
-	}
-
-	return node, nil
-}
-
-func processEntry(
-	node *model.Directory,
-	entry os.DirEntry,
-	entryPath, rootPath string,
-	rules []filter.Rule,
-	progress Progress,
-) error {
-	// Compute relative path first (cheap string operation) so we can apply the
-	// filter rule before paying the cost of os.Stat.
-	relPath, err := filepath.Rel(rootPath, entryPath)
-	if err != nil {
-		return eris.Wrapf(err, "failed to compute relative path for %s", entryPath)
-	}
-
-	if !filter.IsIncluded(relPath, rules) {
-		slog.Debug("excluding by filter rule", "path", relPath)
-
-		return nil
-	}
-
-	// For symlinks we must call os.Stat to follow the link and discover the
-	// real type; non-symlinks can use the type information from ReadDir directly.
-	if isSymlink(entry) {
-		return processSymlink(node, entry, entryPath, rootPath, rules, progress)
-	}
-
-	if entry.Type().IsDir() {
-		return processDir(node, entry, entryPath, rootPath, rules, progress)
-	}
-
-	if entry.Type().IsRegular() {
-		info, err := entry.Info()
-		if err != nil {
-			if errors.Is(err, fs.ErrPermission) {
-				slog.Warn("skipping file: permission denied", "path", entryPath)
-
-				return nil
-			}
-
-			slog.Warn("skipping file", "path", entryPath, "error", err)
-
-			return nil
-		}
-
-		processFile(node, entry, info, entryPath)
-	}
-
-	return nil
-}
-
-// processSymlink resolves a symlink via os.Stat and handles it as either a
-// file (processed) or a directory (skipped, matching processDir behaviour).
-func processSymlink(
-	node *model.Directory,
-	entry os.DirEntry,
-	entryPath, rootPath string,
-	rules []filter.Rule,
-	progress Progress,
-) error {
-	info, err := os.Stat(entryPath)
-	if err != nil {
-		if errors.Is(err, fs.ErrPermission) {
-			slog.Warn("skipping file: permission denied", "path", entryPath)
-
-			return nil
-		}
-
-		slog.Warn("skipping file", "path", entryPath, "error", err)
-
-		return nil
-	}
-
-	if info.IsDir() {
-		return processDir(node, entry, entryPath, rootPath, rules, progress)
-	}
-
-	if info.Mode().IsRegular() {
-		processFile(node, entry, info, entryPath)
-	}
-
-	return nil
-}
-
-func processDir(
-	node *model.Directory,
-	entry os.DirEntry,
-	entryPath, rootPath string,
-	rules []filter.Rule,
-	progress Progress,
-) error {
-	if isSymlink(entry) {
-		slog.Debug("skipping directory symlink", "path", entryPath)
-
-		return nil
-	}
-
-	child, err := scanDir(entryPath, rootPath, rules, progress)
-	if err != nil {
-		if errors.Is(err, fs.ErrPermission) {
-			slog.Warn("skipping directory: permission denied", "path", entryPath)
-
-			return nil
-		}
-
-		return err
-	}
-
-	// Prune empty directories
-	if len(child.Files) > 0 || len(child.Dirs) > 0 {
-		node.Dirs = append(node.Dirs, child)
-	}
-
-	return nil
-}
-
-func isSymlink(entry os.DirEntry) bool {
-	return entry.Type()&os.ModeSymlink != 0
 }

--- a/internal/scan/walker.go
+++ b/internal/scan/walker.go
@@ -1,0 +1,148 @@
+package scan
+
+import (
+	"errors"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/rotisserie/eris"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/filter"
+	"github.com/theunrepentantgeek/code-visualizer/internal/model"
+)
+
+type walker struct {
+	policy   filterPolicy
+	builder  nodeBuilder
+	progress Progress
+}
+
+func newWalker(rootPath string, rules []filter.Rule, progress Progress) walker {
+	return walker{
+		policy:   newFilterPolicy(rootPath, rules),
+		builder:  newNodeBuilder(IsBinaryFile),
+		progress: progress,
+	}
+}
+
+func (w walker) scanDir(dirPath string) (*model.Directory, error) {
+	entries, err := os.ReadDir(dirPath)
+	if err != nil {
+		return nil, eris.Wrapf(err, "failed to read directory %s", dirPath)
+	}
+
+	node := &model.Directory{
+		Path: dirPath,
+		Name: filepath.Base(dirPath),
+	}
+
+	for _, entry := range entries {
+		entryPath := filepath.Join(dirPath, entry.Name())
+
+		if err := w.processEntry(node, entry, entryPath); err != nil {
+			return nil, err
+		}
+	}
+
+	if w.progress != nil {
+		w.progress.OnDirectoryScanned(dirPath, len(node.Files))
+	}
+
+	return node, nil
+}
+
+func (w walker) processEntry(node *model.Directory, entry os.DirEntry, entryPath string) error {
+	included, relPath, err := w.policy.includes(entryPath)
+	if err != nil {
+		return err
+	}
+
+	if !included {
+		slog.Debug("excluding by filter rule", "path", relPath)
+
+		return nil
+	}
+
+	if isSymlink(entry) {
+		return w.processSymlink(node, entry, entryPath)
+	}
+
+	if entry.Type().IsDir() {
+		return w.processDir(node, entry, entryPath)
+	}
+
+	if entry.Type().IsRegular() {
+		info, err := entry.Info()
+		if err != nil {
+			if errors.Is(err, fs.ErrPermission) {
+				slog.Warn("skipping file: permission denied", "path", entryPath)
+
+				return nil
+			}
+
+			slog.Warn("skipping file", "path", entryPath, "error", err)
+
+			return nil
+		}
+
+		w.builder.processFile(node, entry, info, entryPath)
+	}
+
+	return nil
+}
+
+func (w walker) processSymlink(node *model.Directory, entry os.DirEntry, entryPath string) error {
+	info, err := os.Stat(entryPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrPermission) {
+			slog.Warn("skipping file: permission denied", "path", entryPath)
+
+			return nil
+		}
+
+		slog.Warn("skipping file", "path", entryPath, "error", err)
+
+		return nil
+	}
+
+	if info.IsDir() {
+		return w.processDir(node, entry, entryPath)
+	}
+
+	if info.Mode().IsRegular() {
+		w.builder.processFile(node, entry, info, entryPath)
+	}
+
+	return nil
+}
+
+func (w walker) processDir(node *model.Directory, entry os.DirEntry, entryPath string) error {
+	if isSymlink(entry) {
+		slog.Debug("skipping directory symlink", "path", entryPath)
+
+		return nil
+	}
+
+	child, err := w.scanDir(entryPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrPermission) {
+			slog.Warn("skipping directory: permission denied", "path", entryPath)
+
+			return nil
+		}
+
+		return err
+	}
+
+	if len(child.Files) > 0 || len(child.Dirs) > 0 {
+		node.Dirs = append(node.Dirs, child)
+	}
+
+	return nil
+}
+
+func isSymlink(entry os.DirEntry) bool {
+	return entry.Type()&os.ModeSymlink != 0
+}


### PR DESCRIPTION
Closes #326

Splits the 259-line `internal/scan/scanner.go` into focused collaborators:

- **scanner.go** — thin orchestrator (Progress interface + Scan entry point)
- **walker.go** — filesystem traversal (symlinks, permissions, directory pruning)
- **node_builder.go** — model node construction and binary filtering

`binary.go` was already separate and remains untouched.

No behavior change — pure structural refactor. All existing tests pass.