### PR TITLE
feat(scatter): logarithmic axis scales (#396)

### DIFF
--- a/cmd/codeviz/scatter_cmd.go
+++ b/cmd/codeviz/scatter_cmd.go
@@ -20,6 +20,9 @@ type ScatterCmd struct {
 	YAxis metric.Name `default:"" help:"Metric for Y-axis position; run 'codeviz help metrics' for available metrics." name:"y-axis" short:"y"` //nolint:revive,nolintlint // kong struct tags require long lines
 	Size  metric.Name `default:"" help:"Metric for disc size; run 'codeviz help metrics' for available metrics." short:"s"`                     //nolint:revive,nolintlint // kong struct tags require long lines
 
+	XScale string `default:"" enum:",linear,log" help:"X-axis scale (linear or log)." name:"x-scale"` //nolint:revive,nolintlint // kong struct tags require long lines
+	YScale string `default:"" enum:",linear,log" help:"Y-axis scale (linear or log)." name:"y-scale"` //nolint:revive,nolintlint // kong struct tags require long lines
+
 	Fill   config.MetricSpec `help:"Fill colour: metric[,palette] (e.g. file-type,categorization)." optional:"" short:"f"` //nolint:revive,nolintlint // kong struct tags require long lines
 	Border config.MetricSpec `help:"Border colour: metric[,palette] (e.g. file-lines,foliage)." optional:"" short:"b"`     //nolint:revive,nolintlint // kong struct tags require long lines
 
@@ -155,6 +158,8 @@ func (c *ScatterCmd) applyOverrides(cfg *config.Config) {
 	cfg.Scatter.OverrideXAxis(string(c.XAxis))
 	cfg.Scatter.OverrideYAxis(string(c.YAxis))
 	cfg.Scatter.OverrideSize(string(c.Size))
+	cfg.Scatter.OverrideXScale(c.XScale)
+	cfg.Scatter.OverrideYScale(c.YScale)
 	cfg.Scatter.OverrideFill(c.Fill)
 	cfg.Scatter.OverrideBorder(c.Border)
 	cfg.OverrideLegendPosition(c.Legend)

--- a/docs/superpowers/plans/2026-06-13-scatter-log-axis.md
+++ b/docs/superpowers/plans/2026-06-13-scatter-log-axis.md
@@ -1,0 +1,723 @@
+# Scatter Logarithmic Axis Scales Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add per-axis logarithmic scale options (`--x-scale=log`, `--y-scale=log`) to scatter visualizations so clustered low-range data spreads out.
+
+**Architecture:** Add `ScaleType` (Linear/Log) to `AxisSpec`. Thread the scale through config → CLI → axis resolution → tick generation → position mapping. Log positioning uses `ln(value)` normalized to [0,1]; tick labels show original values. Validate all values positive when log is active.
+
+**Tech Stack:** Go 1.26.1 + Kong (CLI), Gomega (assertions), existing `internal/scatter` axis resolution code.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `internal/scatter/axis.go` | Modify | Add `ScaleType` type and constants; add `Scale` field to `AxisSpec` |
+| `internal/config/scatter.go` | Modify | Add `XScale`/`YScale` fields + override methods |
+| `cmd/codeviz/scatter_cmd.go` | Modify | Add `--x-scale`/`--y-scale` CLI flags; wire overrides |
+| `internal/scatter/axis_resolve.go` | Modify | Add `logNumericTicks`; branch `resolveAxis` and `positionForValue` on scale |
+| `internal/scatter/resolved_axis.go` | Modify | Add `Scale` field to `NumericAxis` |
+| `internal/scatter/stages.go` | Modify | Parse scale from config in `resolveAxisSpec`; add `validateLogScale` |
+| `internal/scatter/layout_test.go` | Modify | Add tests for log tick generation, log positioning, validation |
+| `internal/scatter/stages_test.go` | Modify | Add test for scale parsing in `ResolveMetrics` |
+
+---
+
+### Task 1: Add ScaleType and Config Fields
+
+**Files:**
+- Modify: `internal/scatter/axis.go`
+- Modify: `internal/config/scatter.go`
+
+- [ ] **Step 1: Add `ScaleType` to `axis.go`**
+
+Add after the `AxisBand` struct at the end of `internal/scatter/axis.go`:
+
+```go
+// ScaleType controls how numeric values are mapped to axis positions.
+type ScaleType int
+
+const (
+	Linear ScaleType = iota
+	Log
+)
+```
+
+Add a `Scale` field to `AxisSpec`:
+
+```go
+type AxisSpec struct {
+	Metric metric.Name
+	Kind   metric.Kind
+	Scale  ScaleType
+}
+```
+
+- [ ] **Step 2: Add `Scale` field to `NumericAxis`**
+
+In `internal/scatter/resolved_axis.go`, add `Scale ScaleType` to `NumericAxis`:
+
+```go
+type NumericAxis struct {
+	Min   float64
+	Max   float64
+	Scale ScaleType
+	Ticks []AxisTick
+}
+```
+
+- [ ] **Step 3: Add config fields**
+
+In `internal/config/scatter.go`, add after the `Border` field:
+
+```go
+XScale *string `yaml:"xScale,omitempty" json:"xScale,omitempty"`
+YScale *string `yaml:"yScale,omitempty" json:"yScale,omitempty"`
+```
+
+Add override methods:
+
+```go
+// OverrideXScale sets XScale to v if v is non-empty.
+func (s *Scatter) OverrideXScale(v string) { overrideString(&s.XScale, v) }
+
+// OverrideYScale sets YScale to v if v is non-empty.
+func (s *Scatter) OverrideYScale(v string) { overrideString(&s.YScale, v) }
+```
+
+- [ ] **Step 4: Verify build**
+
+Run: `task build`
+Expected: clean compile (no test changes needed yet — `Scale` zero-value is `Linear`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/scatter/axis.go internal/scatter/resolved_axis.go internal/config/scatter.go
+git commit -m "feat(scatter): add ScaleType and config fields for log axis (#396)"
+```
+
+---
+
+### Task 2: Wire CLI Flags and Config Parsing
+
+**Files:**
+- Modify: `cmd/codeviz/scatter_cmd.go`
+- Modify: `internal/scatter/stages.go`
+
+- [ ] **Step 1: Add CLI flags to `ScatterCmd`**
+
+In `cmd/codeviz/scatter_cmd.go`, add after the `Size` field:
+
+```go
+XScale string `default:"" enum:",linear,log" help:"X-axis scale (linear or log)." name:"x-scale"` //nolint:revive,nolintlint // kong struct tags require long lines
+YScale string `default:"" enum:",linear,log" help:"Y-axis scale (linear or log)." name:"y-scale"` //nolint:revive,nolintlint // kong struct tags require long lines
+```
+
+- [ ] **Step 2: Wire overrides in `applyOverrides`**
+
+In `cmd/codeviz/scatter_cmd.go`, in `applyOverrides`, add after `cfg.Scatter.OverrideSize(string(c.Size))`:
+
+```go
+cfg.Scatter.OverrideXScale(c.XScale)
+cfg.Scatter.OverrideYScale(c.YScale)
+```
+
+- [ ] **Step 3: Parse scale in `resolveAxisSpec`**
+
+In `internal/scatter/stages.go`, change `resolveAxisSpec` to accept a scale string:
+
+```go
+func resolveAxisSpec(name *string, scale *string) (AxisSpec, error) {
+	metricName := metric.Name(stages.PtrString(name))
+	descriptor, ok := provider.GetDescriptor(metricName)
+
+	if !ok {
+		return AxisSpec{}, eris.Errorf("unknown axis metric %q", metricName)
+	}
+
+	spec := AxisSpec{Metric: metricName, Kind: descriptor.Kind}
+
+	switch stages.PtrString(scale) {
+	case "", "linear":
+		spec.Scale = Linear
+	case "log":
+		spec.Scale = Log
+	default:
+		return AxisSpec{}, eris.Errorf("unknown scale %q; must be \"linear\" or \"log\"", stages.PtrString(scale))
+	}
+
+	return spec, nil
+}
+```
+
+- [ ] **Step 4: Update `ResolveMetrics` callers**
+
+In `internal/scatter/stages.go`, update the two calls to `resolveAxisSpec` in `ResolveMetrics`:
+
+```go
+xAxis, err := resolveAxisSpec(cfg.XAxis, cfg.XScale)
+```
+
+```go
+yAxis, err := resolveAxisSpec(cfg.YAxis, cfg.YScale)
+```
+
+- [ ] **Step 5: Verify build and existing tests pass**
+
+Run: `task build && task test`
+Expected: all pass (existing tests use `nil` scale which maps to `Linear`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/codeviz/scatter_cmd.go internal/scatter/stages.go
+git commit -m "feat(scatter): wire --x-scale/--y-scale CLI flags through config (#396)"
+```
+
+---
+
+### Task 3: Add Scale Parsing Test
+
+**Files:**
+- Modify: `internal/scatter/stages_test.go`
+
+- [ ] **Step 1: Write test for log scale parsing**
+
+Add to `internal/scatter/stages_test.go`:
+
+```go
+func TestResolveMetrics_ParsesLogScale(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	common := &stages.CommonState{}
+	viz := &scatter.State{}
+	cfg := &config.Scatter{
+		XAxis:  new("file-lines"),
+		YAxis:  new("file-size"),
+		Size:   new("file-size"),
+		XScale: new("log"),
+		YScale: new("linear"),
+	}
+
+	err := scatter.ResolveMetrics(common, viz, cfg)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(viz.XAxis.Scale).To(Equal(scatter.Log))
+	g.Expect(viz.YAxis.Scale).To(Equal(scatter.Linear))
+}
+```
+
+- [ ] **Step 2: Run and verify test passes**
+
+Run: `go test -run TestResolveMetrics_ParsesLogScale ./internal/scatter/ -count=1 -v`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/scatter/stages_test.go
+git commit -m "test(scatter): add test for log scale parsing in ResolveMetrics (#396)"
+```
+
+---
+
+### Task 4: Implement Log Tick Generation
+
+**Files:**
+- Modify: `internal/scatter/axis_resolve.go`
+- Modify: `internal/scatter/layout_test.go`
+
+- [ ] **Step 1: Write failing test for `logNumericTicks`**
+
+Add to `internal/scatter/layout_test.go`:
+
+```go
+func TestLogNumericTicks_SpansMultipleDecades(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	plot := PlotRect{X: 0, Y: 0, W: 800, H: 600}
+	ticks := logNumericTicks(1, 10000, plot, horizontalAxis)
+
+	// Expect ticks at powers of 10: 1, 10, 100, 1000, 10000
+	g.Expect(ticks).To(HaveLen(5))
+	g.Expect(ticks[0].Value).To(BeNumerically("~", 1, 1e-9))
+	g.Expect(ticks[1].Value).To(BeNumerically("~", 10, 1e-9))
+	g.Expect(ticks[2].Value).To(BeNumerically("~", 100, 1e-9))
+	g.Expect(ticks[3].Value).To(BeNumerically("~", 1000, 1e-9))
+	g.Expect(ticks[4].Value).To(BeNumerically("~", 10000, 1e-9))
+
+	// Positions should be logarithmically spaced (equal increments in log space)
+	for i := 1; i < len(ticks); i++ {
+		g.Expect(ticks[i].Position).To(BeNumerically(">", ticks[i-1].Position))
+	}
+
+	// Each gap should be the same size (equal decades = equal spacing)
+	gap := ticks[1].Position - ticks[0].Position
+	for i := 2; i < len(ticks); i++ {
+		g.Expect(ticks[i].Position - ticks[i-1].Position).To(BeNumerically("~", gap, 1e-6))
+	}
+}
+
+func TestLogNumericTicks_NarrowRange_AddsIntermediateTicks(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	plot := PlotRect{X: 0, Y: 0, W: 800, H: 600}
+	ticks := logNumericTicks(50, 500, plot, horizontalAxis)
+
+	// Range spans ~1 decade, so intermediate ticks (2x, 5x) are added.
+	// Expect at least 4 ticks.
+	g.Expect(len(ticks)).To(BeNumerically(">=", 4))
+
+	// All tick values should be within [50, 500]
+	for _, tick := range ticks {
+		g.Expect(tick.Value).To(BeNumerically(">=", 50))
+		g.Expect(tick.Value).To(BeNumerically("<=", 500))
+	}
+
+	// Positions should be monotonically increasing
+	for i := 1; i < len(ticks); i++ {
+		g.Expect(ticks[i].Position).To(BeNumerically(">", ticks[i-1].Position))
+	}
+}
+
+func TestLogNumericTicks_SingleValue_ReturnsCenterTick(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	plot := PlotRect{X: 0, Y: 0, W: 800, H: 600}
+	ticks := logNumericTicks(42, 42, plot, horizontalAxis)
+
+	g.Expect(ticks).To(HaveLen(1))
+	g.Expect(ticks[0].Value).To(BeNumerically("~", 42, 1e-9))
+	g.Expect(ticks[0].Position).To(BeNumerically("~", 400, 1e-6)) // center of 800-wide plot
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -run TestLogNumericTicks ./internal/scatter/ -count=1 -v 2>&1 | tail -10`
+Expected: FAIL — `logNumericTicks` undefined.
+
+- [ ] **Step 3: Implement `logNumericTicks`**
+
+Add to `internal/scatter/axis_resolve.go`:
+
+```go
+func logNumericTicks(minValue, maxValue float64, plot PlotRect, direction axisDirection) []AxisTick {
+	if minValue == maxValue {
+		return []AxisTick{{
+			Value:    minValue,
+			Label:    formatTick(minValue, 0),
+			Position: direction.center(plot),
+		}}
+	}
+
+	logMin := math.Log(minValue)
+	logMax := math.Log(maxValue)
+
+	// Collect candidate tick values at powers of 10 within [minValue, maxValue]
+	candidates := logTickCandidates(minValue, maxValue)
+
+	// If fewer than 4 ticks, add 2x and 5x intermediate values per decade
+	if len(candidates) < 4 {
+		candidates = logTickCandidatesWithSubdivisions(minValue, maxValue)
+	}
+
+	ticks := make([]AxisTick, 0, len(candidates))
+	for _, value := range candidates {
+		norm := (math.Log(value) - logMin) / (logMax - logMin)
+		ticks = append(ticks, AxisTick{
+			Value:    value,
+			Label:    formatTick(value, 0),
+			Position: direction.position(plot, norm),
+		})
+	}
+
+	return ticks
+}
+
+// logTickCandidates returns powers of 10 within [minValue, maxValue].
+func logTickCandidates(minValue, maxValue float64) []float64 {
+	startExp := math.Floor(math.Log10(minValue))
+	endExp := math.Ceil(math.Log10(maxValue))
+
+	candidates := make([]float64, 0, int(endExp-startExp)+1)
+	for exp := startExp; exp <= endExp; exp++ {
+		value := math.Pow(10, exp)
+		if value >= minValue && value <= maxValue {
+			candidates = append(candidates, value)
+		}
+	}
+
+	return candidates
+}
+
+// logTickCandidatesWithSubdivisions returns powers of 10 plus 2x and 5x
+// subdivisions within [minValue, maxValue].
+func logTickCandidatesWithSubdivisions(minValue, maxValue float64) []float64 {
+	startExp := math.Floor(math.Log10(minValue))
+	endExp := math.Ceil(math.Log10(maxValue))
+	multipliers := []float64{1, 2, 5}
+
+	candidates := make([]float64, 0, int(endExp-startExp)*3+1)
+	for exp := startExp; exp <= endExp; exp++ {
+		base := math.Pow(10, exp)
+		for _, m := range multipliers {
+			value := base * m
+			if value >= minValue && value <= maxValue {
+				candidates = append(candidates, value)
+			}
+		}
+	}
+
+	return candidates
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -run TestLogNumericTicks ./internal/scatter/ -count=1 -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/scatter/axis_resolve.go internal/scatter/layout_test.go
+git commit -m "feat(scatter): implement logNumericTicks with decade/subdivision ticks (#396)"
+```
+
+---
+
+### Task 5: Branch `resolveAxis` and `positionForValue` on Scale
+
+**Files:**
+- Modify: `internal/scatter/axis_resolve.go`
+- Modify: `internal/scatter/layout_test.go`
+
+- [ ] **Step 1: Write failing test for log positioning**
+
+Add to `internal/scatter/layout_test.go`:
+
+```go
+func TestLayout_LogScalePositionsPointsLogarithmically(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	small := scatterTestFile("small.go")
+	small.SetQuantity(filesystem.FileLines, 10)
+	small.SetQuantity(filesystem.FileSize, 100)
+
+	medium := scatterTestFile("medium.go")
+	medium.SetQuantity(filesystem.FileLines, 100)
+	medium.SetQuantity(filesystem.FileSize, 100)
+
+	large := scatterTestFile("large.go")
+	large.SetQuantity(filesystem.FileLines, 1000)
+	large.SetQuantity(filesystem.FileSize, 100)
+
+	root := &model.Directory{Files: []*model.File{small, medium, large}}
+	xAxis := AxisSpec{Metric: filesystem.FileLines, Kind: metric.Quantity, Scale: Log}
+	yAxis := AxisSpec{Metric: filesystem.FileSize, Kind: metric.Quantity, Scale: Linear}
+
+	dataset := CollectDataset(root, xAxis, yAxis, filesystem.FileSize)
+	layout := Layout(dataset, 800, 600, xAxis, yAxis)
+
+	points := map[string]ScatterPoint{}
+	for _, point := range layout.Points {
+		points[point.File.Name] = point
+	}
+
+	// With log scale, the gap between 10→100 should equal the gap between 100→1000
+	// (both are one decade)
+	gap1 := points["medium.go"].X - points["small.go"].X
+	gap2 := points["large.go"].X - points["medium.go"].X
+	g.Expect(gap1).To(BeNumerically("~", gap2, 1.0))
+
+	// All X values should be within the plot area
+	g.Expect(points["small.go"].X).To(BeNumerically(">=", scatterPlotLeftMargin))
+	g.Expect(points["large.go"].X).To(BeNumerically("<=", 800-scatterPlotRightMargin))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run TestLayout_LogScalePositionsPointsLogarithmically ./internal/scatter/ -count=1 -v 2>&1 | tail -10`
+Expected: FAIL — log scale not yet used in `resolveAxis`/`positionForValue`.
+
+- [ ] **Step 3: Update `resolveAxis` to branch on scale**
+
+In `internal/scatter/axis_resolve.go`, modify `resolveAxis`:
+
+```go
+func resolveAxis(points []PointDatum, plot PlotRect, spec AxisSpec, direction axisDirection) ResolvedAxis {
+	axis := ResolvedAxis{Spec: spec, Title: string(spec.Metric)}
+	if spec.Kind == metric.Classification {
+		axis.Categorical = &CategoricalAxis{Bands: categoricalBands(points, plot, direction)}
+
+		return axis
+	}
+
+	minValue, maxValue := numericExtent(points, direction)
+
+	if spec.Scale == Log {
+		axis.Numeric = &NumericAxis{
+			Min:   minValue,
+			Max:   maxValue,
+			Scale: Log,
+			Ticks: logNumericTicks(minValue, maxValue, plot, direction),
+		}
+	} else {
+		axis.Numeric = &NumericAxis{
+			Min:   minValue,
+			Max:   maxValue,
+			Scale: Linear,
+			Ticks: numericTicks(minValue, maxValue, plot, direction),
+		}
+	}
+
+	return axis
+}
+```
+
+- [ ] **Step 4: Update `positionForValue` for log scale**
+
+In `internal/scatter/axis_resolve.go`, modify `positionForValue`:
+
+```go
+func positionForValue(value AxisValue, axis ResolvedAxis, plot PlotRect, direction axisDirection) float64 {
+	if axis.Categorical != nil {
+		for _, band := range axis.Categorical.Bands {
+			if band.Label == value.Category {
+				return band.Center
+			}
+		}
+
+		return direction.center(plot)
+	}
+
+	minValue := axis.Numeric.Min
+	maxValue := axis.Numeric.Max
+
+	if minValue == maxValue {
+		return direction.center(plot)
+	}
+
+	var norm float64
+	if axis.Numeric.Scale == Log {
+		norm = (math.Log(value.Numeric) - math.Log(minValue)) / (math.Log(maxValue) - math.Log(minValue))
+	} else {
+		norm = (value.Numeric - minValue) / (maxValue - minValue)
+	}
+
+	return direction.position(plot, norm)
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `go test -run TestLayout_LogScalePositionsPointsLogarithmically ./internal/scatter/ -count=1 -v`
+Expected: PASS
+
+- [ ] **Step 6: Run all tests to verify nothing is broken**
+
+Run: `task test`
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/scatter/axis_resolve.go internal/scatter/layout_test.go
+git commit -m "feat(scatter): branch resolveAxis and positionForValue on log scale (#396)"
+```
+
+---
+
+### Task 6: Add Log Scale Validation
+
+**Files:**
+- Modify: `internal/scatter/stages.go`
+- Modify: `internal/scatter/layout_test.go`
+
+- [ ] **Step 1: Write failing test for validation**
+
+Add to `internal/scatter/layout_test.go`:
+
+```go
+func TestValidateLogScale_ErrorsOnZeroValue(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	zero := scatterTestFile("zero.go")
+	zero.SetQuantity(filesystem.FileLines, 0)
+	zero.SetQuantity(filesystem.FileSize, 100)
+
+	positive := scatterTestFile("positive.go")
+	positive.SetQuantity(filesystem.FileLines, 10)
+	positive.SetQuantity(filesystem.FileSize, 50)
+
+	root := &model.Directory{Files: []*model.File{zero, positive}}
+	xAxis := AxisSpec{Metric: filesystem.FileLines, Kind: metric.Quantity, Scale: Log}
+	yAxis := AxisSpec{Metric: filesystem.FileSize, Kind: metric.Quantity, Scale: Linear}
+
+	dataset := CollectDataset(root, xAxis, yAxis, filesystem.FileSize)
+
+	err := ValidateLogScale(dataset, xAxis, yAxis)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("x-axis"))
+	g.Expect(err.Error()).To(ContainSubstring("zero.go"))
+}
+
+func TestValidateLogScale_PassesWhenAllPositive(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	a := scatterTestFile("a.go")
+	a.SetQuantity(filesystem.FileLines, 10)
+	a.SetQuantity(filesystem.FileSize, 100)
+
+	b := scatterTestFile("b.go")
+	b.SetQuantity(filesystem.FileLines, 200)
+	b.SetQuantity(filesystem.FileSize, 50)
+
+	root := &model.Directory{Files: []*model.File{a, b}}
+	xAxis := AxisSpec{Metric: filesystem.FileLines, Kind: metric.Quantity, Scale: Log}
+	yAxis := AxisSpec{Metric: filesystem.FileSize, Kind: metric.Quantity, Scale: Log}
+
+	dataset := CollectDataset(root, xAxis, yAxis, filesystem.FileSize)
+
+	err := ValidateLogScale(dataset, xAxis, yAxis)
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+func TestValidateLogScale_SkipsLinearAxes(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	zero := scatterTestFile("zero.go")
+	zero.SetQuantity(filesystem.FileLines, 0)
+	zero.SetQuantity(filesystem.FileSize, 100)
+
+	root := &model.Directory{Files: []*model.File{zero}}
+	xAxis := AxisSpec{Metric: filesystem.FileLines, Kind: metric.Quantity, Scale: Linear}
+	yAxis := AxisSpec{Metric: filesystem.FileSize, Kind: metric.Quantity, Scale: Linear}
+
+	dataset := CollectDataset(root, xAxis, yAxis, filesystem.FileSize)
+
+	err := ValidateLogScale(dataset, xAxis, yAxis)
+	g.Expect(err).NotTo(HaveOccurred())
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -run TestValidateLogScale ./internal/scatter/ -count=1 -v 2>&1 | tail -10`
+Expected: FAIL — `ValidateLogScale` undefined.
+
+- [ ] **Step 3: Implement `ValidateLogScale`**
+
+Add to `internal/scatter/stages.go`:
+
+```go
+// ValidateLogScale checks that all data values are positive when log scale is used.
+func ValidateLogScale(dataset Dataset, xAxis, yAxis AxisSpec) error {
+	if xAxis.Scale == Log {
+		for _, point := range dataset.Points {
+			if point.X.Numeric <= 0 {
+				return eris.Errorf(
+					"log scale on x-axis requires all values to be positive; file %q has value %g",
+					point.File.Name, point.X.Numeric,
+				)
+			}
+		}
+	}
+
+	if yAxis.Scale == Log {
+		for _, point := range dataset.Points {
+			if point.Y.Numeric <= 0 {
+				return eris.Errorf(
+					"log scale on y-axis requires all values to be positive; file %q has value %g",
+					point.File.Name, point.Y.Numeric,
+				)
+			}
+		}
+	}
+
+	return nil
+}
+```
+
+- [ ] **Step 4: Call `ValidateLogScale` from `BuildInksStage`**
+
+In `internal/scatter/stages.go`, in `BuildInksStage`, add after the `CollectDataset` call:
+
+```go
+func BuildInksStage(c *stages.CommonState, x *State) error {
+	x.Dataset = CollectDataset(c.Root, x.XAxis, x.YAxis, x.Size)
+
+	if err := ValidateLogScale(x.Dataset, x.XAxis, x.YAxis); err != nil {
+		return err
+	}
+
+	x.Inks = BuildInks(x.Dataset, x.FillMetric, x.FillPalette, x.BorderMetric, x.BorderPalette)
+
+	slog.Info("Rendering image", "output", c.Output, "width", c.Width, "height", c.Height)
+
+	return nil
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test -run TestValidateLogScale ./internal/scatter/ -count=1 -v`
+Expected: PASS
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `task test`
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/scatter/stages.go internal/scatter/layout_test.go
+git commit -m "feat(scatter): validate positive values required for log scale axes (#396)"
+```
+
+---
+
+### Task 7: Final Verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full CI checks**
+
+Run: `task ci`
+Expected: build, test, lint all pass.
+
+- [ ] **Step 2: Verify sample config works with log scale**
+
+Run:
+```bash
+go run ./cmd/codeviz scatter . -o /tmp/scatter-log-test.png \
+  --x-axis file-size --y-axis file-lines --size file-size \
+  --x-scale log --y-scale log
+```
+Expected: produces `/tmp/scatter-log-test.png` without errors (some files may be skipped if they have 0 lines — that's an expected validation error which tells us the feature works).
+
+If validation errors about zero values, run with only `--x-scale log` on a metric known to be positive (e.g., `file-size`):
+
+```bash
+go run ./cmd/codeviz scatter . -o /tmp/scatter-log-test.png \
+  --x-axis file-size --y-axis file-lines --size file-size \
+  --x-scale log
+```
+
+- [ ] **Step 3: Verify help output includes new flags**
+
+Run: `go run ./cmd/codeviz scatter --help 2>&1 | grep -A1 'scale'`
+Expected: shows `--x-scale` and `--y-scale` with `linear` and `log` enum values.

--- a/internal/config/scatter.go
+++ b/internal/config/scatter.go
@@ -9,6 +9,8 @@ type Scatter struct {
 	Size   *string     `yaml:"size,omitempty"              json:"size,omitempty"`
 	Fill   *MetricSpec `yaml:"fill,omitempty"              json:"fill,omitempty"`
 	Border *MetricSpec `yaml:"border,omitempty"            json:"border,omitempty"`
+	XScale *string     `yaml:"xScale,omitempty"            json:"xScale,omitempty"`
+	YScale *string     `yaml:"yScale,omitempty"            json:"yScale,omitempty"`
 }
 
 // OverrideXAxis sets XAxis to v if v is non-empty.
@@ -25,3 +27,9 @@ func (s *Scatter) OverrideFill(v MetricSpec) { overrideMetricSpec(&s.Fill, v) }
 
 // OverrideBorder sets Border to v if v is non-zero.
 func (s *Scatter) OverrideBorder(v MetricSpec) { overrideMetricSpec(&s.Border, v) }
+
+// OverrideXScale sets XScale to v if v is non-empty.
+func (s *Scatter) OverrideXScale(v string) { overrideString(&s.XScale, v) }
+
+// OverrideYScale sets YScale to v if v is non-empty.
+func (s *Scatter) OverrideYScale(v string) { overrideString(&s.YScale, v) }

--- a/internal/scatter/axis.go
+++ b/internal/scatter/axis.go
@@ -2,14 +2,6 @@ package scatter
 
 import "github.com/theunrepentantgeek/code-visualizer/internal/metric"
 
-// ScaleType controls how numeric values are mapped to axis positions.
-type ScaleType int
-
-const (
-	Linear ScaleType = iota
-	Log
-)
-
 // AxisSpec identifies the metric and kind used for one scatter axis.
 type AxisSpec struct {
 	Metric metric.Name

--- a/internal/scatter/axis.go
+++ b/internal/scatter/axis.go
@@ -2,10 +2,19 @@ package scatter
 
 import "github.com/theunrepentantgeek/code-visualizer/internal/metric"
 
+// ScaleType controls how numeric values are mapped to axis positions.
+type ScaleType int
+
+const (
+	Linear ScaleType = iota
+	Log
+)
+
 // AxisSpec identifies the metric and kind used for one scatter axis.
 type AxisSpec struct {
 	Metric metric.Name
 	Kind   metric.Kind
+	Scale  ScaleType
 }
 
 // AxisValue carries one file's resolved value for a scatter axis.

--- a/internal/scatter/axis_resolve.go
+++ b/internal/scatter/axis_resolve.go
@@ -336,3 +336,73 @@ func (d axisDirection) categoryValue(point PointDatum) string {
 
 	return point.Y.Category
 }
+
+func logNumericTicks(minValue, maxValue float64, plot PlotRect, direction axisDirection) []AxisTick {
+	if minValue == maxValue {
+		return []AxisTick{{
+			Value:    minValue,
+			Label:    formatTick(minValue, 0),
+			Position: direction.center(plot),
+		}}
+	}
+
+	logMin := math.Log(minValue)
+	logMax := math.Log(maxValue)
+
+	// Collect candidate tick values at powers of 10 within [minValue, maxValue]
+	candidates := logTickCandidates(minValue, maxValue)
+
+	// If fewer than 4 ticks, add 2x and 5x intermediate values per decade
+	if len(candidates) < 4 {
+		candidates = logTickCandidatesWithSubdivisions(minValue, maxValue)
+	}
+
+	ticks := make([]AxisTick, 0, len(candidates))
+	for _, value := range candidates {
+		norm := (math.Log(value) - logMin) / (logMax - logMin)
+		ticks = append(ticks, AxisTick{
+			Value:    value,
+			Label:    formatTick(value, 0),
+			Position: direction.position(plot, norm),
+		})
+	}
+
+	return ticks
+}
+
+// logTickCandidates returns powers of 10 within [minValue, maxValue].
+func logTickCandidates(minValue, maxValue float64) []float64 {
+	startExp := math.Floor(math.Log10(minValue))
+	endExp := math.Ceil(math.Log10(maxValue))
+
+	candidates := make([]float64, 0, int(endExp-startExp)+1)
+	for exp := startExp; exp <= endExp; exp++ {
+		value := math.Pow(10, exp)
+		if value >= minValue && value <= maxValue {
+			candidates = append(candidates, value)
+		}
+	}
+
+	return candidates
+}
+
+// logTickCandidatesWithSubdivisions returns powers of 10 plus 2x and 5x
+// subdivisions within [minValue, maxValue].
+func logTickCandidatesWithSubdivisions(minValue, maxValue float64) []float64 {
+	startExp := math.Floor(math.Log10(minValue))
+	endExp := math.Ceil(math.Log10(maxValue))
+	multipliers := []float64{1, 2, 5}
+
+	candidates := make([]float64, 0, int(endExp-startExp)*3+1)
+	for exp := startExp; exp <= endExp; exp++ {
+		base := math.Pow(10, exp)
+		for _, m := range multipliers {
+			value := base * m
+			if value >= minValue && value <= maxValue {
+				candidates = append(candidates, value)
+			}
+		}
+	}
+
+	return candidates
+}

--- a/internal/scatter/axis_resolve.go
+++ b/internal/scatter/axis_resolve.go
@@ -373,9 +373,9 @@ func logNumericTicks(minValue, maxValue float64, plot PlotRect, direction axisDi
 		candidates = logTickCandidatesWithSubdivisions(minValue, maxValue)
 	}
 
-	// Fallback: if still no candidates (narrow sub-decade range), generate
+	// Fallback: if still too few candidates (narrow sub-decade range), generate
 	// evenly-spaced ticks in log space using the endpoints and midpoints
-	if len(candidates) == 0 {
+	if len(candidates) < 4 {
 		candidates = logTickFallback(minValue, maxValue)
 	}
 

--- a/internal/scatter/axis_resolve.go
+++ b/internal/scatter/axis_resolve.go
@@ -373,6 +373,12 @@ func logNumericTicks(minValue, maxValue float64, plot PlotRect, direction axisDi
 		candidates = logTickCandidatesWithSubdivisions(minValue, maxValue)
 	}
 
+	// Fallback: if still no candidates (narrow sub-decade range), generate
+	// evenly-spaced ticks in log space using the endpoints and midpoints
+	if len(candidates) == 0 {
+		candidates = logTickFallback(minValue, maxValue)
+	}
+
 	ticks := make([]AxisTick, 0, len(candidates))
 	for _, value := range candidates {
 		norm := (math.Log(value) - logMin) / (logMax - logMin)
@@ -384,6 +390,23 @@ func logNumericTicks(minValue, maxValue float64, plot PlotRect, direction axisDi
 	}
 
 	return ticks
+}
+
+const logFallbackTicks = 5
+
+// logTickFallback generates tick values evenly spaced in log space for narrow
+// ranges where no standard power-of-10 or subdivision candidates exist.
+func logTickFallback(minValue, maxValue float64) []float64 {
+	logMin := math.Log(minValue)
+	logMax := math.Log(maxValue)
+	candidates := make([]float64, logFallbackTicks)
+
+	for i := range logFallbackTicks {
+		t := float64(i) / float64(logFallbackTicks-1)
+		candidates[i] = math.Exp(logMin + t*(logMax-logMin))
+	}
+
+	return candidates
 }
 
 // logTickCandidates returns powers of 10 within [minValue, maxValue].

--- a/internal/scatter/axis_resolve.go
+++ b/internal/scatter/axis_resolve.go
@@ -32,10 +32,21 @@ func resolveAxis(points []PointDatum, plot PlotRect, spec AxisSpec, direction ax
 	}
 
 	minValue, maxValue := numericExtent(points, direction)
-	axis.Numeric = &NumericAxis{
-		Min:   minValue,
-		Max:   maxValue,
-		Ticks: numericTicks(minValue, maxValue, plot, direction),
+
+	if spec.Scale == Log {
+		axis.Numeric = &NumericAxis{
+			Min:   minValue,
+			Max:   maxValue,
+			Scale: Log,
+			Ticks: logNumericTicks(minValue, maxValue, plot, direction),
+		}
+	} else {
+		axis.Numeric = &NumericAxis{
+			Min:   minValue,
+			Max:   maxValue,
+			Scale: Linear,
+			Ticks: numericTicks(minValue, maxValue, plot, direction),
+		}
 	}
 
 	return axis
@@ -284,7 +295,12 @@ func positionForValue(value AxisValue, axis ResolvedAxis, plot PlotRect, directi
 		return direction.center(plot)
 	}
 
-	norm := (value.Numeric - minValue) / (maxValue - minValue)
+	var norm float64
+	if axis.Numeric.Scale == Log {
+		norm = (math.Log(value.Numeric) - math.Log(minValue)) / (math.Log(maxValue) - math.Log(minValue))
+	} else {
+		norm = (value.Numeric - minValue) / (maxValue - minValue)
+	}
 
 	return direction.position(plot, norm)
 }

--- a/internal/scatter/layout_test.go
+++ b/internal/scatter/layout_test.go
@@ -288,3 +288,42 @@ func TestLogNumericTicks_SingleValue_ReturnsCenterTick(t *testing.T) {
 	g.Expect(ticks[0].Value).To(BeNumerically("~", 42, 1e-9))
 	g.Expect(ticks[0].Position).To(BeNumerically("~", 400, 1e-6)) // center of 800-wide plot
 }
+
+func TestLayout_LogScalePositionsPointsLogarithmically(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	small := scatterTestFile("small.go")
+	small.SetQuantity(filesystem.FileLines, 10)
+	small.SetQuantity(filesystem.FileSize, 100)
+
+	medium := scatterTestFile("medium.go")
+	medium.SetQuantity(filesystem.FileLines, 100)
+	medium.SetQuantity(filesystem.FileSize, 100)
+
+	large := scatterTestFile("large.go")
+	large.SetQuantity(filesystem.FileLines, 1000)
+	large.SetQuantity(filesystem.FileSize, 100)
+
+	root := &model.Directory{Files: []*model.File{small, medium, large}}
+	xAxis := AxisSpec{Metric: filesystem.FileLines, Kind: metric.Quantity, Scale: Log}
+	yAxis := AxisSpec{Metric: filesystem.FileSize, Kind: metric.Quantity, Scale: Linear}
+
+	dataset := CollectDataset(root, xAxis, yAxis, filesystem.FileSize)
+	layout := Layout(dataset, 800, 600, xAxis, yAxis)
+
+	points := map[string]ScatterPoint{}
+	for _, point := range layout.Points {
+		points[point.File.Name] = point
+	}
+
+	// With log scale, the gap between 10→100 should equal the gap between 100→1000
+	// (both are one decade)
+	gap1 := points["medium.go"].X - points["small.go"].X
+	gap2 := points["large.go"].X - points["medium.go"].X
+	g.Expect(gap1).To(BeNumerically("~", gap2, 1.0))
+
+	// All X values should be within the plot area
+	g.Expect(points["small.go"].X).To(BeNumerically(">=", scatterPlotLeftMargin))
+	g.Expect(points["large.go"].X).To(BeNumerically("<=", 800-scatterPlotRightMargin))
+}

--- a/internal/scatter/layout_test.go
+++ b/internal/scatter/layout_test.go
@@ -327,3 +327,67 @@ func TestLayout_LogScalePositionsPointsLogarithmically(t *testing.T) {
 	g.Expect(points["small.go"].X).To(BeNumerically(">=", scatterPlotLeftMargin))
 	g.Expect(points["large.go"].X).To(BeNumerically("<=", 800-scatterPlotRightMargin))
 }
+
+func TestValidateLogScale_ErrorsOnZeroValue(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	zero := scatterTestFile("zero.go")
+	zero.SetQuantity(filesystem.FileLines, 0)
+	zero.SetQuantity(filesystem.FileSize, 100)
+
+	positive := scatterTestFile("positive.go")
+	positive.SetQuantity(filesystem.FileLines, 10)
+	positive.SetQuantity(filesystem.FileSize, 50)
+
+	root := &model.Directory{Files: []*model.File{zero, positive}}
+	xAxis := AxisSpec{Metric: filesystem.FileLines, Kind: metric.Quantity, Scale: Log}
+	yAxis := AxisSpec{Metric: filesystem.FileSize, Kind: metric.Quantity, Scale: Linear}
+
+	dataset := CollectDataset(root, xAxis, yAxis, filesystem.FileSize)
+
+	err := ValidateLogScale(dataset, xAxis, yAxis)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("x-axis"))
+	g.Expect(err.Error()).To(ContainSubstring("zero.go"))
+}
+
+func TestValidateLogScale_PassesWhenAllPositive(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	a := scatterTestFile("a.go")
+	a.SetQuantity(filesystem.FileLines, 10)
+	a.SetQuantity(filesystem.FileSize, 100)
+
+	b := scatterTestFile("b.go")
+	b.SetQuantity(filesystem.FileLines, 200)
+	b.SetQuantity(filesystem.FileSize, 50)
+
+	root := &model.Directory{Files: []*model.File{a, b}}
+	xAxis := AxisSpec{Metric: filesystem.FileLines, Kind: metric.Quantity, Scale: Log}
+	yAxis := AxisSpec{Metric: filesystem.FileSize, Kind: metric.Quantity, Scale: Log}
+
+	dataset := CollectDataset(root, xAxis, yAxis, filesystem.FileSize)
+
+	err := ValidateLogScale(dataset, xAxis, yAxis)
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+func TestValidateLogScale_SkipsLinearAxes(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	zero := scatterTestFile("zero.go")
+	zero.SetQuantity(filesystem.FileLines, 0)
+	zero.SetQuantity(filesystem.FileSize, 100)
+
+	root := &model.Directory{Files: []*model.File{zero}}
+	xAxis := AxisSpec{Metric: filesystem.FileLines, Kind: metric.Quantity, Scale: Linear}
+	yAxis := AxisSpec{Metric: filesystem.FileSize, Kind: metric.Quantity, Scale: Linear}
+
+	dataset := CollectDataset(root, xAxis, yAxis, filesystem.FileSize)
+
+	err := ValidateLogScale(dataset, xAxis, yAxis)
+	g.Expect(err).NotTo(HaveOccurred())
+}

--- a/internal/scatter/layout_test.go
+++ b/internal/scatter/layout_test.go
@@ -277,6 +277,25 @@ func TestLogNumericTicks_NarrowRange_AddsIntermediateTicks(t *testing.T) {
 	}
 }
 
+func TestLogNumericTicks_SubDecadeRange_UsesFallback(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	plot := PlotRect{X: 0, Y: 0, W: 800, H: 600}
+	// Range [11, 19] has no power-of-10 or subdivision candidate inside it
+	ticks := logNumericTicks(11, 19, plot, horizontalAxis)
+
+	// Fallback generates 5 evenly-spaced ticks in log space
+	g.Expect(ticks).To(HaveLen(5))
+	g.Expect(ticks[0].Value).To(BeNumerically("~", 11, 0.01))
+	g.Expect(ticks[4].Value).To(BeNumerically("~", 19, 0.01))
+
+	// Positions should be monotonically increasing
+	for i := 1; i < len(ticks); i++ {
+		g.Expect(ticks[i].Position).To(BeNumerically(">", ticks[i-1].Position))
+	}
+}
+
 func TestLogNumericTicks_SingleValue_ReturnsCenterTick(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)

--- a/internal/scatter/layout_test.go
+++ b/internal/scatter/layout_test.go
@@ -226,3 +226,65 @@ func TestResolvedAxis_OffsetShiftsCategoricalBands(t *testing.T) {
 
 	g.Expect(axis.Categorical.Bands).To(Equal([]AxisBand{{Label: "go", Start: 5, End: 15, Center: 10}}))
 }
+
+func TestLogNumericTicks_SpansMultipleDecades(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	plot := PlotRect{X: 0, Y: 0, W: 800, H: 600}
+	ticks := logNumericTicks(1, 10000, plot, horizontalAxis)
+
+	// Expect ticks at powers of 10: 1, 10, 100, 1000, 10000
+	g.Expect(ticks).To(HaveLen(5))
+	g.Expect(ticks[0].Value).To(BeNumerically("~", 1, 1e-9))
+	g.Expect(ticks[1].Value).To(BeNumerically("~", 10, 1e-9))
+	g.Expect(ticks[2].Value).To(BeNumerically("~", 100, 1e-9))
+	g.Expect(ticks[3].Value).To(BeNumerically("~", 1000, 1e-9))
+	g.Expect(ticks[4].Value).To(BeNumerically("~", 10000, 1e-9))
+
+	// Positions should be logarithmically spaced (equal increments in log space)
+	for i := 1; i < len(ticks); i++ {
+		g.Expect(ticks[i].Position).To(BeNumerically(">", ticks[i-1].Position))
+	}
+
+	// Each gap should be the same size (equal decades = equal spacing)
+	gap := ticks[1].Position - ticks[0].Position
+	for i := 2; i < len(ticks); i++ {
+		g.Expect(ticks[i].Position - ticks[i-1].Position).To(BeNumerically("~", gap, 1e-6))
+	}
+}
+
+func TestLogNumericTicks_NarrowRange_AddsIntermediateTicks(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	plot := PlotRect{X: 0, Y: 0, W: 800, H: 600}
+	ticks := logNumericTicks(50, 500, plot, horizontalAxis)
+
+	// Range spans ~1 decade, so intermediate ticks (2x, 5x) are added.
+	// Expect at least 4 ticks.
+	g.Expect(len(ticks)).To(BeNumerically(">=", 4))
+
+	// All tick values should be within [50, 500]
+	for _, tick := range ticks {
+		g.Expect(tick.Value).To(BeNumerically(">=", 50))
+		g.Expect(tick.Value).To(BeNumerically("<=", 500))
+	}
+
+	// Positions should be monotonically increasing
+	for i := 1; i < len(ticks); i++ {
+		g.Expect(ticks[i].Position).To(BeNumerically(">", ticks[i-1].Position))
+	}
+}
+
+func TestLogNumericTicks_SingleValue_ReturnsCenterTick(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	plot := PlotRect{X: 0, Y: 0, W: 800, H: 600}
+	ticks := logNumericTicks(42, 42, plot, horizontalAxis)
+
+	g.Expect(ticks).To(HaveLen(1))
+	g.Expect(ticks[0].Value).To(BeNumerically("~", 42, 1e-9))
+	g.Expect(ticks[0].Position).To(BeNumerically("~", 400, 1e-6)) // center of 800-wide plot
+}

--- a/internal/scatter/layout_test.go
+++ b/internal/scatter/layout_test.go
@@ -348,6 +348,7 @@ func TestValidateLogScale_ErrorsOnZeroValue(t *testing.T) {
 
 	err := ValidateLogScale(dataset, xAxis, yAxis)
 	g.Expect(err).To(HaveOccurred())
+	//nolint:nilaway,nolintlint // guarded by HaveOccurred above
 	g.Expect(err.Error()).To(ContainSubstring("x-axis"))
 	g.Expect(err.Error()).To(ContainSubstring("zero.go"))
 }

--- a/internal/scatter/resolved_axis.go
+++ b/internal/scatter/resolved_axis.go
@@ -4,6 +4,7 @@ package scatter
 type NumericAxis struct {
 	Min   float64
 	Max   float64
+	Scale ScaleType
 	Ticks []AxisTick
 }
 

--- a/internal/scatter/resolved_axis.go
+++ b/internal/scatter/resolved_axis.go
@@ -1,5 +1,13 @@
 package scatter
 
+// ScaleType controls how numeric values are mapped to axis positions.
+type ScaleType int
+
+const (
+	Linear ScaleType = iota
+	Log
+)
+
 // NumericAxis holds the numeric range and ticks for one axis.
 type NumericAxis struct {
 	Min   float64

--- a/internal/scatter/stages.go
+++ b/internal/scatter/stages.go
@@ -29,7 +29,7 @@ func ResolveMetrics(c *stages.CommonState, x *State, cfg *config.Scatter) error 
 
 	yAxis, err := resolveAxisSpec(cfg.YAxis, cfg.YScale)
 	if err != nil {
-		return eris.Wrap(err, "invalid y-axis metric")
+		return eris.Wrap(err, "invalid y-axis configuration")
 	}
 
 	size := metric.Name(stages.PtrString(cfg.Size))

--- a/internal/scatter/stages.go
+++ b/internal/scatter/stages.go
@@ -111,25 +111,27 @@ func BuildInksStage(c *stages.CommonState, x *State) error {
 
 // ValidateLogScale checks that all data values are positive when log scale is used.
 func ValidateLogScale(dataset Dataset, xAxis, yAxis AxisSpec) error {
-	if xAxis.Scale == Log {
-		for _, point := range dataset.Points {
-			if point.X.Numeric <= 0 {
-				return eris.Errorf(
-					"log scale on x-axis requires all values to be positive; file %q has value %g",
-					point.File.Name, point.X.Numeric,
-				)
-			}
-		}
+	xValue := func(p PointDatum) float64 { return p.X.Numeric }
+	if err := validateAxisPositive(dataset.Points, xAxis, "x-axis", xValue); err != nil {
+		return err
 	}
 
-	if yAxis.Scale == Log {
-		for _, point := range dataset.Points {
-			if point.Y.Numeric <= 0 {
-				return eris.Errorf(
-					"log scale on y-axis requires all values to be positive; file %q has value %g",
-					point.File.Name, point.Y.Numeric,
-				)
-			}
+	yValue := func(p PointDatum) float64 { return p.Y.Numeric }
+
+	return validateAxisPositive(dataset.Points, yAxis, "y-axis", yValue)
+}
+
+func validateAxisPositive(points []PointDatum, axis AxisSpec, label string, value func(PointDatum) float64) error {
+	if axis.Scale != Log {
+		return nil
+	}
+
+	for _, point := range points {
+		if value(point) <= 0 {
+			return eris.Errorf(
+				"log scale on %s requires all values to be positive; file %q has value %g",
+				label, point.File.Name, value(point),
+			)
 		}
 	}
 

--- a/internal/scatter/stages.go
+++ b/internal/scatter/stages.go
@@ -97,9 +97,41 @@ func collectRequestedMetrics(xAxis, yAxis, size metric.Name, fill, border *confi
 // BuildInksStage collects plottable files and creates point inks.
 func BuildInksStage(c *stages.CommonState, x *State) error {
 	x.Dataset = CollectDataset(c.Root, x.XAxis, x.YAxis, x.Size)
+
+	if err := ValidateLogScale(x.Dataset, x.XAxis, x.YAxis); err != nil {
+		return err
+	}
+
 	x.Inks = BuildInks(x.Dataset, x.FillMetric, x.FillPalette, x.BorderMetric, x.BorderPalette)
 
 	slog.Info("Rendering image", "output", c.Output, "width", c.Width, "height", c.Height)
+
+	return nil
+}
+
+// ValidateLogScale checks that all data values are positive when log scale is used.
+func ValidateLogScale(dataset Dataset, xAxis, yAxis AxisSpec) error {
+	if xAxis.Scale == Log {
+		for _, point := range dataset.Points {
+			if point.X.Numeric <= 0 {
+				return eris.Errorf(
+					"log scale on x-axis requires all values to be positive; file %q has value %g",
+					point.File.Name, point.X.Numeric,
+				)
+			}
+		}
+	}
+
+	if yAxis.Scale == Log {
+		for _, point := range dataset.Points {
+			if point.Y.Numeric <= 0 {
+				return eris.Errorf(
+					"log scale on y-axis requires all values to be positive; file %q has value %g",
+					point.File.Name, point.Y.Numeric,
+				)
+			}
+		}
+	}
 
 	return nil
 }

--- a/internal/scatter/stages.go
+++ b/internal/scatter/stages.go
@@ -66,7 +66,8 @@ func resolveAxisSpec(name *string, scale *string) (AxisSpec, error) {
 		if descriptor.Kind == metric.Classification {
 			return AxisSpec{}, eris.Errorf(
 				"log scale is only valid for numeric metrics; %q is a classification metric",
-				metricName)
+				metricName,
+			)
 		}
 
 		spec.Scale = Log

--- a/internal/scatter/stages.go
+++ b/internal/scatter/stages.go
@@ -58,13 +58,17 @@ func resolveAxisSpec(name *string, scale *string) (AxisSpec, error) {
 
 	spec := AxisSpec{Metric: metricName, Kind: descriptor.Kind}
 
-	switch stages.PtrString(scale) {
+	scaleStr := stages.PtrString(scale)
+	switch scaleStr {
 	case "", "linear":
 		spec.Scale = Linear
 	case "log":
+		if descriptor.Kind == metric.Classification {
+			return AxisSpec{}, eris.Errorf("log scale is only valid for numeric metrics; %q is a classification metric", metricName)
+		}
 		spec.Scale = Log
 	default:
-		return AxisSpec{}, eris.Errorf("unknown scale %q; must be \"linear\" or \"log\"", stages.PtrString(scale))
+		return AxisSpec{}, eris.Errorf("unknown scale %q; must be \"linear\" or \"log\"", scaleStr)
 	}
 
 	return spec, nil

--- a/internal/scatter/stages.go
+++ b/internal/scatter/stages.go
@@ -64,8 +64,11 @@ func resolveAxisSpec(name *string, scale *string) (AxisSpec, error) {
 		spec.Scale = Linear
 	case "log":
 		if descriptor.Kind == metric.Classification {
-			return AxisSpec{}, eris.Errorf("log scale is only valid for numeric metrics; %q is a classification metric", metricName)
+			return AxisSpec{}, eris.Errorf(
+				"log scale is only valid for numeric metrics; %q is a classification metric",
+				metricName)
 		}
+
 		spec.Scale = Log
 	default:
 		return AxisSpec{}, eris.Errorf("unknown scale %q; must be \"linear\" or \"log\"", scaleStr)

--- a/internal/scatter/stages.go
+++ b/internal/scatter/stages.go
@@ -18,7 +18,7 @@ func ResolveMetrics(c *stages.CommonState, x *State, cfg *config.Scatter) error 
 		return eris.New("x-axis metric is required")
 	}
 
-	xAxis, err := resolveAxisSpec(cfg.XAxis)
+	xAxis, err := resolveAxisSpec(cfg.XAxis, cfg.XScale)
 	if err != nil {
 		return eris.Wrap(err, "invalid x-axis metric")
 	}
@@ -27,7 +27,7 @@ func ResolveMetrics(c *stages.CommonState, x *State, cfg *config.Scatter) error 
 		return eris.New("y-axis metric is required")
 	}
 
-	yAxis, err := resolveAxisSpec(cfg.YAxis)
+	yAxis, err := resolveAxisSpec(cfg.YAxis, cfg.YScale)
 	if err != nil {
 		return eris.Wrap(err, "invalid y-axis metric")
 	}
@@ -48,7 +48,7 @@ func ResolveMetrics(c *stages.CommonState, x *State, cfg *config.Scatter) error 
 	return nil
 }
 
-func resolveAxisSpec(name *string) (AxisSpec, error) {
+func resolveAxisSpec(name *string, scale *string) (AxisSpec, error) {
 	metricName := metric.Name(stages.PtrString(name))
 	descriptor, ok := provider.GetDescriptor(metricName)
 
@@ -56,7 +56,18 @@ func resolveAxisSpec(name *string) (AxisSpec, error) {
 		return AxisSpec{}, eris.Errorf("unknown axis metric %q", metricName)
 	}
 
-	return AxisSpec{Metric: metricName, Kind: descriptor.Kind}, nil
+	spec := AxisSpec{Metric: metricName, Kind: descriptor.Kind}
+
+	switch stages.PtrString(scale) {
+	case "", "linear":
+		spec.Scale = Linear
+	case "log":
+		spec.Scale = Log
+	default:
+		return AxisSpec{}, eris.Errorf("unknown scale %q; must be \"linear\" or \"log\"", stages.PtrString(scale))
+	}
+
+	return spec, nil
 }
 
 func resolveFillMetric(cfg *config.Scatter, size metric.Name) metric.Name {

--- a/internal/scatter/stages.go
+++ b/internal/scatter/stages.go
@@ -20,7 +20,7 @@ func ResolveMetrics(c *stages.CommonState, x *State, cfg *config.Scatter) error 
 
 	xAxis, err := resolveAxisSpec(cfg.XAxis, cfg.XScale)
 	if err != nil {
-		return eris.Wrap(err, "invalid x-axis metric")
+		return eris.Wrap(err, "invalid x-axis configuration")
 	}
 
 	if stages.PtrString(cfg.YAxis) == "" {

--- a/internal/scatter/stages_test.go
+++ b/internal/scatter/stages_test.go
@@ -37,6 +37,26 @@ func TestResolveMetrics_FillDefaultsToSize(t *testing.T) {
 	}))
 }
 
+func TestResolveMetrics_ParsesLogScale(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	common := &stages.CommonState{}
+	viz := &scatter.State{}
+	cfg := &config.Scatter{
+		XAxis:  new("file-lines"),
+		YAxis:  new("file-size"),
+		Size:   new("file-size"),
+		XScale: new("log"),
+		YScale: new("linear"),
+	}
+
+	err := scatter.ResolveMetrics(common, viz, cfg)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(viz.XAxis.Scale).To(Equal(scatter.Log))
+	g.Expect(viz.YAxis.Scale).To(Equal(scatter.Linear))
+}
+
 func TestResolveMetrics_FillAndBorderOverrideDefaults(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)

--- a/specs/2026-06-13-scatter-log-axis-design.md
+++ b/specs/2026-06-13-scatter-log-axis-design.md
@@ -1,0 +1,138 @@
+# Scatter Logarithmic Axis Scales
+
+**Date:** 2026-06-13
+**Issue:** #396
+
+## Summary
+
+Add per-axis logarithmic scale options to the scatter visualization.
+Log scaling spreads out data points that cluster at low values by positioning
+them according to `ln(value)` while labeling ticks with original values.
+
+## Configuration
+
+### Config YAML
+
+Add two new optional fields to the `scatter:` section:
+
+```yaml
+scatter:
+  xAxis: file-size
+  yAxis: comment-ratio
+  xScale: log       # new — "linear" (default) or "log"
+  yScale: linear    # new — "linear" (default) or "log"
+  size: declaration-count
+```
+
+### CLI Flags
+
+```
+--x-scale=log    X-axis scale (linear or log). Default: linear.
+--y-scale=log    Y-axis scale (linear or log). Default: linear.
+```
+
+## Types
+
+New `ScaleType` in `internal/scatter/axis.go`:
+
+```go
+type ScaleType int
+
+const (
+    Linear ScaleType = iota
+    Log
+)
+```
+
+`AxisSpec` gains a `Scale ScaleType` field.
+
+`config.Scatter` gains:
+
+```go
+XScale *string `yaml:"xScale,omitempty" json:"xScale,omitempty"`
+YScale *string `yaml:"yScale,omitempty" json:"yScale,omitempty"`
+```
+
+With corresponding `OverrideXScale` / `OverrideYScale` methods.
+
+`ScatterCmd` gains:
+
+```go
+XScale string `default:"" enum:",linear,log" help:"X-axis scale (linear or log)." name:"x-scale"`
+YScale string `default:"" enum:",linear,log" help:"Y-axis scale (linear or log)." name:"y-scale"`
+```
+
+## Validation
+
+Log scale requires all data values on that axis to be strictly positive (`> 0`).
+Validation occurs after dataset collection (in `BuildInksStage`), since actual
+values are not known until providers have run.
+
+A new function:
+
+```go
+func validateLogScale(dataset Dataset, xAxis, yAxis AxisSpec) error
+```
+
+Returns an error identifying the first file with a non-positive value:
+
+```
+log scale on x-axis requires all values to be positive; file "foo.go" has value 0
+```
+
+## Log Tick Generation
+
+New function `logNumericTicks(minValue, maxValue float64, plot PlotRect, direction axisDirection) []AxisTick`:
+
+1. Compute `logMin = ln(min)`, `logMax = ln(max)`.
+2. Choose tick values at powers of 10 within `[min, max]` (1, 10, 100, 1000, …).
+3. If the resulting tick count is fewer than 3, supplement with 2× and 5×
+   intermediate ticks per decade (e.g., 20, 50, 200, 500) until at least 4 ticks
+   are present.
+4. Position each tick: `norm = (ln(tickValue) - logMin) / (logMax - logMin)`.
+5. Labels show original numeric values via `formatTick`.
+
+## Position Mapping
+
+`positionForValue` gains a log branch when `axis.Numeric.Scale == Log`:
+
+```go
+norm = (math.Log(value.Numeric) - math.Log(minValue)) / (math.Log(maxValue) - math.Log(minValue))
+```
+
+The `NumericAxis` struct stores the `Scale` so `positionForValue` can branch:
+
+```go
+type NumericAxis struct {
+    Min   float64
+    Max   float64
+    Scale ScaleType
+    Ticks []AxisTick
+}
+```
+
+## Axis Resolution Changes
+
+`resolveAxis` receives the `ScaleType` from `AxisSpec.Scale` and:
+
+- For `Log`: calls `logNumericTicks` instead of `numericTicks`.
+- Sets `axis.Numeric.Scale = spec.Scale` so downstream code can branch.
+
+## Pipeline Wiring
+
+1. `resolveAxisSpec` in `stages.go` parses the scale string from config and sets
+   `AxisSpec.Scale`.
+2. `applyOverrides` in `scatter_cmd.go` calls `cfg.Scatter.OverrideXScale(c.XScale)`
+   and `cfg.Scatter.OverrideYScale(c.YScale)`.
+3. `BuildInksStage` calls `validateLogScale` after `CollectDataset`.
+
+## Testing
+
+1. **`logNumericTicks` unit tests**: verify tick values and positions for ranges
+   like 1–1000, 50–500, 1–10000.
+2. **`positionForValue` log tests**: verify log-proportional positioning.
+3. **`validateLogScale` tests**: error on zero/negative, pass on all-positive.
+4. **Golden-file integration test**: render a scatter plot with `xScale: log` and
+   verify via Goldie snapshot.
+5. **Config round-trip test**: verify `xScale`/`yScale` serialize and deserialize
+   correctly.


### PR DESCRIPTION
## Summary

- Add `--x-scale=log` and `--y-scale=log` CLI flags (and config YAML equivalents) to control per-axis logarithmic scaling
- Implement logarithmic tick generation with power-of-10 ticks, 2×/5× subdivisions for narrow ranges, and a fallback for sub-decade ranges
- Position scatter points using `ln(value)` normalization while labeling ticks with original values
- Validate all axis values are positive when log scale is active, with clear error messages identifying offending files

## Testing

- Unit tests for log tick generation (multiple decades, narrow range, sub-decade fallback, single value)
- Unit test for log-scale positioning (verifying equal decades = equal spacing)
- Unit tests for validation (zero value error, all-positive pass, linear axes skip)
- Integration test for scale parsing in ResolveMetrics
- Full CI passes (build, test, lint)

Closes #396