### PR TITLE
Improve help display

### DIFF
--- a/cmd/codeviz/help_list.go
+++ b/cmd/codeviz/help_list.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// nameDescription is a single entry in a help listing: a short identifier
+// paired with a longer human-readable description.
+type nameDescription struct {
+	Name        string
+	Description string
+}
+
+// renderNameDescriptionList renders entries in the same aligned, border-free
+// style used by `help metrics`: an underlined section header followed by a
+// name column aligned to the widest name, with descriptions wrapped to the
+// console width.
+func renderNameDescriptionList(title string, entries []nameDescription, width int) string {
+	content := &strings.Builder{}
+
+	if title != "" {
+		writeSectionHeader(content, title)
+	}
+
+	nameWidth := 0
+	for _, entry := range entries {
+		nameWidth = max(nameWidth, utf8.RuneCountInString(entry.Name))
+	}
+
+	for _, entry := range entries {
+		writeNameDescriptionBlock(content, nameWidth, entry, width)
+	}
+
+	return content.String()
+}
+
+func writeNameDescriptionBlock(content *strings.Builder, nameWidth int, entry nameDescription, width int) {
+	prefix := fmt.Sprintf("  %-*s  ", nameWidth, entry.Name)
+
+	if utf8.RuneCountInString(prefix) >= width {
+		writeWrappedText(content, "  ", entry.Name, width)
+		writeWrappedText(content, "    ", entry.Description, width)
+		content.WriteString("\n")
+
+		return
+	}
+
+	writeWrappedText(content, prefix, entry.Description, width)
+	content.WriteString("\n")
+}

--- a/cmd/codeviz/help_palettes_cmd.go
+++ b/cmd/codeviz/help_palettes_cmd.go
@@ -2,13 +2,11 @@ package main
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/theunrepentantgeek/code-visualizer/internal/palette"
-	"github.com/theunrepentantgeek/code-visualizer/internal/table"
 )
 
-// HelpPalettesCmd prints a table of all available colour palettes.
+// HelpPalettesCmd prints a list of all available colour palettes.
 type HelpPalettesCmd struct{}
 
 const palettesDocURL = "https://github.com/theunrepentantgeek/code-visualizer/blob/main/docs/palettes.md"
@@ -17,19 +15,17 @@ const palettesDocURL = "https://github.com/theunrepentantgeek/code-visualizer/bl
 func (HelpPalettesCmd) Run(_ *Flags) error {
 	infos := palette.Infos()
 
-	tbl := table.New("Palette", "Description")
-
+	entries := make([]nameDescription, 0, len(infos))
 	for _, info := range infos {
-		tbl.AddRow(string(info.Name), info.Description)
+		entries = append(entries, nameDescription{
+			Name:        string(info.Name),
+			Description: info.Description,
+		})
 	}
 
-	content := &strings.Builder{}
+	fmt.Print(renderNameDescriptionList("Palettes", entries, consoleWidth()))
 
-	tbl.WriteTo(content)
-
-	fmt.Print(content.String())
-
-	fmt.Printf("\nFor colour swatches, see: %s\n", palettesDocURL)
+	fmt.Printf("For colour swatches, see: %s\n", palettesDocURL)
 
 	return nil
 }

--- a/cmd/codeviz/help_palettes_cmd_test.go
+++ b/cmd/codeviz/help_palettes_cmd_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/theunrepentantgeek/code-visualizer/internal/palette"
+)
+
+func TestHelpPalettesCmdRun_UsesMetricsStyleLayout(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	output := captureStdout(t, func() {
+		err := (HelpPalettesCmd{}).Run(&Flags{})
+		g.Expect(err).NotTo(HaveOccurred())
+	})
+
+	g.Expect(output).To(ContainSubstring("Palettes\n────────"))
+	g.Expect(output).NotTo(ContainSubstring("|"), "should not use ASCII table borders")
+	g.Expect(output).To(ContainSubstring("For colour swatches, see:"))
+
+	for _, info := range palette.Infos() {
+		g.Expect(output).To(ContainSubstring(string(info.Name)))
+	}
+}
+
+func TestHelpPalettesCmdRun_WrapsOutputToConsoleWidth(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	t.Setenv("COLUMNS", "40")
+
+	output := captureStdout(t, func() {
+		err := (HelpPalettesCmd{}).Run(&Flags{})
+		g.Expect(err).NotTo(HaveOccurred())
+	})
+
+	for line := range strings.SplitSeq(output, "\n") {
+		if strings.Contains(line, "For colour swatches") {
+			continue // the footer URL is intentionally not wrapped
+		}
+
+		g.Expect(utf8.RuneCountInString(line)).To(BeNumerically("<=", 40), "line exceeds console width: %q", line)
+	}
+}

--- a/cmd/codeviz/render_cmd.go
+++ b/cmd/codeviz/render_cmd.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/theunrepentantgeek/code-visualizer/internal/config"
 	"github.com/theunrepentantgeek/code-visualizer/internal/metric"
-	"github.com/theunrepentantgeek/code-visualizer/internal/table"
 )
 
 // RenderCmd renders a named preset — a predefined combination of
@@ -133,16 +132,15 @@ func (r *RenderCmd) Run(flags *Flags) error {
 }
 
 func (*RenderCmd) listPresets() error {
-	tbl := table.New("Preset", "Description")
-	tbl.SetMaxWidth(consoleWidth())
-
+	entries := make([]nameDescription, 0, len(presets))
 	for _, p := range presets {
-		tbl.AddRow(p.Name, p.Description)
+		entries = append(entries, nameDescription{
+			Name:        p.Name,
+			Description: p.Description,
+		})
 	}
 
-	sb := &strings.Builder{}
-	tbl.WriteTo(sb)
-	fmt.Print(sb.String())
+	fmt.Print(renderNameDescriptionList("Presets", entries, consoleWidth()))
 
 	return nil
 }

--- a/cmd/codeviz/render_cmd_test.go
+++ b/cmd/codeviz/render_cmd_test.go
@@ -97,6 +97,23 @@ func TestRenderCmd_AllPresets_RegisteredAndUnique(t *testing.T) {
 	}
 }
 
+func TestRenderCmd_ListPresets_UsesMetricsStyleLayout(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	output := captureStdout(t, func() {
+		err := (&RenderCmd{}).Run(&Flags{})
+		g.Expect(err).NotTo(HaveOccurred())
+	})
+
+	g.Expect(output).To(ContainSubstring("Presets\n───────"))
+	g.Expect(output).NotTo(ContainSubstring("|"), "should not use ASCII table borders")
+
+	for _, p := range presets {
+		g.Expect(output).To(ContainSubstring(p.Name))
+	}
+}
+
 func TestRenderCmd_ParsedFromCLI_NoArgs(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)


### PR DESCRIPTION
This pull request refactors the way help listings for palettes and presets are rendered in the CLI, replacing ASCII table layouts with a more readable, border-free, metrics-style format. It introduces a new utility for rendering aligned name-description lists, updates the relevant commands to use this utility, and adds comprehensive tests to ensure correct formatting and wrapping.
