### PR TITLE
Improve help commands

### DIFF
--- a/cmd/codeviz/bubbletree_cmd.go
+++ b/cmd/codeviz/bubbletree_cmd.go
@@ -16,7 +16,7 @@ type BubbletreeCmd struct {
 	TargetPath string `arg:"" help:"Path to directory to scan."`
 	Output     string `help:"Output image file path (png, jpg, jpeg, svg)." required:"true" short:"o"`
 
-	Size metric.Name `default:"" help:"Metric for circle size; run 'codeviz help-metrics' for available metrics." short:"s"` //nolint:revive,nolintlint // kong struct tags require long lines
+	Size metric.Name `default:"" help:"Metric for circle size; run 'codeviz help metrics' for available metrics." short:"s"` //nolint:revive,nolintlint // kong struct tags require long lines
 
 	Fill config.MetricSpec `help:"Fill colour: metric[,palette] (e.g. file-type,categorization)." optional:"" short:"f"`
 

--- a/cmd/codeviz/help_cmd.go
+++ b/cmd/codeviz/help_cmd.go
@@ -13,6 +13,7 @@ type HelpDefaultCmd struct{}
 func (HelpDefaultCmd) Run(realCtx *kong.Context) error {
 	ctx, err := kong.Trace(realCtx.Kong, nil) // nil path => application root
 	if err != nil {
+		//nolint:wrapcheck // Returning the Kong usage error directly is fine here
 		return err
 	}
 
@@ -20,5 +21,6 @@ func (HelpDefaultCmd) Run(realCtx *kong.Context) error {
 		return ctx.Error
 	}
 
+	//nolint:wrapcheck // Returning the Kong usage error directly is fine here
 	return ctx.PrintUsage(false)
 }

--- a/cmd/codeviz/help_cmd.go
+++ b/cmd/codeviz/help_cmd.go
@@ -1,0 +1,24 @@
+package main
+
+import "github.com/alecthomas/kong"
+
+type HelpCmd struct {
+	Default  HelpDefaultCmd  `cmd:"" hidden:"" default:"1"`
+	Metrics  HelpMetricsCmd  `cmd:"" help:"List all available metrics."`
+	Palettes HelpPalettesCmd `cmd:"" help:"List all available colour palettes."`
+}
+
+type HelpDefaultCmd struct{}
+
+func (HelpDefaultCmd) Run(realCtx *kong.Context) error {
+	ctx, err := kong.Trace(realCtx.Kong, nil) // nil path => application root
+	if err != nil {
+		return err
+	}
+
+	if ctx.Error != nil {
+		return ctx.Error
+	}
+
+	return ctx.PrintUsage(false)
+}

--- a/cmd/codeviz/main.go
+++ b/cmd/codeviz/main.go
@@ -25,10 +25,9 @@ type CLI struct {
 	ExportConfig string `help:"Write effective configuration to file (.yaml, .yml, or .json)." name:"export-config" optional:""`
 	ExportData   string `help:"Write computed metrics to file (.json or .yaml/.yml)." name:"export-data" optional:""`
 
-	Render       RenderCmd       `cmd:"" help:"Render a visualization."`
-	Run          RunCmd          `cmd:"" help:"Run a preset visualization."`
-	HelpMetrics  HelpMetricsCmd  `cmd:"" help:"List all available metrics."`
-	HelpPalettes HelpPalettesCmd `cmd:"" help:"List all available colour palettes."`
+	Render RenderCmd `cmd:"" help:"Render a visualization."`
+	Run    RunCmd    `cmd:"" help:"Run a preset visualization."`
+	Help   HelpCmd   `cmd:"" help:"Show this help message."`
 }
 
 // Flags bundles cross-cutting concerns that are passed to every command's Run method.

--- a/cmd/codeviz/radialtree_cmd.go
+++ b/cmd/codeviz/radialtree_cmd.go
@@ -16,7 +16,7 @@ type RadialCmd struct {
 	TargetPath string `arg:"" help:"Path to directory to scan."`
 	Output     string `help:"Output image file path (png, jpg, jpeg, svg)." required:"true" short:"o"`
 
-	DiscSize metric.Name `default:"" help:"Metric for disc size; run 'codeviz help-metrics' for available metrics." short:"d"` //nolint:revive,nolintlint // kong struct tags require long lines
+	DiscSize metric.Name `default:"" help:"Metric for disc size; run 'codeviz help metrics' for available metrics." short:"d"` //nolint:revive,nolintlint // kong struct tags require long lines
 
 	Fill   config.MetricSpec `help:"Fill colour: metric[,palette] (e.g. file-type,categorization)." optional:"" short:"f"` //nolint:revive,nolintlint // kong struct tags require long lines
 	Border config.MetricSpec `help:"Border colour: metric[,palette] (e.g. file-lines,foliage)." optional:"" short:"b"`     //nolint:revive,nolintlint // kong struct tags require long lines

--- a/cmd/codeviz/scatter_cmd.go
+++ b/cmd/codeviz/scatter_cmd.go
@@ -16,9 +16,9 @@ type ScatterCmd struct {
 	TargetPath string `arg:"" help:"Path to directory to scan."`
 	Output     string `help:"Output image file path (png, jpg, jpeg, svg)." required:"true" short:"o"`
 
-	XAxis metric.Name `default:"" help:"Metric for X-axis position; run 'codeviz help-metrics' for available metrics." name:"x-axis" short:"x"` //nolint:revive,nolintlint // kong struct tags require long lines
-	YAxis metric.Name `default:"" help:"Metric for Y-axis position; run 'codeviz help-metrics' for available metrics." name:"y-axis" short:"y"` //nolint:revive,nolintlint // kong struct tags require long lines
-	Size  metric.Name `default:"" help:"Metric for disc size; run 'codeviz help-metrics' for available metrics." short:"s"`                     //nolint:revive,nolintlint // kong struct tags require long lines
+	XAxis metric.Name `default:"" help:"Metric for X-axis position; run 'codeviz help metrics' for available metrics." name:"x-axis" short:"x"` //nolint:revive,nolintlint // kong struct tags require long lines
+	YAxis metric.Name `default:"" help:"Metric for Y-axis position; run 'codeviz help metrics' for available metrics." name:"y-axis" short:"y"` //nolint:revive,nolintlint // kong struct tags require long lines
+	Size  metric.Name `default:"" help:"Metric for disc size; run 'codeviz help metrics' for available metrics." short:"s"`                     //nolint:revive,nolintlint // kong struct tags require long lines
 
 	Fill   config.MetricSpec `help:"Fill colour: metric[,palette] (e.g. file-type,categorization)." optional:"" short:"f"` //nolint:revive,nolintlint // kong struct tags require long lines
 	Border config.MetricSpec `help:"Border colour: metric[,palette] (e.g. file-lines,foliage)." optional:"" short:"b"`     //nolint:revive,nolintlint // kong struct tags require long lines

--- a/cmd/codeviz/spiral_cmd.go
+++ b/cmd/codeviz/spiral_cmd.go
@@ -18,7 +18,7 @@ type SpiralCmd struct {
 
 	Resolution string `short:"r" help:"Time resolution (hourly or daily)." enum:",hourly,daily" default:""`
 
-	Size metric.Name `default:"" help:"Metric for disc size; run 'codeviz help-metrics' for available metrics." short:"s"` //nolint:revive,nolintlint // kong struct tags require long lines
+	Size metric.Name `default:"" help:"Metric for disc size; run 'codeviz help metrics' for available metrics." short:"s"` //nolint:revive,nolintlint // kong struct tags require long lines
 
 	Fill   config.MetricSpec `help:"Fill colour: metric[,palette] (e.g. file-type,categorization)." optional:"" short:"f"` //nolint:revive,nolintlint // kong struct tags require long lines
 	Border config.MetricSpec `help:"Border colour: metric[,palette] (e.g. file-lines,foliage)." optional:"" short:"b"`     //nolint:revive,nolintlint // kong struct tags require long lines

--- a/cmd/codeviz/treemap_cmd.go
+++ b/cmd/codeviz/treemap_cmd.go
@@ -18,7 +18,7 @@ type TreemapCmd struct {
 	TargetPath string `arg:"" help:"Path to directory to scan."`
 	Output     string `help:"Output image file path (png, jpg, jpeg, svg)." required:"true" short:"o"`
 
-	Size metric.Name `default:"" help:"Metric for rectangle area; run 'codeviz help-metrics' for available metrics." short:"s"` //nolint:revive,nolintlint // kong struct tags require long lines
+	Size metric.Name `default:"" help:"Metric for rectangle area; run 'codeviz help metrics' for available metrics." short:"s"` //nolint:revive,nolintlint // kong struct tags require long lines
 
 	Fill   config.MetricSpec `help:"Fill colour: metric[,palette] (e.g. file-type,categorization)." optional:"" short:"f"` //nolint:revive,nolintlint // kong struct tags require long lines
 	Border config.MetricSpec `help:"Border colour: metric[,palette] (e.g. file-lines,foliage)." optional:"" short:"b"`     //nolint:revive,nolintlint // kong struct tags require long lines


### PR DESCRIPTION
Having `help-palettes` and `help-metrics` was awkward, so these have been restructured.

`codeviz help` - displays normal CLI help
`codeviz help metrics` - displays help about metrics
`codeviz help palettes` - displays help about palettes
