### PR TITLE
[repo-assist] fix(ci): add build:release step before uploading release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,13 @@ jobs:
           push: never
           runCmd: task ci
 
+      - name: Build release binaries in devcontainer
+        uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3.1900000450
+        with:
+          imageName: ghcr.io/theunrepentantgeek/code-visualizer-devcontainer
+          push: never
+          runCmd: task build:release
+
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2.11.5
         with:


### PR DESCRIPTION
The release workflow ran 'task ci' which only builds bin/codeviz for
the host platform. The subsequent upload step expected cross-platform
binaries in build/* but that directory was never populated.

Added a separate 'Build release binaries' step running 'task build:release'
to produce build/codeviz-{linux,darwin,windows}-{amd64,arm64}(.exe)
before the upload step.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
