### PR TITLE
feat(config): group image dimensions under imageSize (#322)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,6 +92,7 @@ func (c *Config) Load(path string) error {
 		if err := yaml.Unmarshal(data, c); err != nil {
 			return eris.Wrapf(err, "failed to parse YAML config file %q", path)
 		}
+
 		if err := yaml.Unmarshal(data, &compat); err != nil {
 			return eris.Wrapf(err, "failed to parse YAML config file %q", path)
 		}
@@ -99,6 +100,7 @@ func (c *Config) Load(path string) error {
 		if err := json.Unmarshal(data, c); err != nil {
 			return eris.Wrapf(err, "failed to parse JSON config file %q", path)
 		}
+
 		if err := json.Unmarshal(data, &compat); err != nil {
 			return eris.Wrapf(err, "failed to parse JSON config file %q", path)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,6 +85,8 @@ func (c *Config) Load(path string) error {
 
 	ext := strings.ToLower(filepath.Ext(path))
 
+	// Parse into a small compatibility struct as well so legacy top-level width/height
+	// values can be migrated into ImageSize without changing the persisted format.
 	var compat imageSizeCompatConfig
 
 	switch ext {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,12 @@ const (
 	extJSON = ".json"
 )
 
+// ImageSize groups the output image dimensions.
+type ImageSize struct {
+	Width  *int `yaml:"width,omitempty"  json:"width,omitempty"`
+	Height *int `yaml:"height,omitempty" json:"height,omitempty"`
+}
+
 // Config is the root configuration struct for the application.
 // It is the single source of truth for all configuration, regardless of
 // whether values came from defaults, a config file, or CLI flags.
@@ -28,8 +34,7 @@ const (
 // non-nil or non-empty means it was explicitly set (by a config file or
 // by a CLI flag override).
 type Config struct {
-	Width      *int          `yaml:"width,omitempty"      json:"width,omitempty"`
-	Height     *int          `yaml:"height,omitempty"     json:"height,omitempty"`
+	ImageSize  *ImageSize    `yaml:"imageSize,omitempty"  json:"imageSize,omitempty"`
 	Treemap    *Treemap      `yaml:"treemap,omitempty"    json:"treemap,omitempty"`
 	Radial     *Radial       `yaml:"radial,omitempty"     json:"radial,omitempty"`
 	Bubbletree *Bubbletree   `yaml:"bubbletree,omitempty" json:"bubbletree,omitempty"`
@@ -41,6 +46,13 @@ type Config struct {
 	Source *string `yaml:"-" json:"-"`
 }
 
+// imageSizeCompatConfig captures both the new and legacy image dimension formats.
+type imageSizeCompatConfig struct {
+	ImageSize *ImageSize `yaml:"imageSize,omitempty" json:"imageSize,omitempty"`
+	Width     *int       `yaml:"width,omitempty"     json:"width,omitempty"`
+	Height    *int       `yaml:"height,omitempty"    json:"height,omitempty"`
+}
+
 // New returns a Config populated with sensible defaults.
 // Call this unconditionally at startup; subsequent layers (config file, CLI
 // flags) overlay their values on top of the struct returned here.
@@ -49,8 +61,7 @@ func New() *Config {
 	height := 1080
 
 	return &Config{
-		Width:      &width,
-		Height:     &height,
+		ImageSize:  &ImageSize{Width: &width, Height: &height},
 		Treemap:    &Treemap{},
 		Radial:     &Radial{Labels: new("all")},
 		Bubbletree: &Bubbletree{Labels: new("folders")},
@@ -74,18 +85,28 @@ func (c *Config) Load(path string) error {
 
 	ext := strings.ToLower(filepath.Ext(path))
 
+	var compat imageSizeCompatConfig
+
 	switch ext {
 	case extYAML, extYML:
 		if err := yaml.Unmarshal(data, c); err != nil {
+			return eris.Wrapf(err, "failed to parse YAML config file %q", path)
+		}
+		if err := yaml.Unmarshal(data, &compat); err != nil {
 			return eris.Wrapf(err, "failed to parse YAML config file %q", path)
 		}
 	case extJSON:
 		if err := json.Unmarshal(data, c); err != nil {
 			return eris.Wrapf(err, "failed to parse JSON config file %q", path)
 		}
+		if err := json.Unmarshal(data, &compat); err != nil {
+			return eris.Wrapf(err, "failed to parse JSON config file %q", path)
+		}
 	default:
 		return eris.Errorf("unsupported config file extension %q (use .yaml, .yml, or .json)", ext)
 	}
+
+	c.applyLegacyImageSize(compat)
 
 	// Record the source path for informational purposes.
 	c.Source = &path
@@ -147,11 +168,37 @@ func (c *Config) Save(path string) error {
 	return nil
 }
 
+func (c *Config) ensureImageSize() {
+	if c.ImageSize == nil {
+		c.ImageSize = &ImageSize{}
+	}
+}
+
+func (c *Config) applyLegacyImageSize(compat imageSizeCompatConfig) {
+	if compat.ImageSize != nil || compat.Width != nil || compat.Height != nil {
+		c.ensureImageSize()
+	}
+
+	if compat.Width != nil && (compat.ImageSize == nil || compat.ImageSize.Width == nil) {
+		c.ImageSize.Width = compat.Width
+	}
+
+	if compat.Height != nil && (compat.ImageSize == nil || compat.ImageSize.Height == nil) {
+		c.ImageSize.Height = compat.Height
+	}
+}
+
 // OverrideWidth sets Width to v if v is non-zero.
-func (c *Config) OverrideWidth(v int) { overrideInt(&c.Width, v) }
+func (c *Config) OverrideWidth(v int) {
+	c.ensureImageSize()
+	overrideInt(&c.ImageSize.Width, v)
+}
 
 // OverrideHeight sets Height to v if v is non-zero.
-func (c *Config) OverrideHeight(v int) { overrideInt(&c.Height, v) }
+func (c *Config) OverrideHeight(v int) {
+	c.ensureImageSize()
+	overrideInt(&c.ImageSize.Height, v)
+}
 
 // FindAutoConfig looks for a config file alongside the output file.
 // It strips the output file extension, appends "-config", and probes for

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,12 +61,22 @@ func New() *Config {
 	height := 1080
 
 	return &Config{
-		ImageSize:  &ImageSize{Width: &width, Height: &height},
-		Treemap:    &Treemap{},
-		Radial:     &Radial{Labels: new("all")},
-		Bubbletree: &Bubbletree{Labels: new("folders")},
-		Spiral:     &Spiral{Resolution: new("daily"), Labels: new("laps")},
-		Scatter:    &Scatter{},
+		ImageSize: &ImageSize{
+			Width:  &width,
+			Height: &height,
+		},
+		Treemap: &Treemap{},
+		Radial: &Radial{
+			Labels: new("all"),
+		},
+		Bubbletree: &Bubbletree{
+			Labels: new("folders"),
+		},
+		Spiral: &Spiral{
+			Resolution: new("daily"),
+			Labels:     new("laps"),
+		},
+		Scatter: &Scatter{},
 		FileFilter: []filter.Rule{
 			{Pattern: ".*", Mode: filter.Exclude},
 		},
@@ -192,13 +202,13 @@ func (c *Config) applyLegacyImageSize(compat imageSizeCompatConfig) {
 	}
 }
 
-// OverrideWidth sets Width to v if v is non-zero.
+// OverrideWidth sets ImageSize.Width to v if v is non-zero.
 func (c *Config) OverrideWidth(v int) {
 	c.ensureImageSize()
 	overrideInt(&c.ImageSize.Width, v)
 }
 
-// OverrideHeight sets Height to v if v is non-zero.
+// OverrideHeight sets ImageSize.Height to v if v is non-zero.
 func (c *Config) OverrideHeight(v int) {
 	c.ensureImageSize()
 	overrideInt(&c.ImageSize.Height, v)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -122,6 +122,28 @@ func TestLoad_YAMLImageSize_OverridesWidth(t *testing.T) {
 	g.Expect(*cfg.ImageSize.Height).To(Equal(1080)) // default preserved
 }
 
+func TestLoad_YAMLLegacyWidth_ParsesIntoImageSize(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	// Arrange
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := "width: 800\n"
+	g.Expect(os.WriteFile(path, []byte(content), 0o600)).To(Succeed())
+
+	cfg := New()
+
+	// Act
+	err := cfg.Load(path)
+
+	// Assert
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(cfg.ImageSize).NotTo(BeNil())
+	g.Expect(*cfg.ImageSize.Width).To(Equal(800))
+	g.Expect(*cfg.ImageSize.Height).To(Equal(1080)) // default preserved
+}
+
 func TestLoad_YMLExtension_ParsesLegacyHeight(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+
 	"go.yaml.in/yaml/v3"
 
 	"github.com/theunrepentantgeek/code-visualizer/internal/filter"
@@ -165,6 +166,49 @@ func TestLoad_JSONConfig_OverridesFill(t *testing.T) {
 	g.Expect(cfg.Treemap.Fill.Palette).To(Equal(palette.PaletteName("categorization")))
 }
 
+func TestLoad_JSONLegacyWidth_ParsesIntoImageSize(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	// Arrange
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	content := `{"width":800}`
+	g.Expect(os.WriteFile(path, []byte(content), 0o600)).To(Succeed())
+
+	cfg := New()
+
+	// Act
+	err := cfg.Load(path)
+
+	// Assert
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(cfg.ImageSize).NotTo(BeNil())
+	g.Expect(*cfg.ImageSize.Width).To(Equal(800))
+	g.Expect(*cfg.ImageSize.Height).To(Equal(1080))
+}
+
+func TestLoad_ImageSizeTakesPrecedenceOverLegacyWidth(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	// Arrange
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := "width: 700\nimageSize:\n  width: 800\n"
+	g.Expect(os.WriteFile(path, []byte(content), 0o600)).To(Succeed())
+
+	cfg := New()
+
+	// Act
+	err := cfg.Load(path)
+
+	// Assert
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(cfg.ImageSize).NotTo(BeNil())
+	g.Expect(*cfg.ImageSize.Width).To(Equal(800))
+}
+
 func TestLoad_InvalidYAML_ReturnsError(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
@@ -214,64 +258,63 @@ func TestSave_UnknownExtension_ReturnsError(t *testing.T) {
 	g.Expect(err).To(MatchError(ContainSubstring("unsupported config file extension")))
 }
 
-func TestSave_YAML_WritesImageSizeObject(t *testing.T) {
+func TestSave_WritesImageSizeObject(t *testing.T) {
 	t.Parallel()
-	g := NewGomegaWithT(t)
 
-	// Arrange
-	dir := t.TempDir()
-	path := filepath.Join(dir, "out.yaml")
-	cfg := New()
+	tests := []struct {
+		name     string
+		fileName string
+		decode   func([]byte, any) error
+		width    any
+		height   any
+	}{
+		{
+			name:     "yaml",
+			fileName: "out.yaml",
+			decode:   yaml.Unmarshal,
+			width:    1920,
+			height:   1080,
+		},
+		{
+			name:     "json",
+			fileName: "out.json",
+			decode:   json.Unmarshal,
+			width:    1920.0,
+			height:   1080.0,
+		},
+	}
 
-	// Act
-	err := cfg.Save(path)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
 
-	// Assert
-	g.Expect(err).NotTo(HaveOccurred())
+			// Arrange
+			dir := t.TempDir()
+			path := filepath.Join(dir, tc.fileName)
+			cfg := New()
 
-	data, readErr := os.ReadFile(path)
-	g.Expect(readErr).NotTo(HaveOccurred())
+			// Act
+			err := cfg.Save(path)
 
-	var decoded map[string]any
-	g.Expect(yaml.Unmarshal(data, &decoded)).To(Succeed())
-	g.Expect(decoded).To(HaveKey("imageSize"))
-	g.Expect(decoded).NotTo(HaveKey("width"))
-	g.Expect(decoded).NotTo(HaveKey("height"))
+			// Assert
+			g.Expect(err).NotTo(HaveOccurred())
 
-	imageSize, ok := decoded["imageSize"].(map[string]any)
-	g.Expect(ok).To(BeTrue())
-	g.Expect(imageSize["width"]).To(Equal(1920))
-	g.Expect(imageSize["height"]).To(Equal(1080))
-}
+			data, readErr := os.ReadFile(path)
+			g.Expect(readErr).NotTo(HaveOccurred())
 
-func TestSave_JSON_WritesImageSizeObject(t *testing.T) {
-	t.Parallel()
-	g := NewGomegaWithT(t)
+			var decoded map[string]any
+			g.Expect(tc.decode(data, &decoded)).To(Succeed())
+			g.Expect(decoded).To(HaveKey("imageSize"))
+			g.Expect(decoded).NotTo(HaveKey("width"))
+			g.Expect(decoded).NotTo(HaveKey("height"))
 
-	// Arrange
-	dir := t.TempDir()
-	path := filepath.Join(dir, "out.json")
-	cfg := New()
-
-	// Act
-	err := cfg.Save(path)
-
-	// Assert
-	g.Expect(err).NotTo(HaveOccurred())
-
-	data, readErr := os.ReadFile(path)
-	g.Expect(readErr).NotTo(HaveOccurred())
-
-	var decoded map[string]any
-	g.Expect(json.Unmarshal(data, &decoded)).To(Succeed())
-	g.Expect(decoded).To(HaveKey("imageSize"))
-	g.Expect(decoded).NotTo(HaveKey("width"))
-	g.Expect(decoded).NotTo(HaveKey("height"))
-
-	imageSize, ok := decoded["imageSize"].(map[string]any)
-	g.Expect(ok).To(BeTrue())
-	g.Expect(imageSize["width"]).To(Equal(1920.0))
-	g.Expect(imageSize["height"]).To(Equal(1080.0))
+			imageSize, ok := decoded["imageSize"].(map[string]any)
+			g.Expect(ok).To(BeTrue())
+			g.Expect(imageSize["width"]).To(Equal(tc.width))
+			g.Expect(imageSize["height"]).To(Equal(tc.height))
+		})
+	}
 }
 
 func TestSave_ThenLoad_RoundTrips(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,11 +1,13 @@
 package config
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/theunrepentantgeek/code-visualizer/internal/filter"
 	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
@@ -33,10 +35,11 @@ func TestNew_DefaultsSet(t *testing.T) {
 	cfg := New()
 
 	// Assert
-	g.Expect(cfg.Width).NotTo(BeNil())
-	g.Expect(*cfg.Width).To(Equal(1920))
-	g.Expect(cfg.Height).NotTo(BeNil())
-	g.Expect(*cfg.Height).To(Equal(1080))
+	g.Expect(cfg.ImageSize).NotTo(BeNil())
+	g.Expect(cfg.ImageSize.Width).NotTo(BeNil())
+	g.Expect(*cfg.ImageSize.Width).To(Equal(1920))
+	g.Expect(cfg.ImageSize.Height).NotTo(BeNil())
+	g.Expect(*cfg.ImageSize.Height).To(Equal(1080))
 }
 
 func TestNew_TreemapDefaultsSet(t *testing.T) {
@@ -96,14 +99,14 @@ func TestLoad_MissingFile_ReturnsError(t *testing.T) {
 	g.Expect(err).To(MatchError(ContainSubstring("failed to read config file")))
 }
 
-func TestLoad_YAMLPartialConfig_OverridesWidth(t *testing.T) {
+func TestLoad_YAMLImageSize_OverridesWidth(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
 	// Arrange
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
-	content := "width: 800\n"
+	content := "imageSize:\n  width: 800\n"
 	g.Expect(os.WriteFile(path, []byte(content), 0o600)).To(Succeed())
 
 	cfg := New()
@@ -113,11 +116,12 @@ func TestLoad_YAMLPartialConfig_OverridesWidth(t *testing.T) {
 
 	// Assert
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(*cfg.Width).To(Equal(800))
-	g.Expect(*cfg.Height).To(Equal(1080)) // default preserved
+	g.Expect(cfg.ImageSize).NotTo(BeNil())
+	g.Expect(*cfg.ImageSize.Width).To(Equal(800))
+	g.Expect(*cfg.ImageSize.Height).To(Equal(1080)) // default preserved
 }
 
-func TestLoad_YMLExtension_ParsesCorrectly(t *testing.T) {
+func TestLoad_YMLExtension_ParsesLegacyHeight(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
@@ -134,8 +138,9 @@ func TestLoad_YMLExtension_ParsesCorrectly(t *testing.T) {
 
 	// Assert
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(*cfg.Height).To(Equal(720))
-	g.Expect(*cfg.Width).To(Equal(1920)) // default preserved
+	g.Expect(cfg.ImageSize).NotTo(BeNil())
+	g.Expect(*cfg.ImageSize.Height).To(Equal(720))
+	g.Expect(*cfg.ImageSize.Width).To(Equal(1920)) // default preserved
 }
 
 func TestLoad_JSONConfig_OverridesFill(t *testing.T) {
@@ -209,7 +214,7 @@ func TestSave_UnknownExtension_ReturnsError(t *testing.T) {
 	g.Expect(err).To(MatchError(ContainSubstring("unsupported config file extension")))
 }
 
-func TestSave_YAML_WritesFile(t *testing.T) {
+func TestSave_YAML_WritesImageSizeObject(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
@@ -226,11 +231,20 @@ func TestSave_YAML_WritesFile(t *testing.T) {
 
 	data, readErr := os.ReadFile(path)
 	g.Expect(readErr).NotTo(HaveOccurred())
-	g.Expect(string(data)).To(ContainSubstring("width: 1920"))
-	g.Expect(string(data)).To(ContainSubstring("height: 1080"))
+
+	var decoded map[string]any
+	g.Expect(yaml.Unmarshal(data, &decoded)).To(Succeed())
+	g.Expect(decoded).To(HaveKey("imageSize"))
+	g.Expect(decoded).NotTo(HaveKey("width"))
+	g.Expect(decoded).NotTo(HaveKey("height"))
+
+	imageSize, ok := decoded["imageSize"].(map[string]any)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(imageSize["width"]).To(Equal(1920))
+	g.Expect(imageSize["height"]).To(Equal(1080))
 }
 
-func TestSave_JSON_WritesFile(t *testing.T) {
+func TestSave_JSON_WritesImageSizeObject(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
@@ -247,8 +261,17 @@ func TestSave_JSON_WritesFile(t *testing.T) {
 
 	data, readErr := os.ReadFile(path)
 	g.Expect(readErr).NotTo(HaveOccurred())
-	g.Expect(string(data)).To(ContainSubstring(`"width": 1920`))
-	g.Expect(string(data)).To(ContainSubstring(`"height": 1080`))
+
+	var decoded map[string]any
+	g.Expect(json.Unmarshal(data, &decoded)).To(Succeed())
+	g.Expect(decoded).To(HaveKey("imageSize"))
+	g.Expect(decoded).NotTo(HaveKey("width"))
+	g.Expect(decoded).NotTo(HaveKey("height"))
+
+	imageSize, ok := decoded["imageSize"].(map[string]any)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(imageSize["width"]).To(Equal(1920.0))
+	g.Expect(imageSize["height"]).To(Equal(1080.0))
 }
 
 func TestSave_ThenLoad_RoundTrips(t *testing.T) {
@@ -269,8 +292,9 @@ func TestSave_ThenLoad_RoundTrips(t *testing.T) {
 	g.Expect(loaded.Load(path)).To(Succeed())
 
 	// Assert
-	g.Expect(*loaded.Width).To(Equal(1920))
-	g.Expect(*loaded.Height).To(Equal(1080))
+	g.Expect(loaded.ImageSize).NotTo(BeNil())
+	g.Expect(*loaded.ImageSize.Width).To(Equal(1920))
+	g.Expect(*loaded.ImageSize.Height).To(Equal(1080))
 	g.Expect(loaded.Treemap.Fill).NotTo(BeNil())
 	g.Expect(loaded.Treemap.Fill.Metric).To(Equal(metric.Name("file-type")))
 }
@@ -479,7 +503,8 @@ func TestTryAutoLoad_ConfigFilePresent_LoadsIt(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(cfg.Source).NotTo(BeNil())
 	g.Expect(*cfg.Source).To(Equal(configPath))
-	g.Expect(*cfg.Width).To(Equal(800))
+	g.Expect(cfg.ImageSize).NotTo(BeNil())
+	g.Expect(*cfg.ImageSize.Width).To(Equal(800))
 }
 
 func TestTryAutoLoad_AlreadyLoaded_SkipsAutoLoad(t *testing.T) {
@@ -503,7 +528,8 @@ func TestTryAutoLoad_AlreadyLoaded_SkipsAutoLoad(t *testing.T) {
 	// TryAutoLoad should be a no-op because Source is already set
 	err := cfg.TryAutoLoad(outputPath)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(*cfg.Width).To(Equal(1600)) // unchanged
+	g.Expect(cfg.ImageSize).NotTo(BeNil())
+	g.Expect(*cfg.ImageSize.Width).To(Equal(1600)) // unchanged
 }
 
 func TestNew_ScatterDefaultsSet(t *testing.T) {

--- a/internal/config/override_test.go
+++ b/internal/config/override_test.go
@@ -16,16 +16,17 @@ func TestConfig_OverrideWidth_SetsWhenNonZero(t *testing.T) {
 	g := NewGomegaWithT(t)
 	cfg := New()
 	cfg.OverrideWidth(2560)
-	g.Expect(*cfg.Width).To(Equal(2560))
+	g.Expect(cfg.ImageSize).NotTo(BeNil())
+	g.Expect(*cfg.ImageSize.Width).To(Equal(2560))
 }
 
 func TestConfig_OverrideWidth_SkipsWhenZero(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 	cfg := New()
-	original := *cfg.Width
+	original := *cfg.ImageSize.Width
 	cfg.OverrideWidth(0)
-	g.Expect(*cfg.Width).To(Equal(original))
+	g.Expect(*cfg.ImageSize.Width).To(Equal(original))
 }
 
 func TestConfig_OverrideHeight_SetsWhenNonZero(t *testing.T) {
@@ -33,16 +34,17 @@ func TestConfig_OverrideHeight_SetsWhenNonZero(t *testing.T) {
 	g := NewGomegaWithT(t)
 	cfg := New()
 	cfg.OverrideHeight(1440)
-	g.Expect(*cfg.Height).To(Equal(1440))
+	g.Expect(cfg.ImageSize).NotTo(BeNil())
+	g.Expect(*cfg.ImageSize.Height).To(Equal(1440))
 }
 
 func TestConfig_OverrideHeight_SkipsWhenZero(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 	cfg := New()
-	original := *cfg.Height
+	original := *cfg.ImageSize.Height
 	cfg.OverrideHeight(0)
-	g.Expect(*cfg.Height).To(Equal(original))
+	g.Expect(*cfg.ImageSize.Height).To(Equal(original))
 }
 
 // Treemap overrides

--- a/internal/stages/dimensions.go
+++ b/internal/stages/dimensions.go
@@ -1,6 +1,9 @@
 package stages
 
-import "github.com/theunrepentantgeek/code-visualizer/internal/pipeline"
+import (
+	"github.com/theunrepentantgeek/code-visualizer/internal/config"
+	"github.com/theunrepentantgeek/code-visualizer/internal/pipeline"
+)
 
 // PtrInt safely dereferences *int, returning fallback if nil.
 func PtrInt(p *int, fallback int) int {
@@ -24,8 +27,20 @@ func PtrString(p *string) string {
 // RootConfig, applying the documented defaults (1920x1080).
 func ResolveDimensions[S VizState](s S) error {
 	c := s.Common()
-	c.Width = PtrInt(c.RootConfig.Width, 1920)
-	c.Height = PtrInt(c.RootConfig.Height, 1080)
+
+	var imageSize *config.ImageSize
+	if c.RootConfig != nil {
+		imageSize = c.RootConfig.ImageSize
+	}
+
+	var width, height *int
+	if imageSize != nil {
+		width = imageSize.Width
+		height = imageSize.Height
+	}
+
+	c.Width = PtrInt(width, 1920)
+	c.Height = PtrInt(height, 1080)
 
 	return nil
 }

--- a/internal/stages/scan_test.go
+++ b/internal/stages/scan_test.go
@@ -26,14 +26,10 @@ func TestResolveDimensions_UsesConfigValues(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	g.Expect(os.WriteFile(path, []byte("imageSize:\n  width: 800\n  height: 600\n"), 0o600)).To(Succeed())
-
-	cfg := config.New()
-	g.Expect(cfg.Load(path)).To(Succeed())
-
-	s := &fakeState{common: stages.CommonState{RootConfig: cfg}}
+	width, height := 800, 600
+	s := &fakeState{common: stages.CommonState{
+		RootConfig: &config.Config{ImageSize: &config.ImageSize{Width: &width, Height: &height}},
+	}}
 
 	g.Expect(stages.ResolveDimensions[*fakeState](s)).To(Succeed())
 	g.Expect(s.Common().Width).To(Equal(800))

--- a/internal/stages/scan_test.go
+++ b/internal/stages/scan_test.go
@@ -22,6 +22,17 @@ func TestResolveDimensions_AppliesDefaults(t *testing.T) {
 	g.Expect(s.Common().Height).To(Equal(1080))
 }
 
+func TestResolveDimensions_NilRootConfig_UsesDefaults(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	s := &fakeState{common: stages.CommonState{RootConfig: nil}}
+
+	g.Expect(stages.ResolveDimensions[*fakeState](s)).To(Succeed())
+	g.Expect(s.Common().Width).To(Equal(1920))
+	g.Expect(s.Common().Height).To(Equal(1080))
+}
+
 func TestResolveDimensions_UsesConfigValues(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)

--- a/internal/stages/scan_test.go
+++ b/internal/stages/scan_test.go
@@ -26,10 +26,14 @@ func TestResolveDimensions_UsesConfigValues(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	w, h := 800, 600
-	s := &fakeState{common: stages.CommonState{
-		RootConfig: &config.Config{Width: &w, Height: &h},
-	}}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	g.Expect(os.WriteFile(path, []byte("imageSize:\n  width: 800\n  height: 600\n"), 0o600)).To(Succeed())
+
+	cfg := config.New()
+	g.Expect(cfg.Load(path)).To(Succeed())
+
+	s := &fakeState{common: stages.CommonState{RootConfig: cfg}}
 
 	g.Expect(stages.ResolveDimensions[*fakeState](s)).To(Succeed())
 	g.Expect(s.Common().Width).To(Equal(800))

--- a/samples/codeviz-bubbletree.yml
+++ b/samples/codeviz-bubbletree.yml
@@ -1,5 +1,6 @@
-width: 1920
-height: 1080
+imageSize:
+    width: 1920
+    height: 1080
 treemap: {}
 radial:
     labels: all

--- a/samples/codeviz-radial.yml
+++ b/samples/codeviz-radial.yml
@@ -1,5 +1,6 @@
-width: 1920
-height: 1920
+imageSize:
+    width: 1920
+    height: 1920
 treemap: {}
 radial:
     discSize: file-lines

--- a/samples/codeviz-scatter.yml
+++ b/samples/codeviz-scatter.yml
@@ -1,5 +1,6 @@
-width: 1920
-height: 1080
+imageSize:
+    width: 1920
+    height: 1080
 treemap: {}
 radial:
     labels: all

--- a/samples/codeviz-spiral.yml
+++ b/samples/codeviz-spiral.yml
@@ -1,5 +1,6 @@
-width: 1920
-height: 1920
+imageSize:
+    width: 1920
+    height: 1920
 treemap: {}
 radial:
     labels: all

--- a/samples/codeviz-treemap-config.yaml
+++ b/samples/codeviz-treemap-config.yaml
@@ -1,5 +1,6 @@
-width: 2048
-height: 2048
+imageSize:
+    width: 2048
+    height: 2048
 treemap:
     fill: file-type
     fillPalette: categorization

--- a/samples/codeviz-treemap.yml
+++ b/samples/codeviz-treemap.yml
@@ -1,5 +1,6 @@
-width: 1920
-height: 1080
+imageSize:
+    width: 1920
+    height: 1080
 treemap:
     size: file-lines
     fill:

--- a/samples/test.yaml
+++ b/samples/test.yaml
@@ -1,5 +1,6 @@
-width: 2048
-height: 2048
+imageSize:
+    width: 2048
+    height: 2048
 treemap:
     size: file-lines
     fill: file-freshness


### PR DESCRIPTION
Closes #322

Replaces the top-level `width`/`height` config fields with a structured `imageSize` object:

```yaml
imageSize:
    width: 1920
    height: 1080
```

**Backward compatible**: Old configs with top-level `width`/`height` still load correctly (migrated on load).

Changes:
- Add `ImageSize` struct to config package
- Migrate config image dimension handling to `Config.ImageSize`
- Preserve legacy top-level `width`/`height` during load via compatibility parsing
- Update `ResolveDimensions` stage to read from `ImageSize`
- Update sample configs to use new format
- Update tests for save format, legacy loading, precedence, and default resolution