### PR TITLE
Change default radial labels from 'all' to 'folders'

### DIFF
--- a/internal/radialtree/stages.go
+++ b/internal/radialtree/stages.go
@@ -36,7 +36,7 @@ func resolveLabels(cfg *config.Radial) LabelMode {
 		return LabelMode(lbl)
 	}
 
-	return LabelAll
+	return LabelFoldersOnly
 }
 
 // BuildInksStage builds the radial inks and emits the Rendering image log line.

--- a/internal/radialtree/stages_test.go
+++ b/internal/radialtree/stages_test.go
@@ -44,7 +44,7 @@ func TestResolveRadialMetrics_FillOverridesDiscSizeAsFillMetric(t *testing.T) {
 	g.Expect(common.Requested).To(ContainElements(metric.Name("file-size"), metric.Name("file-type")))
 }
 
-func TestResolveRadialMetrics_LabelsDefaultToAll(t *testing.T) {
+func TestResolveRadialMetrics_LabelsDefaultToFolders(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
@@ -54,7 +54,7 @@ func TestResolveRadialMetrics_LabelsDefaultToAll(t *testing.T) {
 	cfg := &config.Radial{DiscSize: &discSizeStr}
 
 	g.Expect(radialtree.ResolveMetrics(common, viz, cfg)).To(Succeed())
-	g.Expect(viz.Labels).To(Equal(radialtree.LabelAll))
+	g.Expect(viz.Labels).To(Equal(radialtree.LabelFoldersOnly))
 }
 
 func TestResolveRadialMetrics_LabelsNoneExplicit(t *testing.T) {

--- a/samples/codeviz-radial.yml
+++ b/samples/codeviz-radial.yml
@@ -13,7 +13,7 @@ radial:
     border:
         metric: file-freshness
         palette: good-bad
-    labels: all
+    labels: folders
 bubbletree:
     labels: folders
 spiral:


### PR DESCRIPTION
For large codebases, displaying file names is impractical due to insufficient space. This changes the default label mode for radial visualizations to show only folder names, hiding file names by default.

Users can still pass `--labels all` to restore file names.

Closes #391