### PR TITLE
feat(config): export only relevant viz section (#321)

### DIFF
--- a/cmd/codeviz/bubbletree_cmd.go
+++ b/cmd/codeviz/bubbletree_cmd.go
@@ -92,6 +92,7 @@ func (c *BubbletreeCmd) Run(flags *Flags) error {
 			Output:     c.Output,
 			Flags:      toStagesFlags(flags),
 			RootConfig: flags.Config,
+			VizName:    "bubbletree",
 			CLIFilters: c.Filters(),
 		},
 		Config:             flags.Config.Bubbletree,

--- a/cmd/codeviz/radialtree_cmd.go
+++ b/cmd/codeviz/radialtree_cmd.go
@@ -91,6 +91,7 @@ func (c *RadialCmd) Run(flags *Flags) error {
 			Output:     c.Output,
 			Flags:      toStagesFlags(flags),
 			RootConfig: flags.Config,
+			VizName:    "radial",
 			CLIFilters: c.Filters(),
 		},
 		Config:             flags.Config.Radial,

--- a/cmd/codeviz/scatter_cmd.go
+++ b/cmd/codeviz/scatter_cmd.go
@@ -104,6 +104,7 @@ func (c *ScatterCmd) Run(flags *Flags) error {
 			Output:     c.Output,
 			Flags:      toStagesFlags(flags),
 			RootConfig: flags.Config,
+			VizName:    "scatter",
 			CLIFilters: c.Filters(),
 		},
 		Config:             flags.Config.Scatter,

--- a/cmd/codeviz/spiral_cmd.go
+++ b/cmd/codeviz/spiral_cmd.go
@@ -93,6 +93,7 @@ func (c *SpiralCmd) Run(flags *Flags) error {
 			Output:     c.Output,
 			Flags:      toStagesFlags(flags),
 			RootConfig: flags.Config,
+			VizName:    "spiral",
 			CLIFilters: c.Filters(),
 		},
 		Config:             flags.Config.Spiral,

--- a/cmd/codeviz/treemap_cmd.go
+++ b/cmd/codeviz/treemap_cmd.go
@@ -102,6 +102,7 @@ func (c *TreemapCmd) Run(flags *Flags) error {
 			Output:     c.Output,
 			Flags:      toStagesFlags(flags),
 			RootConfig: flags.Config,
+			VizName:    "treemap",
 			CLIFilters: c.Filters(),
 		},
 		Config:             flags.Config.Treemap,

--- a/internal/canvas/legendlayout/layout.go
+++ b/internal/canvas/legendlayout/layout.go
@@ -85,7 +85,6 @@ func ReserveSpace(data *model.LegendData, measurer StringMeasurer) (widthReducti
 	}
 }
 
-//nolint:revive // refactor this later
 func measureLegendV(measurer StringMeasurer, data *model.LegendData) (width, height float64) {
 	var totalH float64
 
@@ -106,24 +105,9 @@ func measureLegendV(measurer StringMeasurer, data *model.LegendData) (width, hei
 			totalH += model.EntryGap
 		}
 
-		lw, _ := measurer.MeasureString(entry.Label)
-		mw, _ := measurer.MeasureString(entry.Metric)
-		totalH += titleHeight()
-
-		if lw > maxW {
-			maxW = lw
-		}
-
-		if mw > maxW {
-			maxW = mw
-		}
-
-		entryW, entryH := measureEntryV(measurer, entry)
+		entryW, entryH := measureSingleEntryV(measurer, entry)
 		totalH += entryH
-
-		if entryW > maxW {
-			maxW = entryW
-		}
+		maxW = max(maxW, entryW)
 	}
 
 	return maxW + 2*model.LegendPadding, totalH + 2*model.LegendPadding
@@ -171,6 +155,14 @@ func measureSingleEntryH(measurer StringMeasurer, entry model.LegendEntryData) (
 	h := titleHeight() + entryH
 
 	return w, h
+}
+
+func measureSingleEntryV(measurer StringMeasurer, entry model.LegendEntryData) (width, height float64) {
+	lw, _ := measurer.MeasureString(entry.Label)
+	mw, _ := measurer.MeasureString(entry.Metric)
+	entryW, entryH := measureEntryV(measurer, entry)
+
+	return max(max(lw, mw), entryW), titleHeight() + entryH
 }
 
 func measureEntryV(measurer StringMeasurer, entry model.LegendEntryData) (width, height float64) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -149,8 +149,7 @@ func (c *Config) TryAutoLoad(outputPath string) error {
 // visualization section populated.
 func (c *Config) ForExport(vizName string) *Config {
 	exported := &Config{
-		Width:      c.Width,
-		Height:     c.Height,
+		ImageSize:  c.ImageSize,
 		FileFilter: c.FileFilter,
 		Source:     c.Source,
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,6 +131,7 @@ func (c *Config) ForExport(vizName string) *Config {
 		exported.Spiral = c.Spiral
 	case "scatter":
 		exported.Scatter = c.Scatter
+	default:
 	}
 
 	return exported

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,6 +110,32 @@ func (c *Config) TryAutoLoad(outputPath string) error {
 	return nil
 }
 
+// ForExport returns a shallow copy of c with only the requested
+// visualization section populated.
+func (c *Config) ForExport(vizName string) *Config {
+	exported := &Config{
+		Width:      c.Width,
+		Height:     c.Height,
+		FileFilter: c.FileFilter,
+		Source:     c.Source,
+	}
+
+	switch vizName {
+	case "treemap":
+		exported.Treemap = c.Treemap
+	case "radial":
+		exported.Radial = c.Radial
+	case "bubbletree":
+		exported.Bubbletree = c.Bubbletree
+	case "spiral":
+		exported.Spiral = c.Spiral
+	case "scatter":
+		exported.Scatter = c.Scatter
+	}
+
+	return exported
+}
+
 // Save writes c to path in YAML or JSON format, determined by the file extension.
 // The format is: .yaml/.yml → YAML, .json → JSON.
 // The file is created or overwritten with mode 0600.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -399,21 +399,19 @@ func TestForExport_OnlyIncludesRelevantViz(t *testing.T) {
 	g.Expect(exported.Scatter).To(BeNil())
 }
 
-func TestForExport_PreservesWidthHeightAndFilter(t *testing.T) {
+func TestForExport_PreservesImageSizeAndFilter(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
 	width := 800
 	height := 600
 	cfg := New()
-	cfg.Width = &width
-	cfg.Height = &height
+	cfg.ImageSize = &ImageSize{Width: &width, Height: &height}
 	cfg.FileFilter = []filter.Rule{{Pattern: "*.go", Mode: filter.Include}}
 
 	exported := cfg.ForExport("scatter")
 
-	g.Expect(exported.Width).To(BeIdenticalTo(cfg.Width))
-	g.Expect(exported.Height).To(BeIdenticalTo(cfg.Height))
+	g.Expect(exported.ImageSize).To(BeIdenticalTo(cfg.ImageSize))
 	g.Expect(exported.FileFilter).To(Equal(cfg.FileFilter))
 	g.Expect(exported.Scatter).To(BeIdenticalTo(cfg.Scatter))
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -295,6 +295,55 @@ func TestSave_OmitsNilFields(t *testing.T) {
 	g.Expect(string(data)).NotTo(ContainSubstring("border"))
 }
 
+func TestForExport_OnlyIncludesRelevantViz(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	cfg := New()
+
+	exported := cfg.ForExport("treemap")
+
+	g.Expect(exported.Treemap).To(BeIdenticalTo(cfg.Treemap))
+	g.Expect(exported.Radial).To(BeNil())
+	g.Expect(exported.Bubbletree).To(BeNil())
+	g.Expect(exported.Spiral).To(BeNil())
+	g.Expect(exported.Scatter).To(BeNil())
+}
+
+func TestForExport_PreservesWidthHeightAndFilter(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	width := 800
+	height := 600
+	cfg := New()
+	cfg.Width = &width
+	cfg.Height = &height
+	cfg.FileFilter = []filter.Rule{{Pattern: "*.go", Mode: filter.Include}}
+
+	exported := cfg.ForExport("scatter")
+
+	g.Expect(exported.Width).To(BeIdenticalTo(cfg.Width))
+	g.Expect(exported.Height).To(BeIdenticalTo(cfg.Height))
+	g.Expect(exported.FileFilter).To(Equal(cfg.FileFilter))
+	g.Expect(exported.Scatter).To(BeIdenticalTo(cfg.Scatter))
+}
+
+func TestForExport_UnknownViz_ExportsNoVizSection(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	cfg := New()
+
+	exported := cfg.ForExport("unknown")
+
+	g.Expect(exported.Treemap).To(BeNil())
+	g.Expect(exported.Radial).To(BeNil())
+	g.Expect(exported.Bubbletree).To(BeNil())
+	g.Expect(exported.Spiral).To(BeNil())
+	g.Expect(exported.Scatter).To(BeNil())
+}
+
 func TestNew_DefaultFileFilter(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)

--- a/internal/provider/golang/cyclomatic.go
+++ b/internal/provider/golang/cyclomatic.go
@@ -9,8 +9,6 @@ import (
 // cyclomaticComplexity computes cyclomatic complexity for a single function body.
 // Base complexity is 1, plus 1 for each decision point:
 // if, for, range, case (non-default), &&, ||.
-//
-//nolint:cyclop,revive // type switch over AST nodes is inherently branchy
 func cyclomaticComplexity(body *dst.BlockStmt) int64 {
 	if body == nil {
 		return 1
@@ -19,31 +17,32 @@ func cyclomaticComplexity(body *dst.BlockStmt) int64 {
 	complexity := int64(1)
 
 	dst.Inspect(body, func(n dst.Node) bool {
-		switch node := n.(type) {
-		case *dst.IfStmt:
-			complexity++
-		case *dst.ForStmt:
-			complexity++
-		case *dst.RangeStmt:
-			complexity++
-		case *dst.CaseClause:
-			if node.List != nil {
-				complexity++
-			}
-		case *dst.CommClause:
-			if node.Comm != nil {
-				complexity++
-			}
-		case *dst.BinaryExpr:
-			if node.Op == token.LAND || node.Op == token.LOR {
-				complexity++
-			}
-		default:
-			// no complexity contribution from other node types
-		}
+		complexity += complexityContribution(n)
 
 		return true
 	})
 
 	return complexity
+}
+
+func complexityContribution(node dst.Node) int64 {
+	switch node := node.(type) {
+	case *dst.IfStmt, *dst.ForStmt, *dst.RangeStmt:
+		return 1
+	case *dst.CaseClause:
+		if node.List != nil {
+			return 1
+		}
+	case *dst.CommClause:
+		if node.Comm != nil {
+			return 1
+		}
+	case *dst.BinaryExpr:
+		if node.Op == token.LAND || node.Op == token.LOR {
+			return 1
+		}
+	default:
+	}
+
+	return 0
 }

--- a/internal/stages/common.go
+++ b/internal/stages/common.go
@@ -33,6 +33,7 @@ type CommonState struct {
 	Output     string
 	Flags      *Flags
 	RootConfig *config.Config
+	VizName    string // active visualization name for export trimming
 	CLIFilters []filter.Rule
 
 	// Populated by shared stages during the pipeline:

--- a/internal/stages/export.go
+++ b/internal/stages/export.go
@@ -15,7 +15,8 @@ func ExportConfig[S VizState](s S) error {
 		return nil
 	}
 
-	if err := c.RootConfig.Save(c.Flags.ExportConfig); err != nil {
+	exportCfg := c.RootConfig.ForExport(c.VizName)
+	if err := exportCfg.Save(c.Flags.ExportConfig); err != nil {
 		return eris.Wrap(err, "failed to save config")
 	}
 

--- a/internal/stages/export_test.go
+++ b/internal/stages/export_test.go
@@ -1,6 +1,7 @@
 package stages_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -19,4 +20,29 @@ func TestExportConfig_NoFlag_NoOp(t *testing.T) {
 	}}
 
 	g.Expect(stages.ExportConfig[*fakeState](s)).To(Succeed())
+}
+
+func TestExportConfig_OnlyWritesSelectedVizSection(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.yaml")
+	rootCfg := config.New()
+
+	s := &fakeState{common: stages.CommonState{
+		Flags:      &stages.Flags{ExportConfig: path},
+		RootConfig: rootCfg,
+		VizName:    "treemap",
+	}}
+
+	g.Expect(stages.ExportConfig[*fakeState](s)).To(Succeed())
+
+	loaded := &config.Config{}
+	g.Expect(loaded.Load(path)).To(Succeed())
+	g.Expect(loaded.Treemap).NotTo(BeNil())
+	g.Expect(loaded.Radial).To(BeNil())
+	g.Expect(loaded.Bubbletree).To(BeNil())
+	g.Expect(loaded.Spiral).To(BeNil())
+	g.Expect(loaded.Scatter).To(BeNil())
 }


### PR DESCRIPTION
Closes #321

When exporting config via `--export-config`, only the visualization section for the active command is included. Other viz sections (which were just empty defaults) are now omitted, reducing noise.

Changes:
- Add `VizName` field to `CommonState` (set by each command)
- Add `Config.ForExport(vizName)` that returns a trimmed copy
- Update `ExportConfig` stage to use `ForExport` before saving
- Each command sets its `VizName` during state initialization
- Tests verify only the relevant section is exported