### PR TITLE
Fix git metrics in linked worktrees

### DIFF
--- a/internal/provider/git/service.go
+++ b/internal/provider/git/service.go
@@ -46,7 +46,10 @@ func getService(repoPath string) (*repoService, error) {
 		return result.svc, result.err
 	}
 
-	repo, err := gogit.PlainOpenWithOptions(repoPath, &gogit.PlainOpenOptions{DetectDotGit: true})
+	repo, err := gogit.PlainOpenWithOptions(repoPath, &gogit.PlainOpenOptions{
+		DetectDotGit:          true,
+		EnableDotGitCommonDir: true,
+	})
 	if err != nil {
 		err = eris.Wrap(err, "failed to open git repository")
 		services[repoPath] = &serviceResult{nil, err}

--- a/internal/scan/gitinfo.go
+++ b/internal/scan/gitinfo.go
@@ -9,7 +9,10 @@ import (
 
 // IsGitRepo checks if the given path is inside a git repository.
 func IsGitRepo(path string) (bool, error) {
-	_, err := git.PlainOpenWithOptions(path, &git.PlainOpenOptions{DetectDotGit: true})
+	_, err := git.PlainOpenWithOptions(path, &git.PlainOpenOptions{
+		DetectDotGit:          true,
+		EnableDotGitCommonDir: true,
+	})
 	if err != nil {
 		if errors.Is(err, git.ErrRepositoryNotExists) {
 			return false, nil


### PR DESCRIPTION
Fixes #390

**Problem:** Running codeviz in a git linked worktree (created via `git worktree add`) fails with `failed to get HEAD` because go-git couldn't resolve references.

**Root cause:** `PlainOpenWithOptions` was not configured to follow the `commondir` pointer. In a linked worktree, refs and objects live in the common directory (the main `.git/`), but go-git was only searching the worktree-specific git dir.

**Fix:** Enable `EnableDotGitCommonDir: true` in both `PlainOpenWithOptions` call sites. This is go-git's built-in mechanism that routes filesystem reads to the correct location based on git's repository-layout spec.