### PR TITLE
Feature: Metric target types (#405)

### DIFF
--- a/cmd/codeviz/bubbletree_cmd.go
+++ b/cmd/codeviz/bubbletree_cmd.go
@@ -53,7 +53,7 @@ func (*BubbletreeCmd) Validate() error {
 func (*BubbletreeCmd) validateConfig(cfg *config.Bubbletree) error {
 	size := ptrString(cfg.Size)
 
-	d, ok := provider.GetDescriptor(metric.Name(size))
+	d, ok := provider.GetDescriptor(metric.Name(size), metric.File)
 	if !ok {
 		return eris.Errorf("unknown size metric %q; available metrics: %s", size, formatMetricNames())
 	}

--- a/cmd/codeviz/help_metrics_cmd.go
+++ b/cmd/codeviz/help_metrics_cmd.go
@@ -33,7 +33,7 @@ var providerSectionOrder = []string{
 
 //nolint:unparam // nil error required to satisfy the interface for Kong
 func (HelpMetricsCmd) Run(_ *Flags) error {
-	descriptors := provider.AllDescriptors()
+	descriptors := provider.AllDescriptors(metric.File)
 	groups := buildProviderGroups(descriptors)
 	fmt.Print(renderProviderGroups(groups))
 

--- a/cmd/codeviz/help_metrics_cmd.go
+++ b/cmd/codeviz/help_metrics_cmd.go
@@ -33,7 +33,7 @@ var providerSectionOrder = []string{
 
 //nolint:unparam // nil error required to satisfy the interface for Kong
 func (HelpMetricsCmd) Run(_ *Flags) error {
-	descriptors := provider.AllDescriptors(metric.File)
+	descriptors := provider.AllDescriptors()
 	groups := buildProviderGroups(descriptors)
 	fmt.Print(renderProviderGroups(groups))
 

--- a/cmd/codeviz/help_metrics_cmd.go
+++ b/cmd/codeviz/help_metrics_cmd.go
@@ -81,12 +81,12 @@ func renderProviderGroups(groups map[string][]provider.MetricDescriptor) string 
 }
 
 func writeProviderGroupTable(content *strings.Builder, group []provider.MetricDescriptor) {
-	tbl := table.New("Metric", "Kind", "Default Palette", "Description")
+	tbl := table.New("Metric", "Target", "Kind", "Default Palette", "Description")
 	tbl.SetMaxWidth(consoleWidth())
 
 	for _, d := range group {
 		desc := d.Description
-		tbl.AddRow(string(d.Name), kindLabel(d.Kind), string(d.DefaultPalette), desc)
+		tbl.AddRow(string(d.Name), d.Target.String(), kindLabel(d.Kind), string(d.DefaultPalette), desc)
 	}
 
 	tbl.WriteTo(content)

--- a/cmd/codeviz/main_test.go
+++ b/cmd/codeviz/main_test.go
@@ -504,6 +504,25 @@ func TestTreemapCmd_ValidateConfig_InvalidFillPalette(t *testing.T) {
 	g.Expect(err).To(MatchError(ContainSubstring("invalid fill palette")))
 }
 
+func TestTreemapCmd_ValidateConfig_InvalidSizeMetricListsAvailableMetrics(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	cfg := config.New()
+	cfg.Treemap.Size = new("not-a-real-metric")
+
+	cmd := &TreemapCmd{}
+
+	err := cmd.validateConfig(cfg.Treemap)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	errText := err.Error()
+	g.Expect(errText).To(ContainSubstring("invalid size metric"))
+	g.Expect(errText).To(ContainSubstring("available metrics:"))
+}
+
 func TestTreemapCmd_ValidateConfig_MeasureMetricAccepted(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)

--- a/cmd/codeviz/main_test.go
+++ b/cmd/codeviz/main_test.go
@@ -520,7 +520,7 @@ func TestTreemapCmd_ValidateConfig_InvalidSizeMetricListsAvailableMetrics(t *tes
 
 	errText := err.Error()
 	g.Expect(errText).To(ContainSubstring("invalid size metric"))
-	g.Expect(errText).To(ContainSubstring("available metrics:"))
+	g.Expect(errText).To(ContainSubstring("available file metrics:"))
 }
 
 func TestTreemapCmd_ValidateConfig_MeasureMetricAccepted(t *testing.T) {

--- a/cmd/codeviz/radialtree_cmd.go
+++ b/cmd/codeviz/radialtree_cmd.go
@@ -51,7 +51,7 @@ func (*RadialCmd) Validate() error {
 func (*RadialCmd) validateConfig(cfg *config.Radial) error {
 	discSize := ptrString(cfg.DiscSize)
 
-	d, ok := provider.GetDescriptor(metric.Name(discSize))
+	d, ok := provider.GetDescriptor(metric.Name(discSize), metric.File)
 	if !ok {
 		return eris.Errorf("unknown disc-size metric %q; available metrics: %s", discSize, formatMetricNames())
 	}

--- a/cmd/codeviz/scatter_cmd.go
+++ b/cmd/codeviz/scatter_cmd.go
@@ -56,7 +56,7 @@ func (*ScatterCmd) validateConfig(cfg *config.Scatter) error {
 	}
 
 	size := ptrString(cfg.Size)
-	d, ok := provider.GetDescriptor(metric.Name(size))
+	d, ok := provider.GetDescriptor(metric.Name(size), metric.File)
 
 	if !ok {
 		return eris.Errorf("unknown size metric %q; available metrics: %s", size, formatMetricNames())
@@ -79,7 +79,7 @@ func (*ScatterCmd) validateConfig(cfg *config.Scatter) error {
 
 func validateScatterAxisMetric(label string, name *string) error {
 	axis := ptrString(name)
-	if _, ok := provider.GetDescriptor(metric.Name(axis)); !ok {
+	if _, ok := provider.GetDescriptor(metric.Name(axis), metric.File); !ok {
 		return eris.Errorf("unknown %s metric %q; available metrics: %s", label, axis, formatMetricNames())
 	}
 

--- a/cmd/codeviz/spiral_cmd.go
+++ b/cmd/codeviz/spiral_cmd.go
@@ -53,7 +53,7 @@ func (*SpiralCmd) Validate() error {
 func (*SpiralCmd) validateConfig(cfg *config.Spiral) error {
 	size := ptrString(cfg.Size)
 	if size != "" {
-		d, ok := provider.GetDescriptor(metric.Name(size))
+		d, ok := provider.GetDescriptor(metric.Name(size), metric.File)
 		if !ok {
 			return eris.Errorf("unknown size metric %q; available metrics: %s", size, formatMetricNames())
 		}

--- a/cmd/codeviz/treemap_cmd.go
+++ b/cmd/codeviz/treemap_cmd.go
@@ -52,7 +52,7 @@ func (*TreemapCmd) Validate() error {
 func (*TreemapCmd) validateConfig(cfg *config.Treemap) error {
 	size := ptrString(cfg.Size)
 
-	d, ok := provider.GetDescriptor(metric.Name(size))
+	d, ok := provider.GetDescriptor(metric.Name(size), metric.File)
 	if !ok {
 		return eris.Errorf("unknown size metric %q; available metrics: %s", size, formatMetricNames())
 	}
@@ -73,7 +73,7 @@ func (*TreemapCmd) validateConfig(cfg *config.Treemap) error {
 }
 
 func formatMetricNames() string {
-	names := provider.Names()
+	names := provider.Names(metric.File)
 	strs := make([]string, len(names))
 
 	for i, n := range names {

--- a/cmd/codeviz/treemap_cmd.go
+++ b/cmd/codeviz/treemap_cmd.go
@@ -78,7 +78,7 @@ func (*TreemapCmd) validateConfig(cfg *config.Treemap) error {
 }
 
 func formatMetricNames() string {
-	names := provider.Names(metric.File)
+	names := provider.NamesFor(metric.File)
 	strs := make([]string, len(names))
 
 	for i, n := range names {

--- a/cmd/codeviz/treemap_cmd.go
+++ b/cmd/codeviz/treemap_cmd.go
@@ -52,11 +52,16 @@ func (*TreemapCmd) Validate() error {
 func (*TreemapCmd) validateConfig(cfg *config.Treemap) error {
 	size := ptrString(cfg.Size)
 
-	d, ok := provider.GetDescriptor(metric.Name(size), metric.File)
-	if !ok {
-		return eris.Errorf("unknown size metric %q; available metrics: %s", size, formatMetricNames())
+	p, err := provider.FindWithHint(metric.Name(size), metric.File)
+	if err != nil {
+		if !strings.Contains(err.Error(), "exists for target") {
+			return eris.Errorf("invalid size metric: %s; available metrics: %s", err, formatMetricNames())
+		}
+
+		return eris.Wrap(err, "invalid size metric")
 	}
 
+	d := provider.Descriptor(p)
 	if d.Kind != metric.Quantity && d.Kind != metric.Measure {
 		return eris.Errorf("size metric must be numeric, got %q (kind: %d)", size, d.Kind)
 	}

--- a/cmd/codeviz/treemap_cmd.go
+++ b/cmd/codeviz/treemap_cmd.go
@@ -54,11 +54,7 @@ func (*TreemapCmd) validateConfig(cfg *config.Treemap) error {
 
 	p, err := provider.FindWithHint(metric.Name(size), metric.File)
 	if err != nil {
-		if !strings.Contains(err.Error(), "exists for target") {
-			return eris.Errorf("invalid size metric: %s; available metrics: %s", err, formatMetricNames())
-		}
-
-		return eris.Wrap(err, "invalid size metric")
+		return eris.Wrapf(err, "invalid size metric; available file metrics: %s", formatMetricNames())
 	}
 
 	d := provider.Descriptor(p)

--- a/docs/superpowers/plans/2026-06-13-metric-target-types.md
+++ b/docs/superpowers/plans/2026-06-13-metric-target-types.md
@@ -1,0 +1,1184 @@
+# Metric Target Types Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Classify each metric with a target type (File or Directory) and restructure the registry to support same-name metrics for different targets, with helpful error messages.
+
+**Architecture:** Add `metric.Target` enum, extend `provider.Interface` with `Target()`, restructure registry to `map[Target]map[Name]Interface`, update all public API functions to accept a target parameter, add `FindWithHint` for actionable errors.
+
+**Tech Stack:** Go 1.26.1, Gomega (test assertions), eris (error wrapping)
+
+---
+
+### Task 1: Define metric.Target type
+
+**Files:**
+- Modify: `internal/metric/metric.go`
+- Create: `internal/metric/target_test.go`
+
+- [ ] **Step 1: Write the test for Target.String()**
+
+```go
+// internal/metric/target_test.go
+package metric
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestTargetString(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	g.Expect(File.String()).To(Equal("file"))
+	g.Expect(Directory.String()).To(Equal("directory"))
+}
+
+func TestTargetStringUnknown(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	g.Expect(Target(99).String()).To(Equal("unknown"))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test`
+Expected: FAIL — `File`, `Directory`, `Target` not defined.
+
+- [ ] **Step 3: Implement metric.Target**
+
+Add to `internal/metric/metric.go` after the `Kind` constants:
+
+```go
+// Target classifies what a metric applies to.
+type Target int
+
+const (
+	File      Target = iota // metric applies to individual files
+	Directory               // metric applies to directories (aggregates)
+)
+
+// String returns the human-readable label for the target.
+func (t Target) String() string {
+	switch t {
+	case File:
+		return "file"
+	case Directory:
+		return "directory"
+	default:
+		return "unknown"
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `task test`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/metric/metric.go internal/metric/target_test.go
+git commit -m "feat(metric): add Target type with File and Directory values
+
+Part of #405 — metric target types."
+```
+
+---
+
+### Task 2: Add Target() to provider.Interface and MetricDescriptor
+
+**Files:**
+- Modify: `internal/provider/provider.go`
+
+- [ ] **Step 1: Add Target to MetricDescriptor**
+
+In `internal/provider/provider.go`, add `Target metric.Target` field to `MetricDescriptor`:
+
+```go
+type MetricDescriptor struct {
+	Name           metric.Name
+	Kind           metric.Kind
+	Target         metric.Target
+	Description    string
+	Dependencies   []metric.Name
+	DefaultPalette palette.PaletteName
+}
+```
+
+- [ ] **Step 2: Add Target() to Interface**
+
+Add `Target() metric.Target` to the `Interface`:
+
+```go
+type Interface interface {
+	Name() metric.Name
+	Kind() metric.Kind
+	Target() metric.Target
+	Description() string
+	Dependencies() []metric.Name
+	DefaultPalette() palette.PaletteName
+	Loader
+}
+```
+
+- [ ] **Step 3: Update Descriptor() to copy Target**
+
+```go
+func Descriptor(p Interface) MetricDescriptor {
+	return MetricDescriptor{
+		Name:           p.Name(),
+		Kind:           p.Kind(),
+		Target:         p.Target(),
+		Description:    p.Description(),
+		Dependencies:   p.Dependencies(),
+		DefaultPalette: p.DefaultPalette(),
+	}
+}
+```
+
+- [ ] **Step 4: Build to verify compilation (expect failures in providers)**
+
+Run: `go build ./...`
+Expected: Compile errors in provider packages (they don't implement `Target()` yet). This is expected and will be fixed in Task 3.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/provider/provider.go
+git commit -m "feat(provider): add Target() to Interface and MetricDescriptor
+
+Part of #405 — metric target types. Providers will be updated next."
+```
+
+---
+
+### Task 3: Implement Target() on all providers
+
+**Files:**
+- Modify: `internal/provider/filesystem/metrics.go`
+- Modify: `internal/provider/git/git_provider.go`
+- Modify: `internal/provider/golang/go_provider.go`
+- Modify: `internal/provider/registry_test.go` (stubProvider)
+- Modify: `internal/provider/run_test.go` (mockProvider)
+
+- [ ] **Step 1: Add Target() to filesystem providers**
+
+In `internal/provider/filesystem/metrics.go`, add to each provider struct:
+
+```go
+func (FileSizeProvider) Target() metric.Target  { return metric.File }
+func (FileTypeProvider) Target() metric.Target  { return metric.File }
+```
+
+For `FileLinesProvider`, add the same method (find where it's defined — it's a pointer receiver provider):
+
+```go
+func (*FileLinesProvider) Target() metric.Target { return metric.File }
+```
+
+- [ ] **Step 2: Add Target() to git provider**
+
+In `internal/provider/git/git_provider.go`, add:
+
+```go
+func (*gitProvider) Target() metric.Target { return metric.File }
+```
+
+- [ ] **Step 3: Add Target() to golang provider**
+
+In `internal/provider/golang/go_provider.go`, add:
+
+```go
+func (*goProvider) Target() metric.Target { return metric.File }
+```
+
+- [ ] **Step 4: Add Target() to test stubs**
+
+In `internal/provider/registry_test.go`, add to `stubProvider`:
+
+```go
+func (*stubProvider) Target() metric.Target { return metric.File }
+```
+
+In `internal/provider/run_test.go`, add to `mockProvider`:
+
+```go
+func (*mockProvider) Target() metric.Target { return metric.File }
+```
+
+- [ ] **Step 5: Build and test**
+
+Run: `task test`
+Expected: All tests pass, compilation succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/provider/filesystem/metrics.go internal/provider/git/git_provider.go \
+  internal/provider/golang/go_provider.go internal/provider/registry_test.go \
+  internal/provider/run_test.go
+git commit -m "feat(provider): implement Target() on all providers
+
+All existing providers return metric.File. Part of #405."
+```
+
+---
+
+### Task 4: Restructure registry backing store
+
+**Files:**
+- Modify: `internal/provider/registry.go`
+- Modify: `internal/provider/registry_test.go`
+
+- [ ] **Step 1: Write tests for the new registry behaviour**
+
+Replace the existing tests in `internal/provider/registry_test.go` with updated versions that pass target:
+
+```go
+package provider
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
+	"github.com/theunrepentantgeek/code-visualizer/internal/model"
+	"github.com/theunrepentantgeek/code-visualizer/internal/palette"
+)
+
+// stubProvider is a minimal Interface implementation for testing.
+type stubProvider struct {
+	name   metric.Name
+	kind   metric.Kind
+	target metric.Target
+}
+
+func (s *stubProvider) Name() metric.Name                 { return s.name }
+func (s *stubProvider) Kind() metric.Kind                 { return s.kind }
+func (s *stubProvider) Target() metric.Target             { return s.target }
+func (*stubProvider) Description() string                 { return "" }
+func (*stubProvider) Dependencies() []metric.Name         { return nil }
+func (*stubProvider) DefaultPalette() palette.PaletteName { return palette.Neutral }
+func (*stubProvider) Load(_ *model.Directory) error       { return nil }
+
+func TestRegisterAndGet(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	reg := newRegistry()
+	p := &stubProvider{name: "test-metric", kind: metric.Quantity, target: metric.File}
+	reg.register(p)
+
+	got, ok := reg.get("test-metric", metric.File)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(got).ToNot(BeNil())
+	g.Expect(got.Name()).To(Equal(metric.Name("test-metric")))
+}
+
+func TestGetWithWrongTarget(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	reg := newRegistry()
+	reg.register(&stubProvider{name: "test-metric", kind: metric.Quantity, target: metric.File})
+
+	_, ok := reg.get("test-metric", metric.Directory)
+	g.Expect(ok).To(BeFalse())
+}
+
+func TestGetUnregistered(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	reg := newRegistry()
+	_, ok := reg.get("nonexistent", metric.File)
+	g.Expect(ok).To(BeFalse())
+}
+
+func TestSameNameDifferentTargets(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	reg := newRegistry()
+	fileP := &stubProvider{name: "size", kind: metric.Quantity, target: metric.File}
+	dirP := &stubProvider{name: "size", kind: metric.Quantity, target: metric.Directory}
+	reg.register(fileP)
+	reg.register(dirP)
+
+	gotFile, ok := reg.get("size", metric.File)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(gotFile.Target()).To(Equal(metric.File))
+
+	gotDir, ok := reg.get("size", metric.Directory)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(gotDir.Target()).To(Equal(metric.Directory))
+}
+
+func TestAllProviders(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	reg := newRegistry()
+	reg.register(&stubProvider{name: "m1", kind: metric.Quantity, target: metric.File})
+	reg.register(&stubProvider{name: "m2", kind: metric.Classification, target: metric.File})
+	reg.register(&stubProvider{name: "m3", kind: metric.Quantity, target: metric.Directory})
+
+	all := reg.all(metric.File)
+	g.Expect(all).To(HaveLen(2))
+
+	allDir := reg.all(metric.Directory)
+	g.Expect(allDir).To(HaveLen(1))
+}
+
+func TestRegisterDuplicatePanics(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	reg := newRegistry()
+	reg.register(&stubProvider{name: "dup", kind: metric.Quantity, target: metric.File})
+
+	g.Expect(func() {
+		reg.register(&stubProvider{name: "dup", kind: metric.Quantity, target: metric.File})
+	}).To(Panic())
+}
+
+func TestDuplicateNameDifferentTargetDoesNotPanic(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	reg := newRegistry()
+	reg.register(&stubProvider{name: "dup", kind: metric.Quantity, target: metric.File})
+
+	g.Expect(func() {
+		reg.register(&stubProvider{name: "dup", kind: metric.Quantity, target: metric.Directory})
+	}).ToNot(Panic())
+}
+
+func TestNamesSorted(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	reg := newRegistry()
+	reg.register(&stubProvider{name: "zebra", kind: metric.Quantity, target: metric.File})
+	reg.register(&stubProvider{name: "alpha", kind: metric.Quantity, target: metric.File})
+	reg.register(&stubProvider{name: "mid", kind: metric.Quantity, target: metric.File})
+
+	names := reg.names(metric.File)
+	g.Expect(names).To(Equal([]metric.Name{"alpha", "mid", "zebra"}))
+}
+
+func TestHasName(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	reg := newRegistry()
+	reg.register(&stubProvider{name: "exists", kind: metric.Quantity, target: metric.File})
+
+	g.Expect(reg.hasName("exists")).To(BeTrue())
+	g.Expect(reg.hasName("missing")).To(BeFalse())
+}
+
+func TestTargetsForName(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	reg := newRegistry()
+	reg.register(&stubProvider{name: "size", kind: metric.Quantity, target: metric.File})
+	reg.register(&stubProvider{name: "size", kind: metric.Quantity, target: metric.Directory})
+
+	targets := reg.targetsForName("size")
+	g.Expect(targets).To(ConsistOf(metric.File, metric.Directory))
+
+	targets = reg.targetsForName("missing")
+	g.Expect(targets).To(BeEmpty())
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `task test`
+Expected: FAIL — `get` takes wrong number of arguments, `all` takes wrong number, etc.
+
+- [ ] **Step 3: Rewrite registry.go**
+
+Replace `internal/provider/registry.go` with:
+
+```go
+package provider
+
+import (
+	"cmp"
+	"fmt"
+	"maps"
+	"slices"
+	"sync"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
+)
+
+// registry holds registered metric providers, grouped by target type.
+type registry struct {
+	mu        sync.RWMutex
+	providers map[metric.Target]map[metric.Name]Interface
+}
+
+func newRegistry() *registry {
+	return &registry{
+		providers: make(map[metric.Target]map[metric.Name]Interface),
+	}
+}
+
+func (r *registry) register(p Interface) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	target := p.Target()
+	if r.providers[target] == nil {
+		r.providers[target] = make(map[metric.Name]Interface)
+	}
+
+	if _, exists := r.providers[target][p.Name()]; exists {
+		panic(fmt.Sprintf("provider %q already registered for target %q", p.Name(), target))
+	}
+
+	r.providers[target][p.Name()] = p
+}
+
+func (r *registry) get(name metric.Name, target metric.Target) (Interface, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	inner := r.providers[target]
+	if inner == nil {
+		return nil, false
+	}
+
+	p, ok := inner[name]
+	if !ok || p == nil {
+		return nil, false
+	}
+
+	return p, true
+}
+
+func (r *registry) all(target metric.Target) []Interface {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	inner := r.providers[target]
+	if inner == nil {
+		return nil
+	}
+
+	result := slices.Collect(maps.Values(inner))
+	slices.SortFunc(
+		result,
+		func(left Interface, right Interface) int {
+			return cmp.Compare(left.Name(), right.Name())
+		},
+	)
+
+	return result
+}
+
+func (r *registry) names(target metric.Target) []metric.Name {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	inner := r.providers[target]
+	if inner == nil {
+		return nil
+	}
+
+	names := slices.Collect(maps.Keys(inner))
+	slices.SortFunc(names, cmp.Compare)
+
+	return names
+}
+
+// hasName reports whether any target has a provider with the given name.
+func (r *registry) hasName(name metric.Name) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, inner := range r.providers {
+		if _, ok := inner[name]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// targetsForName returns all targets that have a provider with the given name.
+func (r *registry) targetsForName(name metric.Name) []metric.Target {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var targets []metric.Target
+
+	for target, inner := range r.providers {
+		if _, ok := inner[name]; ok {
+			targets = append(targets, target)
+		}
+	}
+
+	return targets
+}
+
+// globalRegistry is the process-wide provider registry.
+var globalRegistry = newRegistry()
+
+// Register adds a provider to the global registry.
+// Panics on duplicate (name, target) pair.
+func Register(p Interface) { globalRegistry.register(p) }
+
+// Get retrieves a provider by name and target from the global registry.
+func Get(name metric.Name, target metric.Target) (Interface, bool) {
+	return globalRegistry.get(name, target)
+}
+
+// GetDescriptor retrieves only the metadata for a provider by name and target.
+func GetDescriptor(name metric.Name, target metric.Target) (MetricDescriptor, bool) {
+	p, ok := globalRegistry.get(name, target)
+	if !ok {
+		return MetricDescriptor{}, false
+	}
+
+	return Descriptor(p), true
+}
+
+// All returns all registered providers for the given target.
+func All(target metric.Target) []Interface { return globalRegistry.all(target) }
+
+// AllDescriptors returns metadata for all registered providers for the given target.
+func AllDescriptors(target metric.Target) []MetricDescriptor {
+	providers := globalRegistry.all(target)
+
+	descriptors := make([]MetricDescriptor, len(providers))
+	for i, p := range providers {
+		descriptors[i] = Descriptor(p)
+	}
+
+	return descriptors
+}
+
+// Names returns the sorted names of all registered providers for the given target.
+func Names(target metric.Target) []metric.Name { return globalRegistry.names(target) }
+
+// FindWithHint looks up a provider by name and target. On failure, it checks
+// whether the metric exists for a different target and includes that as a hint.
+func FindWithHint(name metric.Name, target metric.Target) (Interface, error) {
+	p, ok := globalRegistry.get(name, target)
+	if ok {
+		return p, nil
+	}
+
+	targets := globalRegistry.targetsForName(name)
+	if len(targets) > 0 {
+		return nil, fmt.Errorf(
+			"unknown %s metric %q; metric %q exists for target %q",
+			target, name, name, targets[0])
+	}
+
+	return nil, fmt.Errorf("unknown %s metric %q", target, name)
+}
+
+// ResetRegistryForTesting clears the global registry. Test use only.
+func ResetRegistryForTesting() {
+	globalRegistry = newRegistry()
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `task test`
+Expected: Registry tests pass, but other packages will fail due to API change. That's expected.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/provider/registry.go internal/provider/registry_test.go
+git commit -m "feat(provider): restructure registry with target-keyed map
+
+Registry now uses map[metric.Target]map[metric.Name]Interface.
+Get, All, Names all require a target parameter. FindWithHint provides
+helpful errors when a metric exists for a different target.
+
+Part of #405."
+```
+
+---
+
+### Task 5: Update run.go (provider scheduler)
+
+**Files:**
+- Modify: `internal/provider/run.go`
+- Modify: `internal/provider/run_test.go`
+
+- [ ] **Step 1: Update mockProvider in run_test.go**
+
+The `mockProvider` already has `Target()` from Task 3. Update calls to `reg.get(name)` → `reg.get(name, metric.File)` in the test file (or verify there are none — they call through `runWithRegistry` which internally calls `reg.get`).
+
+Actually, the `run.go` functions call `reg.get(name)` internally. Update `expandDeps`, `addEdges`, and the run loop:
+
+- [ ] **Step 2: Update run.go internal calls**
+
+In `internal/provider/run.go`, update all `reg.get(name)` calls to `reg.get(name, target)`. The `Run` function needs to accept a target parameter:
+
+Change `Run` signature and its helper:
+
+```go
+// Run loads the requested metrics (plus transitive dependencies) onto the tree.
+// Providers run in parallel where dependency ordering allows.
+func Run(root *model.Directory, requested []metric.Name, target metric.Target, progress MetricProgress) error {
+	return runWithRegistry(globalRegistry, root, requested, target, progress)
+}
+
+func runWithRegistry(reg *registry, root *model.Directory, requested []metric.Name, target metric.Target, progress MetricProgress) error {
+	if len(requested) == 0 {
+		return nil
+	}
+
+	expanded, err := expandDeps(reg, requested, target)
+	if err != nil {
+		return err
+	}
+
+	levels, err := topoSort(reg, expanded, target)
+	if err != nil {
+		return err
+	}
+
+	for _, level := range levels {
+		g := new(errgroup.Group)
+
+		for _, name := range level {
+			p, _ := reg.get(name, target)
+
+			g.Go(func() error {
+				return runProvider(p, root, name, progress)
+			})
+		}
+
+		if err := g.Wait(); err != nil {
+			return err //nolint:wrapcheck // error is wrapped inside runProvider
+		}
+	}
+
+	return nil
+}
+```
+
+Update `expandDeps` and `visitDep`:
+
+```go
+func expandDeps(reg *registry, requested []metric.Name, target metric.Target) ([]metric.Name, error) {
+	seen := make(map[metric.Name]bool)
+
+	var result []metric.Name
+
+	for _, name := range requested {
+		if err := visitDep(reg, name, target, seen, &result); err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
+}
+
+func visitDep(reg *registry, name metric.Name, target metric.Target, seen map[metric.Name]bool, result *[]metric.Name) error {
+	if seen[name] {
+		return nil
+	}
+
+	p, ok := reg.get(name, target)
+	if !ok || p == nil {
+		return eris.Errorf("unknown metric %q; available metrics: %s", name, formatNames(reg.names(target)))
+	}
+
+	seen[name] = true
+	*result = append(*result, name)
+
+	for _, dep := range p.Dependencies() {
+		if err := visitDep(reg, dep, target, seen, result); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+```
+
+Update `topoSort`, `buildDepGraph`, `addEdges`:
+
+```go
+func topoSort(reg *registry, names []metric.Name, target metric.Target) ([][]metric.Name, error) {
+	inDegree, dependents := buildDepGraph(reg, names, target)
+
+	return computeLevels(names, inDegree, dependents)
+}
+
+func buildDepGraph(reg *registry, names []metric.Name, target metric.Target) (map[metric.Name]int, map[metric.Name][]metric.Name) {
+	nameSet := make(map[metric.Name]bool, len(names))
+	for _, n := range names {
+		nameSet[n] = true
+	}
+
+	inDegree := make(map[metric.Name]int, len(names))
+	dependents := make(map[metric.Name][]metric.Name)
+
+	for _, n := range names {
+		inDegree[n] = 0
+	}
+
+	for _, n := range names {
+		addEdges(reg, n, target, nameSet, inDegree, dependents)
+	}
+
+	return inDegree, dependents
+}
+
+func addEdges(
+	reg *registry,
+	n metric.Name,
+	target metric.Target,
+	nameSet map[metric.Name]bool,
+	inDegree map[metric.Name]int,
+	dependents map[metric.Name][]metric.Name,
+) {
+	p, ok := reg.get(n, target)
+	if !ok || p == nil {
+		return
+	}
+
+	for _, dep := range p.Dependencies() {
+		if nameSet[dep] {
+			inDegree[n]++
+			dependents[dep] = append(dependents[dep], n)
+		}
+	}
+}
+```
+
+- [ ] **Step 3: Update run_test.go calls**
+
+All calls to `runWithRegistry(reg, root, requested, progress)` become `runWithRegistry(reg, root, requested, metric.File, progress)`.
+
+- [ ] **Step 4: Run tests for the provider package**
+
+Run: `go test ./internal/provider/...`
+Expected: All provider tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/provider/run.go internal/provider/run_test.go
+git commit -m "feat(provider): add target parameter to Run and internal helpers
+
+Part of #405."
+```
+
+---
+
+### Task 6: Update caller sites — stages and inks packages
+
+**Files:**
+- Modify: `internal/stages/metrics.go`
+- Modify: `internal/inks/inks.go`
+- Modify: `internal/scatter/stages.go`
+- Modify: `internal/scatter/inks.go`
+- Modify: `internal/spiral/aggregation.go`
+- Modify: `internal/spiral/inks.go`
+
+- [ ] **Step 1: Update internal/stages/metrics.go**
+
+Change `provider.GetDescriptor(fillMetric)` → `provider.GetDescriptor(fillMetric, metric.File)`:
+
+```go
+func ResolveFillPalette(fill *config.MetricSpec, fillMetric metric.Name) palette.PaletteName {
+	if fp := fill.PaletteName(); fp != "" {
+		return fp
+	}
+
+	if d, ok := provider.GetDescriptor(fillMetric, metric.File); ok {
+		return d.DefaultPalette
+	}
+
+	return palette.Neutral
+}
+
+func ResolveBorderMetricAndPalette(border *config.MetricSpec) (metric.Name, palette.PaletteName) {
+	borderMetric := border.MetricName()
+	if borderMetric == "" {
+		return "", ""
+	}
+
+	borderPaletteName := border.PaletteName()
+	if borderPaletteName == "" {
+		if d, ok := provider.GetDescriptor(borderMetric, metric.File); ok {
+			borderPaletteName = d.DefaultPalette
+		} else {
+			borderPaletteName = palette.Neutral
+		}
+	}
+
+	return borderMetric, borderPaletteName
+}
+```
+
+Add `"github.com/theunrepentantgeek/code-visualizer/internal/metric"` to the import if not already there.
+
+- [ ] **Step 2: Update internal/inks/inks.go**
+
+Change `provider.GetDescriptor(m)` → `provider.GetDescriptor(m, metric.File)`.
+
+- [ ] **Step 3: Update internal/scatter/stages.go and internal/scatter/inks.go**
+
+Change all `provider.GetDescriptor(metricName)` → `provider.GetDescriptor(metricName, metric.File)`.
+
+- [ ] **Step 4: Update internal/spiral/aggregation.go and internal/spiral/inks.go**
+
+Change all `provider.GetDescriptor(m)` → `provider.GetDescriptor(m, metric.File)`.
+
+- [ ] **Step 5: Build to verify**
+
+Run: `go build ./internal/...`
+Expected: Internal packages compile. Cmd packages may still fail (next task).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/stages/metrics.go internal/inks/inks.go internal/scatter/stages.go \
+  internal/scatter/inks.go internal/spiral/aggregation.go internal/spiral/inks.go
+git commit -m "fix: update internal packages to pass metric.File to provider lookups
+
+Part of #405."
+```
+
+---
+
+### Task 7: Update caller sites — config and cmd packages
+
+**Files:**
+- Modify: `internal/config/metric_spec.go`
+- Modify: `cmd/codeviz/treemap_cmd.go`
+- Modify: `cmd/codeviz/bubbletree_cmd.go`
+- Modify: `cmd/codeviz/spiral_cmd.go`
+- Modify: `cmd/codeviz/radialtree_cmd.go`
+- Modify: `cmd/codeviz/scatter_cmd.go`
+- Modify: `cmd/codeviz/help_metrics_cmd.go`
+
+- [ ] **Step 1: Update internal/config/metric_spec.go**
+
+Change `Validate` method. Replace `provider.Get(m.Metric)` with `provider.Get(m.Metric, metric.File)` and `provider.Names()` with `provider.Names(metric.File)`:
+
+```go
+func (m *MetricSpec) Validate(label string) error {
+	if m == nil {
+		return nil
+	}
+
+	if m.Metric != "" {
+		if _, ok := provider.Get(m.Metric, metric.File); !ok {
+			names := provider.Names(metric.File)
+			strs := make([]string, len(names))
+
+			for i, n := range names {
+				strs[i] = string(n)
+			}
+
+			return eris.Errorf("invalid %s metric %q; available metrics: %s", label, m.Metric, strings.Join(strs, ", "))
+		}
+	}
+
+	if m.Palette != "" {
+		if !m.Palette.IsValid() {
+			return eris.Errorf("invalid %s palette %q", label, m.Palette)
+		}
+	}
+
+	return nil
+}
+```
+
+Add `"github.com/theunrepentantgeek/code-visualizer/internal/metric"` to imports.
+
+- [ ] **Step 2: Update treemap_cmd.go**
+
+Change `provider.GetDescriptor(metric.Name(size))` → `provider.GetDescriptor(metric.Name(size), metric.File)`.
+Change `provider.Names()` → `provider.Names(metric.File)`.
+
+- [ ] **Step 3: Update bubbletree_cmd.go, spiral_cmd.go, radialtree_cmd.go, scatter_cmd.go**
+
+Same pattern: add `metric.File` argument to all `provider.GetDescriptor()` calls.
+
+- [ ] **Step 4: Update help_metrics_cmd.go**
+
+Change `provider.AllDescriptors()` → `provider.AllDescriptors(metric.File)`.
+
+- [ ] **Step 5: Build and test the full project**
+
+Run: `task test`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/config/metric_spec.go cmd/codeviz/treemap_cmd.go \
+  cmd/codeviz/bubbletree_cmd.go cmd/codeviz/spiral_cmd.go \
+  cmd/codeviz/radialtree_cmd.go cmd/codeviz/scatter_cmd.go \
+  cmd/codeviz/help_metrics_cmd.go
+git commit -m "fix: update config and cmd packages to pass metric.File target
+
+Part of #405."
+```
+
+---
+
+### Task 8: Update pipeline stages that call provider.Run
+
+**Files:**
+- Modify: `internal/stages/progress.go` (or wherever `provider.Run` is called from pipeline stages)
+
+- [ ] **Step 1: Find all callers of provider.Run**
+
+Search for `provider.Run(` in `.go` files to locate the call sites.
+
+- [ ] **Step 2: Add metric.File target parameter**
+
+Change each `provider.Run(root, requested, progress)` to `provider.Run(root, requested, metric.File, progress)`.
+
+- [ ] **Step 3: Build and test**
+
+Run: `task test`
+Expected: All tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -u
+git commit -m "fix: pass metric.File target to provider.Run in pipeline stages
+
+Part of #405."
+```
+
+---
+
+### Task 9: Add FindWithHint test and integrate into validation
+
+**Files:**
+- Create: `internal/provider/find_with_hint_test.go`
+- Modify: `cmd/codeviz/treemap_cmd.go` (use FindWithHint for better errors)
+
+- [ ] **Step 1: Write FindWithHint tests**
+
+```go
+// internal/provider/find_with_hint_test.go
+package provider
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
+)
+
+func TestFindWithHint_Found(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	oldReg := globalRegistry
+	defer func() { globalRegistry = oldReg }()
+
+	globalRegistry = newRegistry()
+	globalRegistry.register(&stubProvider{name: "file-size", kind: metric.Quantity, target: metric.File})
+
+	p, err := FindWithHint("file-size", metric.File)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(p.Name()).To(Equal(metric.Name("file-size")))
+}
+
+func TestFindWithHint_WrongTarget(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	oldReg := globalRegistry
+	defer func() { globalRegistry = oldReg }()
+
+	globalRegistry = newRegistry()
+	globalRegistry.register(&stubProvider{name: "dir-count", kind: metric.Quantity, target: metric.Directory})
+
+	_, err := FindWithHint("dir-count", metric.File)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("exists for target"))
+	g.Expect(err.Error()).To(ContainSubstring("directory"))
+}
+
+func TestFindWithHint_NotFound(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	oldReg := globalRegistry
+	defer func() { globalRegistry = oldReg }()
+
+	globalRegistry = newRegistry()
+
+	_, err := FindWithHint("nonexistent", metric.File)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("unknown file metric"))
+	g.Expect(err.Error()).ToNot(ContainSubstring("exists for target"))
+}
+```
+
+- [ ] **Step 2: Run FindWithHint tests**
+
+Run: `go test ./internal/provider/ -run TestFindWithHint -v`
+Expected: PASS
+
+- [ ] **Step 3: Integrate FindWithHint into treemap validateConfig**
+
+Update `treemap_cmd.go` `validateConfig`:
+
+```go
+func (*TreemapCmd) validateConfig(cfg *config.Treemap) error {
+	size := ptrString(cfg.Size)
+
+	p, err := provider.FindWithHint(metric.Name(size), metric.File)
+	if err != nil {
+		return eris.Wrap(err, "invalid size metric")
+	}
+
+	d := provider.Descriptor(p)
+	if d.Kind != metric.Quantity && d.Kind != metric.Measure {
+		return eris.Errorf("size metric must be numeric, got %q (kind: %d)", size, d.Kind)
+	}
+
+	if err := cfg.Fill.Validate("fill"); err != nil {
+		return eris.Wrap(err, "invalid fill spec")
+	}
+
+	if err := cfg.Border.Validate("border"); err != nil {
+		return eris.Wrap(err, "invalid border spec")
+	}
+
+	return nil
+}
+```
+
+Note: `provider.Descriptor(p)` accepts a `provider.Interface` (the `Descriptor` helper function), which is already defined.
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `task test`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/provider/find_with_hint_test.go cmd/codeviz/treemap_cmd.go
+git commit -m "feat: add FindWithHint tests and integrate into treemap validation
+
+Provides actionable error messages when a metric exists for a different
+target type. Part of #405."
+```
+
+---
+
+### Task 10: Update help metrics table with Target column
+
+**Files:**
+- Modify: `cmd/codeviz/help_metrics_cmd.go`
+
+- [ ] **Step 1: Add Target column to the metrics table**
+
+Update `writeProviderGroupTable`:
+
+```go
+func writeProviderGroupTable(content *strings.Builder, group []provider.MetricDescriptor) {
+	tbl := table.New("Metric", "Target", "Kind", "Default Palette", "Description")
+	tbl.SetMaxWidth(consoleWidth())
+
+	for _, d := range group {
+		tbl.AddRow(string(d.Name), d.Target.String(), kindLabel(d.Kind), string(d.DefaultPalette), d.Description)
+	}
+
+	tbl.WriteTo(content)
+}
+```
+
+- [ ] **Step 2: Build and test**
+
+Run: `task test`
+Expected: All tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/codeviz/help_metrics_cmd.go
+git commit -m "feat: add Target column to help metrics output
+
+Shows 'file' or 'directory' for each metric. Part of #405."
+```
+
+---
+
+### Task 11: Run full CI and lint
+
+**Files:** None (validation only)
+
+- [ ] **Step 1: Run full CI**
+
+Run: `task ci`
+Expected: Build, test, and lint all pass.
+
+- [ ] **Step 2: Fix any lint issues**
+
+Address any linting issues that arise from the changes.
+
+- [ ] **Step 3: Commit any lint fixes**
+
+```bash
+git add -u
+git commit -m "fix: resolve lint issues from metric target implementation"
+```
+
+---
+
+### Task 12: Create pull request
+
+**Files:** None
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin feature/metric-targeting
+```
+
+- [ ] **Step 2: Create PR**
+
+```bash
+gh pr create --title "Feature: Metric target types (#405)" \
+  --body "Implements #405 — metric target types.
+
+## Changes
+
+- Added \`metric.Target\` enumeration with \`File\` and \`Directory\` values
+- Extended \`provider.Interface\` with \`Target()\` method
+- Restructured registry to \`map[Target]map[Name]Interface\`
+- Updated all public API functions to accept a target parameter
+- Added \`FindWithHint\` for actionable error messages when a metric exists for a wrong target
+- All existing providers classified as \`metric.File\`
+- Added Target column to \`help metrics\` output
+
+Closes #405" \
+  --base main
+```

--- a/docs/superpowers/specs/2026-06-13-metric-target-types-design.md
+++ b/docs/superpowers/specs/2026-06-13-metric-target-types-design.md
@@ -1,0 +1,118 @@
+# Metric Target Types
+
+**Issue:** #405  
+**Date:** 2026-06-13  
+**Status:** Approved
+
+## Problem
+
+The list of metrics is growing, and it's no longer obvious which metrics apply to files versus directories. We need a classification system that:
+
+1. Labels each metric with what it targets (file or directory).
+2. Separates metrics by target in the registry so same-name metrics can coexist for different targets.
+3. Provides actionable error messages when a metric is requested for the wrong target type.
+
+## Design
+
+### New type: `metric.Target`
+
+Defined in `internal/metric/metric.go`:
+
+```go
+type Target int
+
+const (
+    File      Target = iota // metric applies to individual files
+    Directory               // metric applies to directories (aggregates)
+)
+```
+
+A `String()` method returns `"file"` or `"directory"`.
+
+### Provider Interface addition
+
+`provider.Interface` gains a `Target() metric.Target` method:
+
+```go
+type Interface interface {
+    Name() metric.Name
+    Kind() metric.Kind
+    Target() metric.Target  // NEW
+    Description() string
+    Dependencies() []metric.Name
+    DefaultPalette() palette.PaletteName
+    Loader
+}
+```
+
+`MetricDescriptor` gains a corresponding `Target metric.Target` field, populated by `Descriptor()`.
+
+### Registry restructure
+
+The backing store changes from `map[metric.Name]Interface` to `map[metric.Target]map[metric.Name]Interface`:
+
+```go
+type registry struct {
+    mu        sync.RWMutex
+    providers map[metric.Target]map[metric.Name]Interface
+}
+```
+
+**Registration:** `register(p)` uses `p.Target()` to select the inner map. Panics if the (target, name) pair already exists.
+
+**Lookup:** `get(name, target)` checks the target's inner map.
+
+**Hint generation:** On a miss, iterates other target maps. If the name exists for another target, returns a hint in the error.
+
+### Public API changes
+
+All functions gain a `target metric.Target` parameter:
+
+| Before | After |
+|--------|-------|
+| `Get(name)` | `Get(name, target)` |
+| `GetDescriptor(name)` | `GetDescriptor(name, target)` |
+| `All()` | `All(target)` |
+| `AllDescriptors()` | `AllDescriptors(target)` |
+| `Names()` | `Names(target)` |
+
+New function:
+
+```go
+func FindWithHint(name metric.Name, target metric.Target) (Interface, error)
+```
+
+Returns the provider on success. On failure, returns an error that includes a hint if the metric exists for a different target. Example:
+
+```
+unknown file metric "dir-count"; metric "dir-count" exists for target "directory"
+```
+
+### Provider updates
+
+All existing providers (`filesystem`, `git`, `golang`) implement `Target()` returning `metric.File`. This is the only target in use today; `metric.Directory` is reserved for future directory-level metrics.
+
+The `providerDef` structs in `git` and `golang` packages gain a `target metric.Target` field (defaulting to `metric.File`).
+
+### Caller updates
+
+Every call site for `provider.Get`, `provider.GetDescriptor`, `provider.All`, `provider.AllDescriptors`, and `provider.Names` is updated to pass the appropriate target. Since all current metrics target files, all current callers pass `metric.File`.
+
+Validation in `MetricSpec.Validate` and `TreemapCmd.validateConfig` (and equivalents) use `FindWithHint` for better error messages.
+
+### Help metrics command
+
+The `help metrics` table gains a "Target" column displaying "file" or "directory". Groups continue to be organized by provider package (filesystem/git/go/other).
+
+### Testing
+
+1. **Registry unit tests:** Register same name with different targets, verify lookup returns correct provider for each target, verify hint error on wrong target, verify panic on duplicate (target, name).
+2. **Existing tests:** All pass unchanged since every provider returns `metric.File` and callers pass `metric.File`.
+3. **Help metrics test:** Verifies the new "Target" column appears.
+4. **Integration:** `validateConfig` tests verify hint message when wrong target is used.
+
+## Out of scope
+
+- Defining actual directory-targeted metrics (future work).
+- Aggregation logic for directory metrics.
+- Changes to the model layer (`MetricContainer` already supports both `File` and `Directory`).

--- a/internal/bubbletree/inks.go
+++ b/internal/bubbletree/inks.go
@@ -8,6 +8,7 @@ import (
 	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
 	"github.com/theunrepentantgeek/code-visualizer/internal/model"
 	"github.com/theunrepentantgeek/code-visualizer/internal/palette"
+	"github.com/theunrepentantgeek/code-visualizer/internal/provider"
 )
 
 var (
@@ -38,9 +39,11 @@ func BuildInks(
 		Border: canvas.FixedInk(bubbleDefaultBorder),
 	}
 
-	inks.Fill = pkginks.BuildMetricInk(root, fillMetric, fillPaletteName, bubbleDefaultFileFill)
+	fillDesc, _ := provider.GetDescriptor(fillMetric, metric.File)
+	inks.Fill = pkginks.BuildMetricInk(root, fillDesc, fillPaletteName, bubbleDefaultFileFill)
 	if borderMetric != "" {
-		inks.Border = pkginks.BuildMetricInk(root, borderMetric, borderPaletteName, bubbleDefaultBorder)
+		borderDesc, _ := provider.GetDescriptor(borderMetric, metric.File)
+		inks.Border = pkginks.BuildMetricInk(root, borderDesc, borderPaletteName, bubbleDefaultBorder)
 		inks.HasBorderMetric = true
 	}
 

--- a/internal/bubbletree/inks.go
+++ b/internal/bubbletree/inks.go
@@ -41,6 +41,7 @@ func BuildInks(
 
 	fillDesc, _ := provider.GetDescriptor(fillMetric, metric.File)
 	inks.Fill = pkginks.BuildMetricInk(root, fillDesc, fillPaletteName, bubbleDefaultFileFill)
+
 	if borderMetric != "" {
 		borderDesc, _ := provider.GetDescriptor(borderMetric, metric.File)
 		inks.Border = pkginks.BuildMetricInk(root, borderDesc, borderPaletteName, bubbleDefaultBorder)

--- a/internal/config/metric_spec.go
+++ b/internal/config/metric_spec.go
@@ -100,7 +100,7 @@ func (m *MetricSpec) Validate(label string) error {
 
 	if m.Metric != "" {
 		if _, ok := provider.Get(m.Metric, metric.File); !ok {
-			names := provider.Names(metric.File)
+			names := provider.NamesFor(metric.File)
 			strs := make([]string, len(names))
 
 			for i, n := range names {

--- a/internal/config/metric_spec.go
+++ b/internal/config/metric_spec.go
@@ -99,15 +99,8 @@ func (m *MetricSpec) Validate(label string) error {
 	}
 
 	if m.Metric != "" {
-		if _, ok := provider.Get(m.Metric, metric.File); !ok {
-			names := provider.NamesFor(metric.File)
-			strs := make([]string, len(names))
-
-			for i, n := range names {
-				strs[i] = string(n)
-			}
-
-			return eris.Errorf("invalid %s metric %q; available metrics: %s", label, m.Metric, strings.Join(strs, ", "))
+		if _, err := provider.FindWithHint(m.Metric, metric.File); err != nil {
+			return eris.Wrapf(err, "invalid %s metric", label)
 		}
 	}
 

--- a/internal/config/metric_spec.go
+++ b/internal/config/metric_spec.go
@@ -99,8 +99,8 @@ func (m *MetricSpec) Validate(label string) error {
 	}
 
 	if m.Metric != "" {
-		if _, ok := provider.Get(m.Metric); !ok {
-			names := provider.Names()
+		if _, ok := provider.Get(m.Metric, metric.File); !ok {
+			names := provider.Names(metric.File)
 			strs := make([]string, len(names))
 
 			for i, n := range names {

--- a/internal/config/metric_spec_test.go
+++ b/internal/config/metric_spec_test.go
@@ -369,7 +369,8 @@ func TestMetricSpec_Validate_UnknownMetric_ReturnsError(t *testing.T) {
 	ms := &MetricSpec{Metric: "not-a-real-metric"}
 	err := ms.Validate("fill")
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(err).To(MatchError(ContainSubstring(`invalid fill metric "not-a-real-metric"`)))
+	g.Expect(err).To(MatchError(ContainSubstring(`invalid fill metric`)))
+	g.Expect(err).To(MatchError(ContainSubstring(`"not-a-real-metric"`)))
 }
 
 func TestMetricSpec_Validate_KnownMetricAndValidPalette_ReturnsNil(t *testing.T) {

--- a/internal/inks/inks.go
+++ b/internal/inks/inks.go
@@ -22,7 +22,7 @@ func BuildMetricInk(
 	palName palette.PaletteName,
 	fallback color.RGBA,
 ) canvas.Ink {
-	d, ok := provider.GetDescriptor(m)
+	d, ok := provider.GetDescriptor(m, metric.File)
 	if !ok {
 		return canvas.FixedInk(fallback)
 	}

--- a/internal/inks/inks.go
+++ b/internal/inks/inks.go
@@ -18,29 +18,28 @@ import (
 // fixed-colour ink when the metric is unknown or when no values are present.
 func BuildMetricInk(
 	root *model.Directory,
-	m metric.Name,
+	d provider.MetricDescriptor,
 	palName palette.PaletteName,
 	fallback color.RGBA,
 ) canvas.Ink {
-	d, ok := provider.GetDescriptor(m, metric.File)
-	if !ok {
+	if d.Name == "" {
 		return canvas.FixedInk(fallback)
 	}
 
 	pal := palette.GetPalette(palName)
 
 	if d.Kind == metric.Quantity || d.Kind == metric.Measure {
-		values := CollectNumericValues(root, m)
+		values := CollectNumericValues(root, d.Name)
 		if len(values) == 0 {
 			return canvas.FixedInk(fallback)
 		}
 
-		return canvas.NumericInk(m, values, pal)
+		return canvas.NumericInk(d.Name, values, pal)
 	}
 
-	types := CollectDistinctTypes(root, m)
+	types := CollectDistinctTypes(root, d.Name)
 
-	return canvas.CategoricalInk(m, types, pal)
+	return canvas.CategoricalInk(d.Name, types, pal)
 }
 
 // MetricValueForFile builds a MetricValue from a file's data for the given

--- a/internal/inks/inks_test.go
+++ b/internal/inks/inks_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
 	"github.com/theunrepentantgeek/code-visualizer/internal/model"
 	"github.com/theunrepentantgeek/code-visualizer/internal/palette"
+	"github.com/theunrepentantgeek/code-visualizer/internal/provider"
 	"github.com/theunrepentantgeek/code-visualizer/internal/provider/filesystem"
 )
 
@@ -29,6 +30,17 @@ func makeFile(name, ext string, size int64) *model.File {
 	f.SetClassification(filesystem.FileType, ext)
 
 	return f
+}
+
+func descriptorFor(t *testing.T, name metric.Name) provider.MetricDescriptor {
+	t.Helper()
+
+	d, ok := provider.GetDescriptor(name, metric.File)
+	if !ok {
+		t.Fatalf("descriptor not found for %q", name)
+	}
+
+	return d
 }
 
 func TestCollectDistinctTypes_ReturnsSortedTypes(t *testing.T) {
@@ -79,7 +91,7 @@ func TestBuildMetricInk_NumericKind(t *testing.T) {
 		},
 	}
 
-	ink := inks.BuildMetricInk(root, filesystem.FileSize, palette.Temperature, fallbackColour())
+	ink := inks.BuildMetricInk(root, descriptorFor(t, filesystem.FileSize), palette.Temperature, fallbackColour())
 
 	g.Expect(ink.Info().Kind).To(Equal(canvas.InkNumeric))
 }
@@ -96,7 +108,7 @@ func TestBuildMetricInk_CategoricalKind(t *testing.T) {
 		},
 	}
 
-	ink := inks.BuildMetricInk(root, filesystem.FileType, palette.Categorization, fallbackColour())
+	ink := inks.BuildMetricInk(root, descriptorFor(t, filesystem.FileType), palette.Categorization, fallbackColour())
 
 	g.Expect(ink.Info().Kind).To(Equal(canvas.InkCategorical))
 }
@@ -107,7 +119,7 @@ func TestBuildMetricInk_UnknownMetricFallsBackToFixed(t *testing.T) {
 
 	root := &model.Directory{Path: "/p"}
 
-	ink := inks.BuildMetricInk(root, metric.Name("does-not-exist"), palette.Temperature, fallbackColour())
+	ink := inks.BuildMetricInk(root, provider.MetricDescriptor{}, palette.Temperature, fallbackColour())
 
 	g.Expect(ink.Info().Kind).To(Equal(canvas.InkFixed))
 }
@@ -119,7 +131,7 @@ func TestBuildMetricInk_EmptyNumericFallsBackToFixed(t *testing.T) {
 	// Numeric descriptor exists, but the tree has no files → no values.
 	root := &model.Directory{Path: "/p"}
 
-	ink := inks.BuildMetricInk(root, filesystem.FileSize, palette.Temperature, fallbackColour())
+	ink := inks.BuildMetricInk(root, descriptorFor(t, filesystem.FileSize), palette.Temperature, fallbackColour())
 
 	g.Expect(ink.Info().Kind).To(Equal(canvas.InkFixed))
 }
@@ -130,7 +142,7 @@ func TestMetricValueForFile_NumericInk(t *testing.T) {
 
 	file := makeFile("a.go", "go", 42)
 	root := &model.Directory{Path: "/p", Files: []*model.File{file}}
-	ink := inks.BuildMetricInk(root, filesystem.FileSize, palette.Temperature, fallbackColour())
+	ink := inks.BuildMetricInk(root, descriptorFor(t, filesystem.FileSize), palette.Temperature, fallbackColour())
 
 	mv := inks.MetricValueForFile(file, ink)
 
@@ -144,7 +156,7 @@ func TestMetricValueForFile_CategoricalInk(t *testing.T) {
 
 	file := makeFile("a.go", "go", 1)
 	root := &model.Directory{Path: "/p", Files: []*model.File{file}}
-	ink := inks.BuildMetricInk(root, filesystem.FileType, palette.Categorization, fallbackColour())
+	ink := inks.BuildMetricInk(root, descriptorFor(t, filesystem.FileType), palette.Categorization, fallbackColour())
 
 	mv := inks.MetricValueForFile(file, ink)
 

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -13,3 +13,23 @@ const (
 	Measure                    // float64 values (percentages, rates)
 	Classification             // string values (file type, category)
 )
+
+// Target classifies what a metric applies to.
+type Target int
+
+const (
+	File      Target = iota // metric applies to individual files
+	Directory               // metric applies to directories (aggregates)
+)
+
+// String returns the human-readable label for the target.
+func (t Target) String() string {
+	switch t {
+	case File:
+		return "file"
+	case Directory:
+		return "directory"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/metric/target_test.go
+++ b/internal/metric/target_test.go
@@ -1,0 +1,22 @@
+package metric
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestTargetString(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	g.Expect(File.String()).To(Equal("file"))
+	g.Expect(Directory.String()).To(Equal("directory"))
+}
+
+func TestTargetStringUnknown(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	g.Expect(Target(99).String()).To(Equal("unknown"))
+}

--- a/internal/provider/filesystem/metrics.go
+++ b/internal/provider/filesystem/metrics.go
@@ -39,6 +39,7 @@ type FileSizeProvider struct{}
 
 func (FileSizeProvider) Name() metric.Name                   { return FileSize }
 func (FileSizeProvider) Kind() metric.Kind                   { return metric.Quantity }
+func (FileSizeProvider) Target() metric.Target               { return metric.File }
 func (FileSizeProvider) Description() string                 { return "Size of each file in bytes." }
 func (FileSizeProvider) Dependencies() []metric.Name         { return nil }
 func (FileSizeProvider) DefaultPalette() palette.PaletteName { return palette.Neutral }
@@ -49,6 +50,7 @@ type FileTypeProvider struct{}
 
 func (FileTypeProvider) Name() metric.Name                   { return FileType }
 func (FileTypeProvider) Kind() metric.Kind                   { return metric.Classification }
+func (FileTypeProvider) Target() metric.Target               { return metric.File }
 func (FileTypeProvider) Description() string                 { return "File extension category (e.g. go, md, png)." }
 func (FileTypeProvider) Dependencies() []metric.Name         { return nil }
 func (FileTypeProvider) DefaultPalette() palette.PaletteName { return palette.Categorization }
@@ -61,6 +63,7 @@ type FileLinesProvider struct {
 
 func (*FileLinesProvider) Name() metric.Name                   { return FileLines }
 func (*FileLinesProvider) Kind() metric.Kind                   { return metric.Quantity }
+func (*FileLinesProvider) Target() metric.Target               { return metric.File }
 func (*FileLinesProvider) Description() string                 { return "Number of lines in each text file." }
 func (*FileLinesProvider) Dependencies() []metric.Name         { return nil }
 func (*FileLinesProvider) DefaultPalette() palette.PaletteName { return palette.Neutral }

--- a/internal/provider/find_with_hint_test.go
+++ b/internal/provider/find_with_hint_test.go
@@ -1,0 +1,72 @@
+package provider
+
+import (
+	"sync"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
+)
+
+var findWithHintTestMu sync.Mutex
+
+func TestFindWithHint_Found(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	findWithHintTestMu.Lock()
+	defer findWithHintTestMu.Unlock()
+
+	oldReg := globalRegistry
+	defer func() { globalRegistry = oldReg }()
+
+	globalRegistry = newRegistry()
+	globalRegistry.register(&stubProvider{name: "file-size", kind: metric.Quantity, target: metric.File})
+
+	p, err := FindWithHint("file-size", metric.File)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	if p == nil {
+		t.Fatal("expected provider")
+	}
+
+	g.Expect(p.Name()).To(Equal(metric.Name("file-size")))
+}
+
+func TestFindWithHint_WrongTarget(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	findWithHintTestMu.Lock()
+	defer findWithHintTestMu.Unlock()
+
+	oldReg := globalRegistry
+	defer func() { globalRegistry = oldReg }()
+
+	globalRegistry = newRegistry()
+	globalRegistry.register(&stubProvider{name: "dir-count", kind: metric.Quantity, target: metric.Directory})
+
+	_, err := FindWithHint("dir-count", metric.File)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("exists for target"))
+	g.Expect(err.Error()).To(ContainSubstring("directory"))
+}
+
+func TestFindWithHint_NotFound(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	findWithHintTestMu.Lock()
+	defer findWithHintTestMu.Unlock()
+
+	oldReg := globalRegistry
+	defer func() { globalRegistry = oldReg }()
+
+	globalRegistry = newRegistry()
+
+	_, err := FindWithHint("nonexistent", metric.File)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("unknown file metric"))
+	g.Expect(err.Error()).ToNot(ContainSubstring("exists for target"))
+}

--- a/internal/provider/git/git_provider.go
+++ b/internal/provider/git/git_provider.go
@@ -23,6 +23,7 @@ type gitProvider struct {
 
 func (p *gitProvider) Name() metric.Name                   { return p.name }
 func (p *gitProvider) Kind() metric.Kind                   { return p.kind }
+func (*gitProvider) Target() metric.Target                 { return metric.File }
 func (p *gitProvider) Description() string                 { return p.description }
 func (*gitProvider) Dependencies() []metric.Name           { return nil }
 func (p *gitProvider) DefaultPalette() palette.PaletteName { return p.defaultPalette }

--- a/internal/provider/golang/go_provider.go
+++ b/internal/provider/golang/go_provider.go
@@ -30,6 +30,7 @@ type goProvider struct {
 
 func (p *goProvider) Name() metric.Name                   { return p.name }
 func (p *goProvider) Kind() metric.Kind                   { return p.kind }
+func (*goProvider) Target() metric.Target                 { return metric.File }
 func (p *goProvider) Description() string                 { return p.description }
 func (*goProvider) Dependencies() []metric.Name           { return nil }
 func (p *goProvider) DefaultPalette() palette.PaletteName { return p.defaultPalette }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -13,6 +13,7 @@ import (
 type MetricDescriptor struct {
 	Name           metric.Name
 	Kind           metric.Kind
+	Target         metric.Target
 	Description    string
 	Dependencies   []metric.Name
 	DefaultPalette palette.PaletteName
@@ -31,6 +32,7 @@ type Loader interface {
 type Interface interface {
 	Name() metric.Name
 	Kind() metric.Kind
+	Target() metric.Target
 	Description() string
 	Dependencies() []metric.Name
 	DefaultPalette() palette.PaletteName
@@ -44,6 +46,7 @@ func Descriptor(p Interface) MetricDescriptor {
 	return MetricDescriptor{
 		Name:           p.Name(),
 		Kind:           p.Kind(),
+		Target:         p.Target(),
 		Description:    p.Description(),
 		Dependencies:   p.Dependencies(),
 		DefaultPalette: p.DefaultPalette(),

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -27,15 +27,18 @@ func (r *registry) register(p Interface) {
 	defer r.mu.Unlock()
 
 	target := p.Target()
-	if r.providers[target] == nil {
-		r.providers[target] = make(map[metric.Name]Interface)
+	targetProviders := r.providers[target]
+
+	if targetProviders == nil {
+		targetProviders = make(map[metric.Name]Interface)
+		r.providers[target] = targetProviders
 	}
 
-	if _, exists := r.providers[target][p.Name()]; exists {
+	if _, exists := targetProviders[p.Name()]; exists {
 		panic(fmt.Sprintf("provider %q already registered for target %q", p.Name(), target))
 	}
 
-	r.providers[target][p.Name()] = p
+	targetProviders[p.Name()] = p
 }
 
 func (r *registry) get(name metric.Name, target metric.Target) (Interface, bool) {

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -10,44 +10,61 @@ import (
 	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
 )
 
-// registry holds registered metric providers.
+// registry holds registered metric providers, grouped by target type.
 type registry struct {
 	mu        sync.RWMutex
-	providers map[metric.Name]Interface
+	providers map[metric.Target]map[metric.Name]Interface
 }
 
 func newRegistry() *registry {
-	return &registry{providers: make(map[metric.Name]Interface)}
+	return &registry{
+		providers: make(map[metric.Target]map[metric.Name]Interface),
+	}
 }
 
 func (r *registry) register(p Interface) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if _, exists := r.providers[p.Name()]; exists {
-		panic(fmt.Sprintf("provider %q already registered", p.Name()))
+	target := p.Target()
+	if r.providers[target] == nil {
+		r.providers[target] = make(map[metric.Name]Interface)
 	}
 
-	r.providers[p.Name()] = p
+	if _, exists := r.providers[target][p.Name()]; exists {
+		panic(fmt.Sprintf("provider %q already registered for target %q", p.Name(), target))
+	}
+
+	r.providers[target][p.Name()] = p
 }
 
-func (r *registry) get(name metric.Name) (Interface, bool) {
+func (r *registry) get(name metric.Name, target metric.Target) (Interface, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	p, ok := r.providers[name]
+	inner := r.providers[target]
+	if inner == nil {
+		return nil, false
+	}
+
+	p, ok := inner[name]
 	if !ok || p == nil {
 		return nil, false
 	}
 
-	return p, ok
+	return p, true
 }
 
-func (r *registry) all() []Interface {
+func (r *registry) all(target metric.Target) []Interface {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	result := slices.Collect(maps.Values(r.providers))
+	inner := r.providers[target]
+	if inner == nil {
+		return nil
+	}
+
+	result := slices.Collect(maps.Values(inner))
 	slices.SortFunc(
 		result,
 		func(left Interface, right Interface) int {
@@ -58,30 +75,66 @@ func (r *registry) all() []Interface {
 	return result
 }
 
-func (r *registry) names() []metric.Name {
+func (r *registry) names(target metric.Target) []metric.Name {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	names := slices.Collect(maps.Keys(r.providers))
+	inner := r.providers[target]
+	if inner == nil {
+		return nil
+	}
 
+	names := slices.Collect(maps.Keys(inner))
 	slices.SortFunc(names, cmp.Compare)
 
 	return names
 }
 
+// hasName reports whether any target has a provider with the given name.
+func (r *registry) hasName(name metric.Name) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, inner := range r.providers {
+		if _, ok := inner[name]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// targetsForName returns all targets that have a provider with the given name.
+func (r *registry) targetsForName(name metric.Name) []metric.Target {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var targets []metric.Target
+
+	for target, inner := range r.providers {
+		if _, ok := inner[name]; ok {
+			targets = append(targets, target)
+		}
+	}
+
+	return targets
+}
+
 // globalRegistry is the process-wide provider registry.
 var globalRegistry = newRegistry()
 
-// Register adds a provider to the global registry. Panics on duplicate name.
+// Register adds a provider to the global registry.
+// Panics on duplicate (name, target) pair.
 func Register(p Interface) { globalRegistry.register(p) }
 
-// Get retrieves a provider by name from the global registry.
-func Get(name metric.Name) (Interface, bool) { return globalRegistry.get(name) }
+// Get retrieves a provider by name and target from the global registry.
+func Get(name metric.Name, target metric.Target) (Interface, bool) {
+	return globalRegistry.get(name, target)
+}
 
-// GetDescriptor retrieves only the metadata for a provider by name.
-// Use this instead of Get() when you only need provider metadata.
-func GetDescriptor(name metric.Name) (MetricDescriptor, bool) {
-	p, ok := globalRegistry.get(name)
+// GetDescriptor retrieves only the metadata for a provider by name and target.
+func GetDescriptor(name metric.Name, target metric.Target) (MetricDescriptor, bool) {
+	p, ok := globalRegistry.get(name, target)
 	if !ok {
 		return MetricDescriptor{}, false
 	}
@@ -89,13 +142,12 @@ func GetDescriptor(name metric.Name) (MetricDescriptor, bool) {
 	return Descriptor(p), true
 }
 
-// All returns all registered providers.
-func All() []Interface { return globalRegistry.all() }
+// All returns all registered providers for the given target.
+func All(target metric.Target) []Interface { return globalRegistry.all(target) }
 
-// AllDescriptors returns metadata for all registered providers.
-// Use this instead of All() when you only need provider metadata.
-func AllDescriptors() []MetricDescriptor {
-	providers := globalRegistry.all()
+// AllDescriptors returns metadata for all registered providers for the given target.
+func AllDescriptors(target metric.Target) []MetricDescriptor {
+	providers := globalRegistry.all(target)
 
 	descriptors := make([]MetricDescriptor, len(providers))
 	for i, p := range providers {
@@ -105,8 +157,26 @@ func AllDescriptors() []MetricDescriptor {
 	return descriptors
 }
 
-// Names returns the sorted names of all registered providers.
-func Names() []metric.Name { return globalRegistry.names() }
+// Names returns the sorted names of all registered providers for the given target.
+func Names(target metric.Target) []metric.Name { return globalRegistry.names(target) }
+
+// FindWithHint looks up a provider by name and target. On failure, it checks
+// whether the metric exists for a different target and includes that as a hint.
+func FindWithHint(name metric.Name, target metric.Target) (Interface, error) {
+	p, ok := globalRegistry.get(name, target)
+	if ok {
+		return p, nil
+	}
+
+	targets := globalRegistry.targetsForName(name)
+	if len(targets) > 0 {
+		return nil, fmt.Errorf(
+			"unknown %s metric %q; metric %q exists for target %q",
+			target, name, name, targets[0])
+	}
+
+	return nil, fmt.Errorf("unknown %s metric %q", target, name)
+}
 
 // ResetRegistryForTesting clears the global registry. Test use only.
 func ResetRegistryForTesting() {

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 	"sync"
 
 	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
@@ -234,9 +235,18 @@ func FindWithHint(name metric.Name, target metric.Target) (Interface, error) {
 
 	targets := globalRegistry.targetsForName(name)
 	if len(targets) > 0 {
+		slices.SortFunc(targets, func(a, b metric.Target) int {
+			return cmp.Compare(a.String(), b.String())
+		})
+
+		targetStrs := make([]string, len(targets))
+		for i, t := range targets {
+			targetStrs[i] = t.String()
+		}
+
 		return nil, fmt.Errorf(
-			"unknown %s metric %q; metric %q exists for target %q",
-			target, name, name, targets[0],
+			"unknown %s metric %q; metric %q exists for target(s): %s",
+			target, name, name, strings.Join(targetStrs, ", "),
 		)
 	}
 

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -172,7 +172,8 @@ func FindWithHint(name metric.Name, target metric.Target) (Interface, error) {
 	if len(targets) > 0 {
 		return nil, fmt.Errorf(
 			"unknown %s metric %q; metric %q exists for target %q",
-			target, name, name, targets[0])
+			target, name, name, targets[0],
+		)
 	}
 
 	return nil, fmt.Errorf("unknown %s metric %q", target, name)

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -58,7 +58,33 @@ func (r *registry) get(name metric.Name, target metric.Target) (Interface, bool)
 	return p, true
 }
 
-func (r *registry) all(target metric.Target) []Interface {
+func (r *registry) all() []Interface {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var result []Interface
+
+	for _, inner := range r.providers {
+		for _, provider := range inner {
+			result = append(result, provider)
+		}
+	}
+
+	slices.SortFunc(
+		result,
+		func(left Interface, right Interface) int {
+			if byName := cmp.Compare(left.Name(), right.Name()); byName != 0 {
+				return byName
+			}
+
+			return cmp.Compare(left.Target(), right.Target())
+		},
+	)
+
+	return result
+}
+
+func (r *registry) allFor(target metric.Target) []Interface {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -78,7 +104,24 @@ func (r *registry) all(target metric.Target) []Interface {
 	return result
 }
 
-func (r *registry) names(target metric.Target) []metric.Name {
+func (r *registry) names() []metric.Name {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	unique := make(map[metric.Name]struct{})
+	for _, inner := range r.providers {
+		for name := range inner {
+			unique[name] = struct{}{}
+		}
+	}
+
+	names := slices.Collect(maps.Keys(unique))
+	slices.SortFunc(names, cmp.Compare)
+
+	return names
+}
+
+func (r *registry) namesFor(target metric.Target) []metric.Name {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -145,12 +188,15 @@ func GetDescriptor(name metric.Name, target metric.Target) (MetricDescriptor, bo
 	return Descriptor(p), true
 }
 
-// All returns all registered providers for the given target.
-func All(target metric.Target) []Interface { return globalRegistry.all(target) }
+// All returns all registered providers across all targets.
+func All() []Interface { return globalRegistry.all() }
 
-// AllDescriptors returns metadata for all registered providers for the given target.
-func AllDescriptors(target metric.Target) []MetricDescriptor {
-	providers := globalRegistry.all(target)
+// AllFor returns all registered providers for the given target.
+func AllFor(target metric.Target) []Interface { return globalRegistry.allFor(target) }
+
+// AllDescriptors returns metadata for all registered providers across all targets.
+func AllDescriptors() []MetricDescriptor {
+	providers := globalRegistry.all()
 
 	descriptors := make([]MetricDescriptor, len(providers))
 	for i, p := range providers {
@@ -160,8 +206,23 @@ func AllDescriptors(target metric.Target) []MetricDescriptor {
 	return descriptors
 }
 
-// Names returns the sorted names of all registered providers for the given target.
-func Names(target metric.Target) []metric.Name { return globalRegistry.names(target) }
+// AllDescriptorsFor returns metadata for all registered providers for the given target.
+func AllDescriptorsFor(target metric.Target) []MetricDescriptor {
+	providers := globalRegistry.allFor(target)
+
+	descriptors := make([]MetricDescriptor, len(providers))
+	for i, p := range providers {
+		descriptors[i] = Descriptor(p)
+	}
+
+	return descriptors
+}
+
+// Names returns the sorted, deduplicated names of all registered providers across all targets.
+func Names() []metric.Name { return globalRegistry.names() }
+
+// NamesFor returns the sorted names of all registered providers for the given target.
+func NamesFor(target metric.Target) []metric.Name { return globalRegistry.namesFor(target) }
 
 // FindWithHint looks up a provider by name and target. On failure, it checks
 // whether the metric exists for a different target and includes that as a hint.

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -110,6 +110,7 @@ func (r *registry) names() []metric.Name {
 	defer r.mu.RUnlock()
 
 	unique := make(map[metric.Name]struct{})
+
 	for _, inner := range r.providers {
 		for name := range inner {
 			unique[name] = struct{}{}

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -12,12 +12,14 @@ import (
 
 // stubProvider is a minimal Interface implementation for testing.
 type stubProvider struct {
-	name metric.Name
-	kind metric.Kind
+	name   metric.Name
+	kind   metric.Kind
+	target metric.Target
 }
 
 func (s *stubProvider) Name() metric.Name                 { return s.name }
 func (s *stubProvider) Kind() metric.Kind                 { return s.kind }
+func (s *stubProvider) Target() metric.Target             { return s.target }
 func (*stubProvider) Description() string                 { return "" }
 func (*stubProvider) Dependencies() []metric.Name         { return nil }
 func (*stubProvider) DefaultPalette() palette.PaletteName { return palette.Neutral }
@@ -28,7 +30,7 @@ func TestRegisterAndGet(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	reg := newRegistry()
-	p := &stubProvider{name: "test-metric", kind: metric.Quantity}
+	p := &stubProvider{name: "test-metric", kind: metric.Quantity, target: metric.File}
 	reg.register(p)
 
 	got, ok := reg.get("test-metric")
@@ -41,6 +43,7 @@ func TestRegisterAndGet(t *testing.T) {
 
 	g.Expect(got.Name()).To(Equal(metric.Name("test-metric")))
 	g.Expect(got.Kind()).To(Equal(metric.Quantity))
+	g.Expect(got.Target()).To(Equal(metric.File))
 }
 
 func TestGetUnregistered(t *testing.T) {
@@ -57,8 +60,8 @@ func TestAllProviders(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	reg := newRegistry()
-	reg.register(&stubProvider{name: "m1", kind: metric.Quantity})
-	reg.register(&stubProvider{name: "m2", kind: metric.Classification})
+	reg.register(&stubProvider{name: "m1", kind: metric.Quantity, target: metric.File})
+	reg.register(&stubProvider{name: "m2", kind: metric.Classification, target: metric.File})
 
 	all := reg.all()
 	g.Expect(all).To(HaveLen(2))
@@ -69,10 +72,10 @@ func TestRegisterDuplicatePanics(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	reg := newRegistry()
-	reg.register(&stubProvider{name: "dup", kind: metric.Quantity})
+	reg.register(&stubProvider{name: "dup", kind: metric.Quantity, target: metric.File})
 
 	g.Expect(func() {
-		reg.register(&stubProvider{name: "dup", kind: metric.Quantity})
+		reg.register(&stubProvider{name: "dup", kind: metric.Quantity, target: metric.File})
 	}).To(Panic())
 }
 
@@ -81,10 +84,19 @@ func TestNamesSorted(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	reg := newRegistry()
-	reg.register(&stubProvider{name: "zebra", kind: metric.Quantity})
-	reg.register(&stubProvider{name: "alpha", kind: metric.Quantity})
-	reg.register(&stubProvider{name: "mid", kind: metric.Quantity})
+	reg.register(&stubProvider{name: "zebra", kind: metric.Quantity, target: metric.File})
+	reg.register(&stubProvider{name: "alpha", kind: metric.Quantity, target: metric.File})
+	reg.register(&stubProvider{name: "mid", kind: metric.Quantity, target: metric.File})
 
 	names := reg.names()
 	g.Expect(names).To(Equal([]metric.Name{"alpha", "mid", "zebra"}))
+}
+
+func TestDescriptorIncludesTarget(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	desc := Descriptor(&stubProvider{name: "test-metric", kind: metric.Quantity, target: metric.Directory})
+
+	g.Expect(desc.Target).To(Equal(metric.Directory))
 }

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -36,6 +36,11 @@ func TestRegisterAndGet(t *testing.T) {
 	got, ok := reg.get("test-metric", metric.File)
 	g.Expect(ok).To(BeTrue())
 	g.Expect(got).ToNot(BeNil())
+
+	if got == nil {
+		return
+	}
+
 	g.Expect(got.Name()).To(Equal(metric.Name("test-metric")))
 }
 
@@ -66,15 +71,28 @@ func TestSameNameDifferentTargets(t *testing.T) {
 	reg := newRegistry()
 	fileP := &stubProvider{name: "size", kind: metric.Quantity, target: metric.File}
 	dirP := &stubProvider{name: "size", kind: metric.Quantity, target: metric.Directory}
+
 	reg.register(fileP)
 	reg.register(dirP)
 
 	gotFile, ok := reg.get("size", metric.File)
 	g.Expect(ok).To(BeTrue())
+	g.Expect(gotFile).ToNot(BeNil())
+
+	if gotFile == nil {
+		return
+	}
+
 	g.Expect(gotFile.Target()).To(Equal(metric.File))
 
 	gotDir, ok := reg.get("size", metric.Directory)
 	g.Expect(ok).To(BeTrue())
+	g.Expect(gotDir).ToNot(BeNil())
+
+	if gotDir == nil {
+		return
+	}
+
 	g.Expect(gotDir.Target()).To(Equal(metric.Directory))
 }
 

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -105,11 +105,27 @@ func TestAllProviders(t *testing.T) {
 	reg.register(&stubProvider{name: "m2", kind: metric.Classification, target: metric.File})
 	reg.register(&stubProvider{name: "m3", kind: metric.Quantity, target: metric.Directory})
 
-	all := reg.all(metric.File)
+	all := reg.allFor(metric.File)
 	g.Expect(all).To(HaveLen(2))
 
-	allDir := reg.all(metric.Directory)
+	allDir := reg.allFor(metric.Directory)
 	g.Expect(allDir).To(HaveLen(1))
+}
+
+func TestAllProvidersAcrossTargets(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	reg := newRegistry()
+	reg.register(&stubProvider{name: "zeta", kind: metric.Quantity, target: metric.Directory})
+	reg.register(&stubProvider{name: "alpha", kind: metric.Quantity, target: metric.File})
+	reg.register(&stubProvider{name: "mid", kind: metric.Classification, target: metric.Directory})
+
+	all := reg.all()
+	g.Expect(all).To(HaveLen(3))
+	g.Expect([]metric.Name{all[0].Name(), all[1].Name(), all[2].Name()}).To(
+		Equal([]metric.Name{"alpha", "mid", "zeta"}),
+	)
 }
 
 func TestRegisterDuplicatePanics(t *testing.T) {
@@ -145,7 +161,21 @@ func TestNamesSorted(t *testing.T) {
 	reg.register(&stubProvider{name: "alpha", kind: metric.Quantity, target: metric.File})
 	reg.register(&stubProvider{name: "mid", kind: metric.Quantity, target: metric.File})
 
-	names := reg.names(metric.File)
+	names := reg.namesFor(metric.File)
+	g.Expect(names).To(Equal([]metric.Name{"alpha", "mid", "zebra"}))
+}
+
+func TestNamesDeduplicateAcrossTargets(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	reg := newRegistry()
+	reg.register(&stubProvider{name: "zebra", kind: metric.Quantity, target: metric.File})
+	reg.register(&stubProvider{name: "alpha", kind: metric.Quantity, target: metric.File})
+	reg.register(&stubProvider{name: "alpha", kind: metric.Quantity, target: metric.Directory})
+	reg.register(&stubProvider{name: "mid", kind: metric.Quantity, target: metric.Directory})
+
+	names := reg.names()
 	g.Expect(names).To(Equal([]metric.Name{"alpha", "mid", "zebra"}))
 }
 

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -123,9 +123,13 @@ func TestAllProvidersAcrossTargets(t *testing.T) {
 
 	all := reg.all()
 	g.Expect(all).To(HaveLen(3))
-	g.Expect([]metric.Name{all[0].Name(), all[1].Name(), all[2].Name()}).To(
-		Equal([]metric.Name{"alpha", "mid", "zeta"}),
-	)
+
+	names := make([]metric.Name, len(all))
+	for i, p := range all {
+		names[i] = p.Name()
+	}
+
+	g.Expect(names).To(Equal([]metric.Name{"alpha", "mid", "zeta"}))
 }
 
 func TestRegisterDuplicatePanics(t *testing.T) {

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -33,17 +33,21 @@ func TestRegisterAndGet(t *testing.T) {
 	p := &stubProvider{name: "test-metric", kind: metric.Quantity, target: metric.File}
 	reg.register(p)
 
-	got, ok := reg.get("test-metric")
+	got, ok := reg.get("test-metric", metric.File)
 	g.Expect(ok).To(BeTrue())
 	g.Expect(got).ToNot(BeNil())
-
-	if got == nil {
-		return
-	}
-
 	g.Expect(got.Name()).To(Equal(metric.Name("test-metric")))
-	g.Expect(got.Kind()).To(Equal(metric.Quantity))
-	g.Expect(got.Target()).To(Equal(metric.File))
+}
+
+func TestGetWithWrongTarget(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	reg := newRegistry()
+	reg.register(&stubProvider{name: "test-metric", kind: metric.Quantity, target: metric.File})
+
+	_, ok := reg.get("test-metric", metric.Directory)
+	g.Expect(ok).To(BeFalse())
 }
 
 func TestGetUnregistered(t *testing.T) {
@@ -51,8 +55,27 @@ func TestGetUnregistered(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	reg := newRegistry()
-	_, ok := reg.get("nonexistent")
+	_, ok := reg.get("nonexistent", metric.File)
 	g.Expect(ok).To(BeFalse())
+}
+
+func TestSameNameDifferentTargets(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	reg := newRegistry()
+	fileP := &stubProvider{name: "size", kind: metric.Quantity, target: metric.File}
+	dirP := &stubProvider{name: "size", kind: metric.Quantity, target: metric.Directory}
+	reg.register(fileP)
+	reg.register(dirP)
+
+	gotFile, ok := reg.get("size", metric.File)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(gotFile.Target()).To(Equal(metric.File))
+
+	gotDir, ok := reg.get("size", metric.Directory)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(gotDir.Target()).To(Equal(metric.Directory))
 }
 
 func TestAllProviders(t *testing.T) {
@@ -62,9 +85,13 @@ func TestAllProviders(t *testing.T) {
 	reg := newRegistry()
 	reg.register(&stubProvider{name: "m1", kind: metric.Quantity, target: metric.File})
 	reg.register(&stubProvider{name: "m2", kind: metric.Classification, target: metric.File})
+	reg.register(&stubProvider{name: "m3", kind: metric.Quantity, target: metric.Directory})
 
-	all := reg.all()
+	all := reg.all(metric.File)
 	g.Expect(all).To(HaveLen(2))
+
+	allDir := reg.all(metric.Directory)
+	g.Expect(allDir).To(HaveLen(1))
 }
 
 func TestRegisterDuplicatePanics(t *testing.T) {
@@ -79,6 +106,18 @@ func TestRegisterDuplicatePanics(t *testing.T) {
 	}).To(Panic())
 }
 
+func TestDuplicateNameDifferentTargetDoesNotPanic(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	reg := newRegistry()
+	reg.register(&stubProvider{name: "dup", kind: metric.Quantity, target: metric.File})
+
+	g.Expect(func() {
+		reg.register(&stubProvider{name: "dup", kind: metric.Quantity, target: metric.Directory})
+	}).ToNot(Panic())
+}
+
 func TestNamesSorted(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
@@ -88,15 +127,32 @@ func TestNamesSorted(t *testing.T) {
 	reg.register(&stubProvider{name: "alpha", kind: metric.Quantity, target: metric.File})
 	reg.register(&stubProvider{name: "mid", kind: metric.Quantity, target: metric.File})
 
-	names := reg.names()
+	names := reg.names(metric.File)
 	g.Expect(names).To(Equal([]metric.Name{"alpha", "mid", "zebra"}))
 }
 
-func TestDescriptorIncludesTarget(t *testing.T) {
+func TestHasName(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	desc := Descriptor(&stubProvider{name: "test-metric", kind: metric.Quantity, target: metric.Directory})
+	reg := newRegistry()
+	reg.register(&stubProvider{name: "exists", kind: metric.Quantity, target: metric.File})
 
-	g.Expect(desc.Target).To(Equal(metric.Directory))
+	g.Expect(reg.hasName("exists")).To(BeTrue())
+	g.Expect(reg.hasName("missing")).To(BeFalse())
+}
+
+func TestTargetsForName(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	reg := newRegistry()
+	reg.register(&stubProvider{name: "size", kind: metric.Quantity, target: metric.File})
+	reg.register(&stubProvider{name: "size", kind: metric.Quantity, target: metric.Directory})
+
+	targets := reg.targetsForName("size")
+	g.Expect(targets).To(ConsistOf(metric.File, metric.Directory))
+
+	targets = reg.targetsForName("missing")
+	g.Expect(targets).To(BeEmpty())
 }

--- a/internal/provider/run.go
+++ b/internal/provider/run.go
@@ -121,6 +121,19 @@ func visitDep(
 
 	p, ok := reg.get(name, target)
 	if !ok || p == nil {
+		targets := reg.targetsForName(name)
+		if len(targets) > 0 {
+			targetStrs := make([]string, len(targets))
+			for i, t := range targets {
+				targetStrs[i] = t.String()
+			}
+
+			return eris.Errorf(
+				"unknown %s metric %q; metric %q exists for target(s): %s",
+				target, name, name, strings.Join(targetStrs, ", "),
+			)
+		}
+
 		return eris.Errorf(
 			"unknown %s metric %q; available metrics: %s",
 			target,

--- a/internal/provider/run.go
+++ b/internal/provider/run.go
@@ -121,25 +121,7 @@ func visitDep(
 
 	p, ok := reg.get(name, target)
 	if !ok || p == nil {
-		targets := reg.targetsForName(name)
-		if len(targets) > 0 {
-			targetStrs := make([]string, len(targets))
-			for i, t := range targets {
-				targetStrs[i] = t.String()
-			}
-
-			return eris.Errorf(
-				"unknown %s metric %q; metric %q exists for target(s): %s",
-				target, name, name, strings.Join(targetStrs, ", "),
-			)
-		}
-
-		return eris.Errorf(
-			"unknown %s metric %q; available metrics: %s",
-			target,
-			name,
-			formatNames(reg.namesFor(target)),
-		)
+		return metricNotFoundError(reg, name, target)
 	}
 
 	seen[name] = true
@@ -152,6 +134,30 @@ func visitDep(
 	}
 
 	return nil
+}
+
+// metricNotFoundError builds an error for a missing metric, including a hint
+// if the metric exists for a different target.
+func metricNotFoundError(reg *registry, name metric.Name, target metric.Target) error {
+	targets := reg.targetsForName(name)
+	if len(targets) > 0 {
+		targetStrs := make([]string, len(targets))
+		for i, t := range targets {
+			targetStrs[i] = t.String()
+		}
+
+		return eris.Errorf(
+			"unknown %s metric %q; metric %q exists for target(s): %s",
+			target, name, name, strings.Join(targetStrs, ", "),
+		)
+	}
+
+	return eris.Errorf(
+		"unknown %s metric %q; available metrics: %s",
+		target,
+		name,
+		formatNames(reg.namesFor(target)),
+	)
 }
 
 // topoSort groups metrics into execution levels. Each level's metrics have

--- a/internal/provider/run.go
+++ b/internal/provider/run.go
@@ -26,21 +26,27 @@ type FileProgressReporter interface {
 
 // Run loads the requested metrics (plus transitive dependencies) onto the tree.
 // Providers run in parallel where dependency ordering allows.
-func Run(root *model.Directory, requested []metric.Name, progress MetricProgress) error {
-	return runWithRegistry(globalRegistry, root, requested, progress)
+func Run(root *model.Directory, requested []metric.Name, target metric.Target, progress MetricProgress) error {
+	return runWithRegistry(globalRegistry, root, requested, target, progress)
 }
 
-func runWithRegistry(reg *registry, root *model.Directory, requested []metric.Name, progress MetricProgress) error {
+func runWithRegistry(
+	reg *registry,
+	root *model.Directory,
+	requested []metric.Name,
+	target metric.Target,
+	progress MetricProgress,
+) error {
 	if len(requested) == 0 {
 		return nil
 	}
 
-	expanded, err := expandDeps(reg, requested)
+	expanded, err := expandDeps(reg, requested, target)
 	if err != nil {
 		return err
 	}
 
-	levels, err := topoSort(reg, expanded)
+	levels, err := topoSort(reg, expanded, target)
 	if err != nil {
 		return err
 	}
@@ -49,7 +55,7 @@ func runWithRegistry(reg *registry, root *model.Directory, requested []metric.Na
 		g := new(errgroup.Group)
 
 		for _, name := range level {
-			p, _ := reg.get(name)
+			p, _ := reg.get(name, target)
 
 			g.Go(func() error {
 				return runProvider(p, root, name, progress)
@@ -88,13 +94,13 @@ func runProvider(p Interface, root *model.Directory, name metric.Name, progress 
 }
 
 // expandDeps returns the transitive closure of requested metric names.
-func expandDeps(reg *registry, requested []metric.Name) ([]metric.Name, error) {
+func expandDeps(reg *registry, requested []metric.Name, target metric.Target) ([]metric.Name, error) {
 	seen := make(map[metric.Name]bool)
 
 	var result []metric.Name
 
 	for _, name := range requested {
-		if err := visitDep(reg, name, seen, &result); err != nil {
+		if err := visitDep(reg, name, seen, &result, target); err != nil {
 			return nil, err
 		}
 	}
@@ -102,21 +108,32 @@ func expandDeps(reg *registry, requested []metric.Name) ([]metric.Name, error) {
 	return result, nil
 }
 
-func visitDep(reg *registry, name metric.Name, seen map[metric.Name]bool, result *[]metric.Name) error {
+func visitDep(
+	reg *registry,
+	name metric.Name,
+	seen map[metric.Name]bool,
+	result *[]metric.Name,
+	target metric.Target,
+) error {
 	if seen[name] {
 		return nil
 	}
 
-	p, ok := reg.get(name)
+	p, ok := reg.get(name, target)
 	if !ok || p == nil {
-		return eris.Errorf("unknown metric %q; available metrics: %s", name, formatNames(reg.names()))
+		return eris.Errorf(
+			"unknown %s metric %q; available metrics: %s",
+			target,
+			name,
+			formatNames(reg.names(target)),
+		)
 	}
 
 	seen[name] = true
 	*result = append(*result, name)
 
 	for _, dep := range p.Dependencies() {
-		if err := visitDep(reg, dep, seen, result); err != nil {
+		if err := visitDep(reg, dep, seen, result, target); err != nil {
 			return err
 		}
 	}
@@ -126,13 +143,17 @@ func visitDep(reg *registry, name metric.Name, seen map[metric.Name]bool, result
 
 // topoSort groups metrics into execution levels. Each level's metrics have
 // all dependencies satisfied by previous levels.
-func topoSort(reg *registry, names []metric.Name) ([][]metric.Name, error) {
-	inDegree, dependents := buildDepGraph(reg, names)
+func topoSort(reg *registry, names []metric.Name, target metric.Target) ([][]metric.Name, error) {
+	inDegree, dependents := buildDepGraph(reg, names, target)
 
 	return computeLevels(names, inDegree, dependents)
 }
 
-func buildDepGraph(reg *registry, names []metric.Name) (map[metric.Name]int, map[metric.Name][]metric.Name) {
+func buildDepGraph(
+	reg *registry,
+	names []metric.Name,
+	target metric.Target,
+) (map[metric.Name]int, map[metric.Name][]metric.Name) {
 	nameSet := make(map[metric.Name]bool, len(names))
 	for _, n := range names {
 		nameSet[n] = true
@@ -146,7 +167,7 @@ func buildDepGraph(reg *registry, names []metric.Name) (map[metric.Name]int, map
 	}
 
 	for _, n := range names {
-		addEdges(reg, n, nameSet, inDegree, dependents)
+		addEdges(reg, target, n, nameSet, inDegree, dependents)
 	}
 
 	return inDegree, dependents
@@ -154,12 +175,13 @@ func buildDepGraph(reg *registry, names []metric.Name) (map[metric.Name]int, map
 
 func addEdges(
 	reg *registry,
+	target metric.Target,
 	n metric.Name,
 	nameSet map[metric.Name]bool,
 	inDegree map[metric.Name]int,
 	dependents map[metric.Name][]metric.Name,
 ) {
-	p, ok := reg.get(n)
+	p, ok := reg.get(n, target)
 	if !ok || p == nil {
 		return
 	}

--- a/internal/provider/run.go
+++ b/internal/provider/run.go
@@ -125,7 +125,7 @@ func visitDep(
 			"unknown %s metric %q; available metrics: %s",
 			target,
 			name,
-			formatNames(reg.names(target)),
+			formatNames(reg.namesFor(target)),
 		)
 	}
 

--- a/internal/provider/run_test.go
+++ b/internal/provider/run_test.go
@@ -38,6 +38,7 @@ type mockProvider struct {
 
 func (m *mockProvider) Name() metric.Name                 { return m.name }
 func (m *mockProvider) Kind() metric.Kind                 { return m.kind }
+func (*mockProvider) Target() metric.Target               { return metric.File }
 func (*mockProvider) Description() string                 { return "" }
 func (m *mockProvider) Dependencies() []metric.Name       { return m.deps }
 func (*mockProvider) DefaultPalette() palette.PaletteName { return palette.Neutral }
@@ -164,6 +165,7 @@ type concurrentProvider struct {
 
 func (c *concurrentProvider) Name() metric.Name                 { return c.name }
 func (*concurrentProvider) Kind() metric.Kind                   { return metric.Quantity }
+func (*concurrentProvider) Target() metric.Target               { return metric.File }
 func (*concurrentProvider) Description() string                 { return "" }
 func (*concurrentProvider) Dependencies() []metric.Name         { return nil }
 func (*concurrentProvider) DefaultPalette() palette.PaletteName { return palette.Neutral }

--- a/internal/provider/run_test.go
+++ b/internal/provider/run_test.go
@@ -59,7 +59,7 @@ func TestRunBasicExecution(t *testing.T) {
 	tracker := &orderTracker{}
 	reg.register(&mockProvider{name: "m1", kind: metric.Quantity, tracker: tracker})
 
-	err := runWithRegistry(reg, nil, []metric.Name{"m1"}, nil)
+	err := runWithRegistry(reg, nil, []metric.Name{"m1"}, metric.File, nil)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(tracker.calls).To(Equal([]metric.Name{"m1"}))
 }
@@ -73,7 +73,7 @@ func TestRunTransitiveDependencies(t *testing.T) {
 	reg.register(&mockProvider{name: "base", kind: metric.Quantity, tracker: tracker})
 	reg.register(&mockProvider{name: "derived", kind: metric.Quantity, deps: []metric.Name{"base"}, tracker: tracker})
 
-	err := runWithRegistry(reg, nil, []metric.Name{"derived"}, nil)
+	err := runWithRegistry(reg, nil, []metric.Name{"derived"}, metric.File, nil)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// "base" must run before "derived"
@@ -103,7 +103,7 @@ func TestRunCycleDetection(t *testing.T) {
 	reg.register(&mockProvider{name: "a", kind: metric.Quantity, deps: []metric.Name{"b"}})
 	reg.register(&mockProvider{name: "b", kind: metric.Quantity, deps: []metric.Name{"a"}})
 
-	err := runWithRegistry(reg, nil, []metric.Name{"a"}, nil)
+	err := runWithRegistry(reg, nil, []metric.Name{"a"}, metric.File, nil)
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err).To(MatchError(ContainSubstring("circular dependency")))
 }
@@ -115,9 +115,9 @@ func TestRunUnknownDependency(t *testing.T) {
 	reg := newRegistry()
 	reg.register(&mockProvider{name: "a", kind: metric.Quantity, deps: []metric.Name{"missing"}})
 
-	err := runWithRegistry(reg, nil, []metric.Name{"a"}, nil)
+	err := runWithRegistry(reg, nil, []metric.Name{"a"}, metric.File, nil)
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(err).To(MatchError(ContainSubstring("unknown metric")))
+	g.Expect(err).To(MatchError(ContainSubstring(`unknown file metric "missing"`)))
 }
 
 func TestRunUnknownRequestedMetric(t *testing.T) {
@@ -126,9 +126,9 @@ func TestRunUnknownRequestedMetric(t *testing.T) {
 
 	reg := newRegistry()
 
-	err := runWithRegistry(reg, nil, []metric.Name{"nonexistent"}, nil)
+	err := runWithRegistry(reg, nil, []metric.Name{"nonexistent"}, metric.File, nil)
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(err).To(MatchError(ContainSubstring("unknown metric")))
+	g.Expect(err).To(MatchError(ContainSubstring(`unknown file metric "nonexistent"`)))
 }
 
 func TestRunUnknownMetricListsAvailable(t *testing.T) {
@@ -139,7 +139,7 @@ func TestRunUnknownMetricListsAvailable(t *testing.T) {
 	reg.register(&mockProvider{name: "alpha", kind: metric.Quantity})
 	reg.register(&mockProvider{name: "beta", kind: metric.Quantity})
 
-	err := runWithRegistry(reg, nil, []metric.Name{"nonexistent"}, nil)
+	err := runWithRegistry(reg, nil, []metric.Name{"nonexistent"}, metric.File, nil)
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err).To(MatchError(ContainSubstring("available metrics: alpha, beta")))
 }
@@ -151,7 +151,7 @@ func TestRunErrorPropagation(t *testing.T) {
 	reg := newRegistry()
 	reg.register(&mockProvider{name: "fail", kind: metric.Quantity, loadErr: errors.New("load failed")})
 
-	err := runWithRegistry(reg, nil, []metric.Name{"fail"}, nil)
+	err := runWithRegistry(reg, nil, []metric.Name{"fail"}, metric.File, nil)
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err).To(MatchError(ContainSubstring("load failed")))
 }
@@ -204,7 +204,7 @@ func TestRunParallelExecution(t *testing.T) {
 	reg.register(&concurrentProvider{name: "p2", counter: &counter, maxConcurrent: &maxConcurrent})
 	reg.register(&concurrentProvider{name: "p3", counter: &counter, maxConcurrent: &maxConcurrent})
 
-	err := runWithRegistry(reg, nil, []metric.Name{"p1", "p2", "p3"}, nil)
+	err := runWithRegistry(reg, nil, []metric.Name{"p1", "p2", "p3"}, metric.File, nil)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(maxConcurrent.Load()).To(BeNumerically(">", 1), "expected concurrent execution")
 }
@@ -215,7 +215,7 @@ func TestRunEmptyRequest(t *testing.T) {
 
 	reg := newRegistry()
 
-	err := runWithRegistry(reg, nil, []metric.Name{}, nil)
+	err := runWithRegistry(reg, nil, []metric.Name{}, metric.File, nil)
 	g.Expect(err).NotTo(HaveOccurred())
 }
 
@@ -230,7 +230,7 @@ func TestRunAutoExpandsDependencies(t *testing.T) {
 	reg.register(&mockProvider{name: "top", kind: metric.Quantity, deps: []metric.Name{"mid"}, tracker: tracker})
 
 	// Only request "top" — "mid" and "base" should be auto-included
-	err := runWithRegistry(reg, nil, []metric.Name{"top"}, nil)
+	err := runWithRegistry(reg, nil, []metric.Name{"top"}, metric.File, nil)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(tracker.calls).To(HaveLen(3))
 }

--- a/internal/radialtree/inks.go
+++ b/internal/radialtree/inks.go
@@ -41,6 +41,7 @@ func BuildInks(
 
 	fillDesc, _ := provider.GetDescriptor(fillMetric, metric.File)
 	inks.Fill = pkginks.BuildMetricInk(root, fillDesc, fillPaletteName, defaultFileFill)
+
 	if borderMetric != "" {
 		borderDesc, _ := provider.GetDescriptor(borderMetric, metric.File)
 		inks.Border = pkginks.BuildMetricInk(root, borderDesc, borderPaletteName, defaultBorder)

--- a/internal/radialtree/inks.go
+++ b/internal/radialtree/inks.go
@@ -8,6 +8,7 @@ import (
 	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
 	"github.com/theunrepentantgeek/code-visualizer/internal/model"
 	"github.com/theunrepentantgeek/code-visualizer/internal/palette"
+	"github.com/theunrepentantgeek/code-visualizer/internal/provider"
 )
 
 var (
@@ -38,9 +39,11 @@ func BuildInks(
 		Border: canvas.FixedInk(defaultBorder),
 	}
 
-	inks.Fill = pkginks.BuildMetricInk(root, fillMetric, fillPaletteName, defaultFileFill)
+	fillDesc, _ := provider.GetDescriptor(fillMetric, metric.File)
+	inks.Fill = pkginks.BuildMetricInk(root, fillDesc, fillPaletteName, defaultFileFill)
 	if borderMetric != "" {
-		inks.Border = pkginks.BuildMetricInk(root, borderMetric, borderPaletteName, defaultBorder)
+		borderDesc, _ := provider.GetDescriptor(borderMetric, metric.File)
+		inks.Border = pkginks.BuildMetricInk(root, borderDesc, borderPaletteName, defaultBorder)
 	}
 
 	return inks

--- a/internal/scatter/inks.go
+++ b/internal/scatter/inks.go
@@ -58,7 +58,7 @@ func buildMetricInk(
 		return canvas.FixedInk(fallback)
 	}
 
-	descriptor, ok := provider.GetDescriptor(name)
+	descriptor, ok := provider.GetDescriptor(name, metric.File)
 	if !ok {
 		return canvas.FixedInk(fallback)
 	}

--- a/internal/scatter/stages.go
+++ b/internal/scatter/stages.go
@@ -50,7 +50,7 @@ func ResolveMetrics(c *stages.CommonState, x *State, cfg *config.Scatter) error 
 
 func resolveAxisSpec(name *string) (AxisSpec, error) {
 	metricName := metric.Name(stages.PtrString(name))
-	descriptor, ok := provider.GetDescriptor(metricName)
+	descriptor, ok := provider.GetDescriptor(metricName, metric.File)
 
 	if !ok {
 		return AxisSpec{}, eris.Errorf("unknown axis metric %q", metricName)

--- a/internal/spiral/aggregation.go
+++ b/internal/spiral/aggregation.go
@@ -45,7 +45,7 @@ func aggregateColourMetric(files []*model.File, m metric.Name, numVal *float64, 
 		return
 	}
 
-	d, ok := provider.GetDescriptor(m)
+	d, ok := provider.GetDescriptor(m, metric.File)
 	if !ok {
 		return
 	}

--- a/internal/spiral/inks.go
+++ b/internal/spiral/inks.go
@@ -65,7 +65,7 @@ func buildBucketInk(
 	categoryFn func(*TimeBucket) string,
 	fallback color.RGBA,
 ) canvas.Ink {
-	d, ok := provider.GetDescriptor(m)
+	d, ok := provider.GetDescriptor(m, metric.File)
 	if !ok {
 		return canvas.FixedInk(fallback)
 	}

--- a/internal/stages/metrics.go
+++ b/internal/stages/metrics.go
@@ -30,7 +30,7 @@ func ResolveFillPalette(fill *config.MetricSpec, fillMetric metric.Name) palette
 		return fp
 	}
 
-	if d, ok := provider.GetDescriptor(fillMetric); ok {
+	if d, ok := provider.GetDescriptor(fillMetric, metric.File); ok {
 		return d.DefaultPalette
 	}
 
@@ -47,7 +47,7 @@ func ResolveBorderMetricAndPalette(border *config.MetricSpec) (metric.Name, pale
 
 	borderPaletteName := border.PaletteName()
 	if borderPaletteName == "" {
-		if d, ok := provider.GetDescriptor(borderMetric); ok {
+		if d, ok := provider.GetDescriptor(borderMetric, metric.File); ok {
 			borderPaletteName = d.DefaultPalette
 		} else {
 			borderPaletteName = palette.Neutral

--- a/internal/stages/providers.go
+++ b/internal/stages/providers.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rotisserie/eris"
 
+	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
 	"github.com/theunrepentantgeek/code-visualizer/internal/model"
 	"github.com/theunrepentantgeek/code-visualizer/internal/provider"
 )
@@ -16,5 +17,5 @@ func RunProviders(c *CommonState) error {
 	metricProg, stopMetricTicker := BuildMetricProgress(c.Flags, model.CountFiles(c.Root))
 	defer stopMetricTicker()
 
-	return eris.Wrap(provider.Run(c.Root, c.Requested, metricProg), "failed to load metrics")
+	return eris.Wrap(provider.Run(c.Root, c.Requested, metric.File, metricProg), "failed to load metrics")
 }

--- a/internal/treemap/inks.go
+++ b/internal/treemap/inks.go
@@ -8,6 +8,7 @@ import (
 	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
 	"github.com/theunrepentantgeek/code-visualizer/internal/model"
 	"github.com/theunrepentantgeek/code-visualizer/internal/palette"
+	"github.com/theunrepentantgeek/code-visualizer/internal/provider"
 )
 
 const (
@@ -42,9 +43,11 @@ func BuildInks(
 		Border: canvas.FixedInk(structuralBorder),
 	}
 
-	inks.Fill = pkginks.BuildMetricInk(root, fillMetric, fillPaletteName, defaultFill)
+	fillDesc, _ := provider.GetDescriptor(fillMetric, metric.File)
+	inks.Fill = pkginks.BuildMetricInk(root, fillDesc, fillPaletteName, defaultFill)
 	if borderMetric != "" {
-		inks.Border = pkginks.BuildMetricInk(root, borderMetric, borderPaletteName, structuralBorder)
+		borderDesc, _ := provider.GetDescriptor(borderMetric, metric.File)
+		inks.Border = pkginks.BuildMetricInk(root, borderDesc, borderPaletteName, structuralBorder)
 	}
 
 	return inks

--- a/internal/treemap/inks.go
+++ b/internal/treemap/inks.go
@@ -45,6 +45,7 @@ func BuildInks(
 
 	fillDesc, _ := provider.GetDescriptor(fillMetric, metric.File)
 	inks.Fill = pkginks.BuildMetricInk(root, fillDesc, fillPaletteName, defaultFill)
+
 	if borderMetric != "" {
 		borderDesc, _ := provider.GetDescriptor(borderMetric, metric.File)
 		inks.Border = pkginks.BuildMetricInk(root, borderDesc, borderPaletteName, structuralBorder)


### PR DESCRIPTION
Implements #405 — metric target types.

## Changes

- Added `metric.Target` enumeration with `File` and `Directory` values
- Extended `provider.Interface` with `Target()` method
- Restructured registry to `map[Target]map[Name]Interface`
- Updated all public API functions to accept a target parameter
- Added `FindWithHint` for actionable error messages when a metric exists for a wrong target
- All existing providers classified as `metric.File`
- Added Target column to `help metrics` output

## Design

Same metric name can now be registered for different targets (e.g. `file-size` for File and `file-size` for Directory). Lookup requires specifying the target, and errors hint at alternative targets when a metric exists elsewhere.

Closes #405