### PR TITLE
Use MatchError() by preference

### DIFF
--- a/internal/canvas/canvas_test.go
+++ b/internal/canvas/canvas_test.go
@@ -456,7 +456,7 @@ func TestCanvas_Render_UnsupportedFormat(t *testing.T) {
 	g.Expect(err).To(HaveOccurred())
 
 	if err != nil {
-		g.Expect(err.Error()).To(ContainSubstring("unsupported"))
+		g.Expect(err).To(MatchError(ContainSubstring("unsupported")))
 	}
 }
 

--- a/internal/canvas/format_test.go
+++ b/internal/canvas/format_test.go
@@ -61,7 +61,7 @@ func TestFormatFromPath_Errors(t *testing.T) {
 
 			_, err := FormatFromPath(tc.path)
 			g.Expect(err).To(HaveOccurred())
-			g.Expect(err.Error()).To(ContainSubstring(tc.errContains))
+			g.Expect(err).To(MatchError(ContainSubstring(tc.errContains)))
 		})
 	}
 }

--- a/internal/canvas/raster/backend_test.go
+++ b/internal/canvas/raster/backend_test.go
@@ -151,7 +151,7 @@ func TestRasterBackend_Finish_UnsupportedFormat(t *testing.T) {
 	g.Expect(err).To(HaveOccurred())
 
 	if err != nil {
-		g.Expect(err.Error()).To(ContainSubstring("unsupported"))
+		g.Expect(err).To(MatchError(ContainSubstring("unsupported")))
 	}
 }
 

--- a/internal/config/selection_metric_test.go
+++ b/internal/config/selection_metric_test.go
@@ -128,7 +128,7 @@ func TestSelectionMetricRule_Validate_EmptyPattern_ReturnsError(t *testing.T) {
 	err := rule.Validate()
 	g.Expect(err).To(HaveOccurred())
 	//nolint:nilaway,nolintlint // guarded by HaveOccurred above
-	g.Expect(err.Error()).To(ContainSubstring("empty glob pattern"))
+	g.Expect(err).To(MatchError(ContainSubstring("empty glob pattern")))
 }
 
 func TestSelectionMetric_Validate_AllValidRules(t *testing.T) {
@@ -159,8 +159,8 @@ func TestSelectionMetric_Validate_InvalidRule_ReturnsError(t *testing.T) {
 	err := m.Validate()
 	g.Expect(err).To(HaveOccurred())
 	//nolint:nilaway,nolintlint // guarded by HaveOccurred above
-	g.Expect(err.Error()).To(ContainSubstring(`"bad-metric"`))
-	g.Expect(err.Error()).To(ContainSubstring(`"broken"`))
+	g.Expect(err).To(MatchError(ContainSubstring(`"bad-metric"`)))
+	g.Expect(err).To(MatchError(ContainSubstring(`"broken"`)))
 }
 
 func TestSelectionMetric_Validate_EmptyRules_Succeeds(t *testing.T) {

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -182,7 +182,7 @@ func TestParseFilterFlag_InvalidGlob(t *testing.T) {
 
 	_, err := ParseFilterFlag("![invalid")
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(err.Error()).To(ContainSubstring("invalid glob pattern"))
+	g.Expect(err).To(MatchError(ContainSubstring("invalid glob pattern")))
 }
 
 func TestParseFilterFlag_EmptyString(t *testing.T) {
@@ -191,7 +191,7 @@ func TestParseFilterFlag_EmptyString(t *testing.T) {
 
 	_, err := ParseFilterFlag("")
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(err.Error()).To(ContainSubstring("empty filter"))
+	g.Expect(err).To(MatchError(ContainSubstring("empty filter")))
 }
 
 func TestParseFilterFlag_BangOnly(t *testing.T) {
@@ -200,7 +200,7 @@ func TestParseFilterFlag_BangOnly(t *testing.T) {
 
 	_, err := ParseFilterFlag("!")
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(err.Error()).To(ContainSubstring("empty filter"))
+	g.Expect(err).To(MatchError(ContainSubstring("empty filter")))
 }
 
 func TestCompareByIndex_ReturnsNegativeForEarlierRule(t *testing.T) {

--- a/internal/metric/expression_test.go
+++ b/internal/metric/expression_test.go
@@ -69,7 +69,7 @@ func TestParseExpression_EmptyStringReturnsError(t *testing.T) {
 
 	_, err := ParseExpression("")
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(err.Error()).To(ContainSubstring("empty"))
+	g.Expect(err).To(MatchError(ContainSubstring("empty")))
 }
 
 func TestParseExpression_TooManySegmentsReturnsError(t *testing.T) {
@@ -78,7 +78,7 @@ func TestParseExpression_TooManySegmentsReturnsError(t *testing.T) {
 
 	_, err := ParseExpression("a.b.c.d")
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(err.Error()).To(ContainSubstring("too many segments"))
+	g.Expect(err).To(MatchError(ContainSubstring("too many segments")))
 }
 
 func TestParseExpression_InvalidCharactersReturnsError(t *testing.T) {
@@ -87,7 +87,7 @@ func TestParseExpression_InvalidCharactersReturnsError(t *testing.T) {
 
 	_, err := ParseExpression("file size")
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(err.Error()).To(ContainSubstring("invalid"))
+	g.Expect(err).To(MatchError(ContainSubstring("invalid")))
 }
 
 func TestParseExpression_ThreeSegmentsUnknownAggregationReturnsError(t *testing.T) {
@@ -96,7 +96,7 @@ func TestParseExpression_ThreeSegmentsUnknownAggregationReturnsError(t *testing.
 
 	_, err := ParseExpression("public.types.total")
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(err.Error()).To(ContainSubstring("aggregation"))
+	g.Expect(err).To(MatchError(ContainSubstring("aggregation")))
 }
 
 func TestParseExpression_EmptySegmentsReturnError(t *testing.T) {
@@ -106,7 +106,7 @@ func TestParseExpression_EmptySegmentsReturnError(t *testing.T) {
 	for _, input := range []string{".a", "a.", "a..b"} {
 		_, err := ParseExpression(input)
 		g.Expect(err).To(HaveOccurred(), input)
-		g.Expect(err.Error()).To(ContainSubstring("invalid"), input)
+		g.Expect(err).To(MatchError(ContainSubstring("invalid")), input)
 	}
 }
 

--- a/internal/provider/resolution_test.go
+++ b/internal/provider/resolution_test.go
@@ -103,8 +103,8 @@ func TestResolveExpression_SameLevelAggregationRejected(t *testing.T) {
 	expr := metric.MetricExpression{Base: "file-size", Aggregation: metric.AggSum}
 	_, err := resolveExpressionWith(reg, expr, metric.LevelFile)
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(err.Error()).To(ContainSubstring("already a per-file metric"))
-	g.Expect(err.Error()).To(ContainSubstring("cross-level"))
+	g.Expect(err).To(MatchError(ContainSubstring("already a per-file metric")))
+	g.Expect(err).To(MatchError(ContainSubstring("cross-level")))
 }
 
 func TestResolveExpression_InvalidAggregationError(t *testing.T) {
@@ -122,9 +122,9 @@ func TestResolveExpression_InvalidAggregationError(t *testing.T) {
 	expr := metric.MetricExpression{Base: "file-size", Aggregation: metric.AggMode}
 	_, err := resolveExpressionWith(reg, expr, metric.LevelDirectory)
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(err.Error()).To(ContainSubstring("mode"))
-	g.Expect(err.Error()).To(ContainSubstring("not a valid aggregation"))
-	g.Expect(err.Error()).To(ContainSubstring("sum, min, max, mean"))
+	g.Expect(err).To(MatchError(ContainSubstring("mode")))
+	g.Expect(err).To(MatchError(ContainSubstring("not a valid aggregation")))
+	g.Expect(err).To(MatchError(ContainSubstring("sum, min, max, mean")))
 }
 
 func TestResolveExpression_InvalidFilterError(t *testing.T) {
@@ -143,8 +143,8 @@ func TestResolveExpression_InvalidFilterError(t *testing.T) {
 	expr := metric.MetricExpression{Filter: "stdlib", Base: "types", Aggregation: metric.AggCount}
 	_, err := resolveExpressionWith(reg, expr, metric.LevelFile)
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(err.Error()).To(ContainSubstring("stdlib"))
-	g.Expect(err.Error()).To(ContainSubstring("not a valid filter"))
+	g.Expect(err).To(MatchError(ContainSubstring("stdlib")))
+	g.Expect(err).To(MatchError(ContainSubstring("not a valid filter")))
 }
 
 func TestResolveExpression_MissingAggregationAtHigherLevel(t *testing.T) {
@@ -162,8 +162,8 @@ func TestResolveExpression_MissingAggregationAtHigherLevel(t *testing.T) {
 	expr := metric.MetricExpression{Base: "cyclomatic-complexity"}
 	_, err := resolveExpressionWith(reg, expr, metric.LevelFile)
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(err.Error()).To(ContainSubstring("requires aggregation"))
-	g.Expect(err.Error()).To(ContainSubstring("sum, max, mean"))
+	g.Expect(err).To(MatchError(ContainSubstring("requires aggregation")))
+	g.Expect(err).To(MatchError(ContainSubstring("sum, max, mean")))
 }
 
 func TestResolveExpression_UnknownBaseMetricError(t *testing.T) {
@@ -175,7 +175,7 @@ func TestResolveExpression_UnknownBaseMetricError(t *testing.T) {
 	expr := metric.MetricExpression{Base: "nonexistent"}
 	_, err := resolveExpressionWith(reg, expr, metric.LevelFile)
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(err.Error()).To(ContainSubstring("unknown base metric"))
+	g.Expect(err).To(MatchError(ContainSubstring("unknown base metric")))
 }
 
 func TestResolveExpression_FilterWithAggregation(t *testing.T) {
@@ -214,5 +214,5 @@ func TestResolveExpression_FilterOnMetricWithNoFilters(t *testing.T) {
 	expr := metric.MetricExpression{Filter: "stdlib", Base: "file-size", Aggregation: metric.AggSum}
 	_, err := resolveExpressionWith(reg, expr, metric.LevelDirectory)
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(err.Error()).To(ContainSubstring("has no filters"))
+	g.Expect(err).To(MatchError(ContainSubstring("has no filters")))
 }

--- a/internal/scatter/layout_test.go
+++ b/internal/scatter/layout_test.go
@@ -437,8 +437,8 @@ func TestValidateLogScale_ErrorsOnZeroValue(t *testing.T) {
 	err := ValidateLogScale(dataset, xAxis, yAxis)
 	g.Expect(err).To(HaveOccurred())
 	//nolint:nilaway,nolintlint // guarded by HaveOccurred above
-	g.Expect(err.Error()).To(ContainSubstring("x-axis"))
-	g.Expect(err.Error()).To(ContainSubstring("zero.go"))
+	g.Expect(err).To(MatchError(ContainSubstring("x-axis")))
+	g.Expect(err).To(MatchError(ContainSubstring("zero.go")))
 }
 
 func TestValidateLogScale_PassesWhenAllPositive(t *testing.T) {

--- a/internal/stages/selection_metrics_test.go
+++ b/internal/stages/selection_metrics_test.go
@@ -118,5 +118,5 @@ selectionMetrics:
 	err := stages.RegisterSelectionMetrics(s)
 	g.Expect(err).To(HaveOccurred())
 	//nolint:nilaway,nolintlint // guarded by HaveOccurred above
-	g.Expect(err.Error()).To(ContainSubstring("invalid selection metric configuration"))
+	g.Expect(err).To(MatchError(ContainSubstring("invalid selection metric configuration")))
 }


### PR DESCRIPTION
This pull request updates various test files to improve error assertion consistency. Specifically, it replaces checks that match error message substrings using `err.Error()` with the more idiomatic `MatchError` assertion from Gomega. This change makes the tests more robust and idiomatic by directly matching error messages, rather than relying on string conversion.
