### PR TITLE
fix(test): eliminate parallel os.Stdout race in cmd/codeviz output tests

### DIFF
--- a/cmd/codeviz/help_metrics_cmd_test.go
+++ b/cmd/codeviz/help_metrics_cmd_test.go
@@ -10,8 +10,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+//nolint:paralleltest // captureStdout swaps global os.Stdout, so this test cannot run in parallel
 func TestHelpMetricsCmdRun_GroupsMetricsByProvider(t *testing.T) {
-	t.Parallel()
 	g := NewGomegaWithT(t)
 
 	output := captureStdout(t, func() {

--- a/cmd/codeviz/help_palettes_cmd_test.go
+++ b/cmd/codeviz/help_palettes_cmd_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/theunrepentantgeek/code-visualizer/internal/palette"
 )
 
+//nolint:paralleltest // captureStdout swaps global os.Stdout, so this test cannot run in parallel
 func TestHelpPalettesCmdRun_UsesMetricsStyleLayout(t *testing.T) {
-	t.Parallel()
 	g := NewGomegaWithT(t)
 
 	output := captureStdout(t, func() {

--- a/cmd/codeviz/render_cmd_test.go
+++ b/cmd/codeviz/render_cmd_test.go
@@ -97,8 +97,8 @@ func TestRenderCmd_AllPresets_RegisteredAndUnique(t *testing.T) {
 	}
 }
 
+//nolint:paralleltest // captureStdout swaps global os.Stdout, so this test cannot run in parallel
 func TestRenderCmd_ListPresets_UsesMetricsStyleLayout(t *testing.T) {
-	t.Parallel()
 	g := NewGomegaWithT(t)
 
 	output := captureStdout(t, func() {

--- a/internal/bubbletree/transforms_test.go
+++ b/internal/bubbletree/transforms_test.go
@@ -29,10 +29,10 @@ func TestExpandBoundsForDisc_MultipleDiscs(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	box := newEmptyBounds()
-	expandBoundsForDisc(&box, 0, 0, 1)   // bounds: (-1,-1)..(1,1)
-	expandBoundsForDisc(&box, 5, 0, 2)   // extends maxX to 7, maxY to 2, minY to -2
-	expandBoundsForDisc(&box, 0, -4, 1)  // extends minY to -5
-	expandBoundsForDisc(&box, -3, 0, 0)  // extends minX to -3
+	expandBoundsForDisc(&box, 0, 0, 1)  // bounds: (-1,-1)..(1,1)
+	expandBoundsForDisc(&box, 5, 0, 2)  // extends maxX to 7, maxY to 2, minY to -2
+	expandBoundsForDisc(&box, 0, -4, 1) // extends minY to -5
+	expandBoundsForDisc(&box, -3, 0, 0) // extends minX to -3
 
 	g.Expect(box.minX).To(BeNumerically("~", -3.0, 1e-9))
 	g.Expect(box.maxX).To(BeNumerically("~", 7.0, 1e-9))

--- a/internal/scatter/render.go
+++ b/internal/scatter/render.go
@@ -212,7 +212,7 @@ func addScatterPoints(cv *canvas.Canvas, points []ScatterPoint, is Inks) {
 	// canvas.TextColourFor returns exactly one of two values (black or white).
 	darkLabelColour := canvas.TextColourFor(scatterBgColour)
 	darkLabelInk := inks.FixedInk(darkLabelColour)
-lightLabelInk := inks.FixedInk(canvas.TextColourFor(darkLabelColour))
+	lightLabelInk := inks.FixedInk(canvas.TextColourFor(darkLabelColour))
 
 	for _, point := range points {
 		fillValue := inks.MetricValueForFile(point.File, is.Fill)
@@ -228,12 +228,14 @@ lightLabelInk := inks.FixedInk(canvas.TextColourFor(darkLabelColour))
 
 		label, fontSize := scatterLabel(point.Label, point.Radius)
 		labelColour := canvas.TextColourFor(is.Fill.Dip(fillValue))
+
 		var labelInk inks.Ink
 		if labelColour == darkLabelColour {
 			labelInk = darkLabelInk
 		} else {
 			labelInk = lightLabelInk
 		}
+
 		labelSpec := &canvas.TextSpec{
 			Ink:      labelInk,
 			FontSize: fontSize,


### PR DESCRIPTION
## Problem

`captureStdout` (in `cmd/codeviz`) swaps the **global** `os.Stdout` to capture command output. Three tests calling it were marked `t.Parallel()`:

- `TestHelpMetricsCmdRun_GroupsMetricsByProvider`
- `TestHelpPalettesCmdRun_UsesMetricsStyleLayout`
- `TestRenderCmd_ListPresets_UsesMetricsStyleLayout`

Because they ran concurrently, they clobbered each other's redirection. In particular a test's `t.Cleanup` restoring `os.Stdout` could fire *mid-capture* of another test, so the capturing test observed **empty output** and failed intermittently. Locally this reproduced at roughly **15/30 runs** of `go test ./cmd/codeviz/`, and it broke the `test` CI job on unrelated PRs.

A mutex around `captureStdout` is **not** sufficient: the `t.Cleanup` restore runs after the test body returns, outside any lock the helper could hold.

## Fix

Remove `t.Parallel()` from the three `captureStdout` callers so they run sequentially. Non-parallel tests never run concurrently with each other or with parallel tests (parallel tests only resume after all non-parallel tests complete), so the global `os.Stdout` swap is safe. A `//nolint:paralleltest` directive documents why — consistent with the existing `t.Setenv`-based non-parallel `captureStdout` tests.

## Also included

A small `style:` commit normalizes **pre-existing** gofumpt drift in `internal/scatter/render.go` and `internal/bubbletree/transforms_test.go`. `task ci` runs `tidy` (gofumpt) then `verify-no-changes`, which fails CI if any file is reformatted; these files were already out of gofumpt v0.10.0 compliance on `main` and would otherwise block this PR's CI.

## Verification

- `go test ./cmd/codeviz/ -count=1` run **50×**: 0 failures (was ~50% flaky).
- `CI=1 task ci`: passes (build, test, lint 0 issues, verify-no-changes clean).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>