### PR TITLE
feat(spiral): adapt daily cadence to timeline length

### DIFF
--- a/docs/superpowers/plans/2026-08-09-spiral-cadence.md
+++ b/docs/superpowers/plans/2026-08-09-spiral-cadence.md
@@ -1,0 +1,316 @@
+# Adaptive Spiral Cadence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Adapt daily spiral dots-per-lap to timeline length so midpoint radial and arc spacing are as equal as possible using only 14, 28, 42, or 56 days.
+
+**Architecture:** Add a cadence selector that scores the four daily candidates with the existing Archimedean geometry. Refactor the shared layout parameter calculation to accept an explicit dots-per-lap value, preserve the existing `Resolution`-based public helpers as compatibility wrappers, and have the pipeline store and use the selected value. Hourly continues to pass its fixed 24 dots-per-lap value.
+
+**Tech Stack:** Go 1.26, Gomega, Task.
+
+---
+
+## File Structure
+
+- Create: `internal/spiral/cadence.go` — selects and scores the allowed daily cadence values.
+- Create: `internal/spiral/cadence_test.go` — unit tests for allowed candidates, geometry-optimal selection, tie handling, and fixed hourly cadence.
+- Modify: `internal/spiral/layout.go` — accepts explicit dots-per-lap internally and exposes cadence-aware layout/disc-radius helpers while retaining `Resolution` wrappers.
+- Modify: `internal/spiral/layout_test.go` — tests cadence-aware layout geometry and disc bounds.
+- Modify: `internal/spiral/state.go` — stores the selected dots-per-lap value in pipeline state.
+- Modify: `internal/spiral/stages.go` — selects cadence after buckets are available and feeds it into layout/disc sizing.
+- Modify: `internal/spiral/stages_test.go` — verifies pipeline state selects adaptive daily cadence and keeps hourly fixed.
+
+### Task 1: Select the Daily Cadence
+
+**Files:**
+- Create: `internal/spiral/cadence.go`
+- Create: `internal/spiral/cadence_test.go`
+
+- [ ] **Step 1: Write failing cadence-selector tests**
+
+```go
+func TestDailySpotsPerLapUsesAllowedCadences(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	for _, bucketCount := range []int{1, 14, 28, 100, 365, 730} {
+		g.Expect(DailySpotsPerLap(bucketCount, 1920, 1080)).To(
+			BeElementOf(14, 28, 42, 56),
+		)
+	}
+}
+
+func TestDailySpotsPerLapMinimizesMidpointGapDifference(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	for _, bucketCount := range []int{28, 100, 365, 730} {
+		selected := DailySpotsPerLap(bucketCount, 1920, 1080)
+		selectedScore := dailyCadenceScore(bucketCount, 1920, 1080, selected)
+
+		for _, candidate := range dailyCadences {
+			g.Expect(selectedScore).To(BeNumerically(
+				"<=", dailyCadenceScore(bucketCount, 1920, 1080, candidate),
+			))
+		}
+	}
+}
+
+func TestSelectDailyCadencePrefersTwentyEightOnTie(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	g.Expect(selectDailyCadence(map[int]float64{
+		14: 0.5, 28: 0.5, 42: 1, 56: 2,
+	})).To(Equal(28))
+}
+
+func TestSpotsPerLapKeepsHourlyCadence(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	g.Expect(SpotsPerLap(Hourly, 730, 1920, 1080)).To(Equal(24))
+}
+```
+
+- [ ] **Step 2: Run the selector tests and verify they fail**
+
+Run: `go test ./internal/spiral -run 'Test(DailySpotsPerLap|SelectDailyCadence|SpotsPerLapKeepsHourlyCadence)' -count=1`
+
+Expected: FAIL because `DailySpotsPerLap`, `dailyCadenceScore`, `dailyCadences`, `selectDailyCadence`, and the cadence-aware `SpotsPerLap` function do not exist.
+
+- [ ] **Step 3: Implement the selector**
+
+Create `internal/spiral/cadence.go`:
+
+```go
+package spiral
+
+import "math"
+
+var dailyCadences = []int{14, 28, 42, 56}
+
+func SpotsPerLap(resolution Resolution, bucketCount, width, height int) int {
+	if resolution != Daily {
+		return resolution.SpotsPerLap()
+	}
+
+	return DailySpotsPerLap(bucketCount, width, height)
+}
+
+func DailySpotsPerLap(bucketCount, width, height int) int {
+	scores := make(map[int]float64, len(dailyCadences))
+	for _, candidate := range dailyCadences {
+		scores[candidate] = dailyCadenceScore(bucketCount, width, height, candidate)
+	}
+
+	return selectDailyCadence(scores)
+}
+
+func selectDailyCadence(scores map[int]float64) int {
+	selected := Daily.SpotsPerLap()
+	selectedScore := scores[selected]
+
+	for _, candidate := range dailyCadences {
+		if scores[candidate] < selectedScore {
+			selected, selectedScore = candidate, scores[candidate]
+		}
+	}
+
+	return selected
+}
+
+func dailyCadenceScore(bucketCount, width, height, spotsPerLap int) float64 {
+	params := computeSpiralParams(bucketCount, width, height, spotsPerLap)
+	if bucketCount <= 1 || params.b == 0 {
+		return math.Inf(1)
+	}
+
+	radialGap := 2 * math.Pi * params.b
+	midpointRadius := params.a + params.b*params.totalAngle/2
+	arcGap := midpointRadius * (2 * math.Pi / float64(spotsPerLap))
+
+	return math.Abs(radialGap - arcGap)
+}
+```
+
+Add `totalAngle float64` to `spiralParams` and assign it in
+`computeSpiralParams`. This permits the selector to measure the same
+midpoint geometry as the layout rather than duplicating its formula.
+
+- [ ] **Step 4: Run the selector tests and verify they pass**
+
+Run: `go test ./internal/spiral -run 'Test(DailySpotsPerLap|SelectDailyCadence|SpotsPerLapKeepsHourlyCadence)' -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the selector**
+
+```bash
+git add internal/spiral/cadence.go internal/spiral/cadence_test.go internal/spiral/layout.go
+git commit -m "feat(spiral): select adaptive daily cadence"
+```
+
+### Task 2: Pass the Selected Cadence Through Layout and Pipeline State
+
+**Files:**
+- Modify: `internal/spiral/layout.go`
+- Modify: `internal/spiral/layout_test.go`
+- Modify: `internal/spiral/state.go`
+- Modify: `internal/spiral/stages.go`
+- Modify: `internal/spiral/stages_test.go`
+
+- [ ] **Step 1: Write failing layout and stage tests**
+
+Add to `internal/spiral/layout_test.go`:
+
+```go
+func TestLayoutWithCadenceUsesProvidedSpotsPerLap(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	layout := LayoutWithCadence(makeBuckets(56, Daily), 1920, 1080, 56)
+	g.Expect(layout.Nodes[56-1].Angle).To(
+		BeNumerically("~", 55*(2*math.Pi/56), 0.001),
+	)
+}
+
+func TestMaxDiscRadiusWithCadenceUsesProvidedSpotsPerLap(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	g.Expect(MaxDiscRadiusWithCadence(365, 1920, 1080, 56)).To(
+		BeNumerically(">", MaxDiscRadiusWithCadence(365, 1920, 1080, 14)),
+	)
+}
+```
+
+Add to `internal/spiral/stages_test.go`:
+
+```go
+func TestLayoutStageSelectsAdaptiveDailyCadence(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	common := &stages.CommonState{
+		Width: 1920, Height: 1080,
+		DrawingBounds: stages.DrawingBounds{MaxX: 1920, MaxY: 1080},
+	}
+	viz := &spiral.State{
+		Resolution: spiral.Daily,
+		Buckets:    make([]spiral.TimeBucket, 365),
+	}
+
+	g.Expect(spiral.LayoutStage(common, viz)).To(Succeed())
+	g.Expect(viz.SpotsPerLap).To(Equal(spiral.DailySpotsPerLap(365, 1920, 1080)))
+}
+
+func TestLayoutStageKeepsHourlyCadence(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	common := &stages.CommonState{
+		Width: 1920, Height: 1080,
+		DrawingBounds: stages.DrawingBounds{MaxX: 1920, MaxY: 1080},
+	}
+	viz := &spiral.State{
+		Resolution: spiral.Hourly,
+		Buckets:    make([]spiral.TimeBucket, 720),
+	}
+
+	g.Expect(spiral.LayoutStage(common, viz)).To(Succeed())
+	g.Expect(viz.SpotsPerLap).To(Equal(24))
+}
+```
+
+- [ ] **Step 2: Run the layout and stage tests and verify they fail**
+
+Run: `go test ./internal/spiral -run 'Test(LayoutWithCadence|MaxDiscRadiusWithCadence|LayoutStageSelectsAdaptive|LayoutStageKeepsHourly)' -count=1`
+
+Expected: FAIL because `LayoutWithCadence`, `MaxDiscRadiusWithCadence`, and `State.SpotsPerLap` do not exist.
+
+- [ ] **Step 3: Implement cadence-aware geometry and pipeline wiring**
+
+In `internal/spiral/layout.go`, make `computeSpiralParams` accept
+`spotsPerLap int`. Keep existing public wrappers and add:
+
+```go
+func LayoutWithCadence(
+	buckets []TimeBucket,
+	width, height, spotsPerLap int,
+) SpiralLayout {
+	if len(buckets) == 0 {
+		return SpiralLayout{}
+	}
+
+	nodes := make([]SpiralNode, len(buckets))
+	params := computeSpiralParams(len(buckets), width, height, spotsPerLap)
+	for i, bucket := range buckets {
+		nodes[i] = positionNode(i, bucket, params)
+	}
+
+	return newSpiralLayout(nodes, params)
+}
+
+func MaxDiscRadiusWithCadence(
+	bucketCount, width, height, spotsPerLap int,
+) float64 {
+	if bucketCount == 0 {
+		return defaultDiscRadius
+	}
+
+	return computeSpiralParams(bucketCount, width, height, spotsPerLap).maxDisc
+}
+```
+
+Make `Layout` call `LayoutWithCadence` with `resolution.SpotsPerLap()`, and
+make `MaxDiscRadius` call `MaxDiscRadiusWithCadence` with the same fixed
+resolution cadence. Extract the existing `SpiralLayout` construction into
+`newSpiralLayout(nodes []SpiralNode, params spiralParams)` so both entry points
+return the identical layout metadata.
+
+In `internal/spiral/state.go`, add:
+
+```go
+SpotsPerLap int
+```
+
+after `Resolution`.
+
+In `internal/spiral/stages.go`, replace the existing geometry calls in
+`LayoutStage`:
+
+```go
+p.SpotsPerLap = SpotsPerLap(p.Resolution, len(p.Buckets), c.Width, availH)
+layout := LayoutWithCadence(p.Buckets, c.Width, availH, p.SpotsPerLap)
+maxDisc := MaxDiscRadiusWithCadence(
+	len(p.Buckets), c.Width, availH, p.SpotsPerLap,
+)
+```
+
+Keep the bounds offset, disc sizing, label construction, and all rendering
+logic unchanged.
+
+- [ ] **Step 4: Run targeted tests and verify they pass**
+
+Run: `go test ./internal/spiral -count=1`
+
+Expected: PASS, including existing layout, disc-size, surface, render, and
+stage tests.
+
+- [ ] **Step 5: Run repository validation**
+
+Run: `task test`
+
+Expected: PASS.
+
+Run via an explore subagent: `task lint`
+
+Expected: exit status 0 and no linter issues.
+
+- [ ] **Step 6: Commit the pipeline integration**
+
+```bash
+git add internal/spiral/layout.go internal/spiral/layout_test.go \
+  internal/spiral/state.go internal/spiral/stages.go \
+  internal/spiral/stages_test.go
+git commit -m "feat(spiral): apply adaptive cadence to layout"
+```

--- a/docs/superpowers/specs/2026-08-09-spiral-cadence-design.md
+++ b/docs/superpowers/specs/2026-08-09-spiral-cadence-design.md
@@ -1,0 +1,61 @@
+# Adaptive Spiral Cadence Design
+
+## Goal
+
+Make the daily spiral cadence adapt to timeline length so dots have similar
+spacing in the radial and arc directions near the middle of the spiral. A
+daily lap must contain exactly 14, 28, 42, or 56 dots.
+
+## Scope
+
+The change affects only daily spiral layout. Hourly spirals keep their existing
+24 dots per lap and one-hour bucket duration. No command-line or configuration
+setting is introduced.
+
+## Cadence Selection
+
+After daily time buckets are created, select one candidate dots-per-lap value
+from `14`, `28`, `42`, and `56`.
+
+For each candidate:
+
+1. Derive the candidate's Archimedean spiral parameters for the current bucket
+   count and drawing bounds.
+2. Measure the radial gap between two points at the same angle on adjacent
+   turns.
+3. Measure the arc gap between consecutive points at the spiral's midpoint
+   radius.
+4. Score the candidate by the absolute difference between those two gaps.
+
+Select the candidate with the lowest score. A tie selects 28 dots per lap,
+preserving the established four-week cadence when the geometry gives no
+preference.
+
+The selector returns an explicit dots-per-lap value. `Resolution` remains
+responsible for time-bucket duration only; it must not be repurposed to encode
+the selected daily cadence.
+
+## Integration
+
+Store the selected cadence in spiral pipeline state after bucket construction.
+Pass it to layout and maximum-disc-radius calculations instead of obtaining
+daily dots per lap from `Resolution`. The layout keeps its current canvas
+centering, inner-to-outer radius ratio, clockwise orientation, and rendering
+interfaces.
+
+Daily bucket boundaries remain calendar-day boundaries. The adaptive cadence
+only changes the visual number of daily buckets per revolution, not the buckets
+or aggregated data themselves.
+
+## Validation
+
+Unit tests will confirm:
+
+- Daily selection always returns one of 14, 28, 42, or 56.
+- Each selected candidate minimizes the defined midpoint spacing score for
+  representative short, medium, and long daily timelines.
+- A score tie selects 28.
+- Hourly cadence remains 24.
+- Layout and maximum-disc-radius calculations use the supplied cadence, while
+  existing geometry invariants remain true.
+

--- a/internal/spiral/cadence.go
+++ b/internal/spiral/cadence.go
@@ -1,0 +1,55 @@
+package spiral
+
+import "math"
+
+var dailyCadences = []int{14, 28, 42, 56}
+
+// SpotsPerLap returns the cadence for a layout at the given resolution.
+func SpotsPerLap(resolution Resolution, bucketCount, width, height int) int {
+	if resolution == Daily {
+		return DailySpotsPerLap(bucketCount, width, height)
+	}
+
+	return resolution.SpotsPerLap()
+}
+
+// DailySpotsPerLap selects the daily cadence with the most even midpoint spacing.
+func DailySpotsPerLap(bucketCount, width, height int) int {
+	scores := make(map[int]float64, len(dailyCadences))
+	for _, spotsPerLap := range dailyCadences {
+		scores[spotsPerLap] = dailyCadenceScore(bucketCount, width, height, spotsPerLap)
+	}
+
+	return selectDailyCadence(scores)
+}
+
+func dailyCadenceScore(bucketCount, width, height, spotsPerLap int) float64 {
+	if bucketCount <= 1 {
+		return math.Inf(1)
+	}
+
+	params := computeSpiralParams(bucketCount, width, height, spotsPerLap)
+	if params.b == 0 {
+		return math.Inf(1)
+	}
+
+	radialGap := 2 * math.Pi * params.b
+	midpointRadius := params.a + params.b*params.totalAngle/2
+	arcGap := midpointRadius * (2 * math.Pi / float64(spotsPerLap))
+
+	return math.Abs(radialGap - arcGap)
+}
+
+func selectDailyCadence(scores map[int]float64) int {
+	selected := 28
+	selectedScore := scores[selected]
+
+	for _, candidate := range dailyCadences {
+		if scores[candidate] < selectedScore {
+			selected = candidate
+			selectedScore = scores[candidate]
+		}
+	}
+
+	return selected
+}

--- a/internal/spiral/cadence.go
+++ b/internal/spiral/cadence.go
@@ -29,7 +29,7 @@ func dailyCadenceScore(bucketCount, width, height, spotsPerLap int) float64 {
 	}
 
 	params := computeSpiralParams(bucketCount, width, height, spotsPerLap)
-	if params.b == 0 {
+	if params.b <= 0 {
 		return math.Inf(1)
 	}
 

--- a/internal/spiral/cadence_test.go
+++ b/internal/spiral/cadence_test.go
@@ -61,6 +61,26 @@ func TestDailySpotsPerLapReturns28WhenGeometryHasNoRadialGrowth(t *testing.T) {
 	g.Expect(DailySpotsPerLap(28, width, height)).To(Equal(28))
 }
 
+func TestDailySpotsPerLapReturns28WhenGeometryHasNegativeRadialGrowth(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	const (
+		bucketCount = 28
+		width       = 79
+		height      = 1080
+	)
+
+	for _, candidate := range dailyCadences {
+		g.Expect(dailyCadenceScore(bucketCount, width, height, candidate)).To(
+			Equal(math.Inf(1)),
+			"candidate %d", candidate,
+		)
+	}
+
+	g.Expect(DailySpotsPerLap(bucketCount, width, height)).To(Equal(28))
+}
+
 func TestSelectDailyCadencePrefers28OnEqualScore(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)

--- a/internal/spiral/cadence_test.go
+++ b/internal/spiral/cadence_test.go
@@ -1,6 +1,7 @@
 package spiral
 
 import (
+	"math"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -18,6 +19,13 @@ func TestDailySpotsPerLapReturnsAllowedCadence(t *testing.T) {
 	}
 }
 
+func TestDailySpotsPerLapReturns28ForSingleBucket(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	g.Expect(DailySpotsPerLap(1, 1920, 1080)).To(Equal(28))
+}
+
 func TestDailySpotsPerLapMinimizesCandidateScore(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
@@ -33,6 +41,24 @@ func TestDailySpotsPerLapMinimizesCandidateScore(t *testing.T) {
 			)
 		}
 	}
+}
+
+func TestDailySpotsPerLapReturns28WhenGeometryHasNoRadialGrowth(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	width := int(2 * margin)
+	const height = 1080
+
+	for _, candidate := range dailyCadences {
+		g.Expect(computeSpiralParams(28, width, height, candidate).b).To(BeZero())
+		g.Expect(dailyCadenceScore(28, width, height, candidate)).To(
+			Equal(math.Inf(1)),
+			"candidate %d", candidate,
+		)
+	}
+
+	g.Expect(DailySpotsPerLap(28, width, height)).To(Equal(28))
 }
 
 func TestSelectDailyCadencePrefers28OnEqualScore(t *testing.T) {

--- a/internal/spiral/cadence_test.go
+++ b/internal/spiral/cadence_test.go
@@ -47,8 +47,9 @@ func TestDailySpotsPerLapReturns28WhenGeometryHasNoRadialGrowth(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	width := int(2 * margin)
 	const height = 1080
+
+	width := int(2 * margin)
 
 	for _, candidate := range dailyCadences {
 		g.Expect(computeSpiralParams(28, width, height, candidate).b).To(BeZero())

--- a/internal/spiral/cadence_test.go
+++ b/internal/spiral/cadence_test.go
@@ -1,0 +1,55 @@
+package spiral
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestDailySpotsPerLapReturnsAllowedCadence(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	for _, bucketCount := range []int{1, 14, 28, 100, 365, 730} {
+		g.Expect(DailySpotsPerLap(bucketCount, 1920, 1080)).To(
+			BeElementOf(14, 28, 42, 56),
+			"bucket count %d", bucketCount,
+		)
+	}
+}
+
+func TestDailySpotsPerLapMinimizesCandidateScore(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	for _, bucketCount := range []int{28, 100, 365, 730} {
+		selected := DailySpotsPerLap(bucketCount, 1920, 1080)
+		selectedScore := dailyCadenceScore(bucketCount, 1920, 1080, selected)
+
+		for _, candidate := range dailyCadences {
+			g.Expect(selectedScore).To(
+				BeNumerically("<=", dailyCadenceScore(bucketCount, 1920, 1080, candidate)),
+				"bucket count %d, candidate %d", bucketCount, candidate,
+			)
+		}
+	}
+}
+
+func TestSelectDailyCadencePrefers28OnEqualScore(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	g.Expect(selectDailyCadence(map[int]float64{
+		14: 1,
+		28: 1,
+		42: 2,
+		56: 3,
+	})).To(Equal(28))
+}
+
+func TestSpotsPerLapKeepsHourlyCadence(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	g.Expect(SpotsPerLap(Hourly, 730, 1920, 1080)).To(Equal(24))
+}

--- a/internal/spiral/layout.go
+++ b/internal/spiral/layout.go
@@ -37,12 +37,23 @@ func Layout(
 	height int,
 	resolution Resolution,
 ) SpiralLayout {
+	return LayoutWithCadence(buckets, width, height, resolution.SpotsPerLap())
+}
+
+// LayoutWithCadence positions time buckets along an Archimedean spiral using
+// the supplied spots-per-lap cadence.
+func LayoutWithCadence(
+	buckets []TimeBucket,
+	width int,
+	height int,
+	spotsPerLap int,
+) SpiralLayout {
 	if len(buckets) == 0 {
 		return SpiralLayout{}
 	}
 
 	nodes := make([]SpiralNode, len(buckets))
-	params := computeSpiralParams(len(buckets), width, height, resolution.SpotsPerLap())
+	params := computeSpiralParams(len(buckets), width, height, spotsPerLap)
 
 	for i, b := range buckets {
 		nodes[i] = positionNode(i, b, params)
@@ -117,11 +128,22 @@ func MaxDiscRadius(
 	height int,
 	resolution Resolution,
 ) float64 {
+	return MaxDiscRadiusWithCadence(bucketCount, width, height, resolution.SpotsPerLap())
+}
+
+// MaxDiscRadiusWithCadence returns the maximum disc radius that avoids overlap
+// for the given layout parameters and spots-per-lap cadence.
+func MaxDiscRadiusWithCadence(
+	bucketCount int,
+	width int,
+	height int,
+	spotsPerLap int,
+) float64 {
 	if bucketCount == 0 {
 		return defaultDiscRadius
 	}
 
-	params := computeSpiralParams(bucketCount, width, height, resolution.SpotsPerLap())
+	params := computeSpiralParams(bucketCount, width, height, spotsPerLap)
 
 	return params.maxDisc
 }

--- a/internal/spiral/layout.go
+++ b/internal/spiral/layout.go
@@ -42,7 +42,7 @@ func Layout(
 	}
 
 	nodes := make([]SpiralNode, len(buckets))
-	params := computeSpiralParams(len(buckets), width, height, resolution)
+	params := computeSpiralParams(len(buckets), width, height, resolution.SpotsPerLap())
 
 	for i, b := range buckets {
 		nodes[i] = positionNode(i, b, params)
@@ -70,12 +70,12 @@ type spiralParams struct {
 	a           float64 // innerRadius (starting radius)
 	b           float64 // radial growth per radian
 	spotsPerLap int
+	totalAngle  float64
 	maxDisc     float64 // maximum disc radius before overlap
 }
 
 // computeSpiralParams derives spiral geometry from canvas dimensions and bucket count.
-func computeSpiralParams(n, width, height int, resolution Resolution) spiralParams {
-	spotsPerLap := resolution.SpotsPerLap()
+func computeSpiralParams(n, width, height, spotsPerLap int) spiralParams {
 	canvasRadius := math.Min(float64(width), float64(height))/2 - margin
 	outerRadius := canvasRadius
 	innerRadius := outerRadius * innerRadiusFraction
@@ -95,6 +95,7 @@ func computeSpiralParams(n, width, height int, resolution Resolution) spiralPara
 		a:           innerRadius,
 		b:           b,
 		spotsPerLap: spotsPerLap,
+		totalAngle:  totalAngle,
 		maxDisc:     maxDisc,
 	}
 }
@@ -120,7 +121,7 @@ func MaxDiscRadius(
 		return defaultDiscRadius
 	}
 
-	params := computeSpiralParams(bucketCount, width, height, resolution)
+	params := computeSpiralParams(bucketCount, width, height, resolution.SpotsPerLap())
 
 	return params.maxDisc
 }

--- a/internal/spiral/layout_test.go
+++ b/internal/spiral/layout_test.go
@@ -135,6 +135,17 @@ func TestLayoutDailySpotsPerLap(t *testing.T) {
 	)
 }
 
+func TestLayoutWithCadence(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	layout := LayoutWithCadence(makeBuckets(56, Daily), 1920, 1080, 56)
+
+	g.Expect(layout.Nodes[len(layout.Nodes)-1].Angle).To(
+		BeNumerically("~", 55*(2*math.Pi/56), 0.001),
+	)
+}
+
 func TestLayoutUniformAngularSpacing(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
@@ -587,6 +598,16 @@ func TestMaxDiscRadius_MoreBuckets_ReturnsSmallerRadius(t *testing.T) {
 	rMany := MaxDiscRadius(365, 1920, 1080, Daily)
 	g.Expect(rFew).To(BeNumerically(">=", rMany),
 		"fewer buckets should allow at least as large a disc radius")
+}
+
+func TestMaxDiscRadiusWithCadence(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	r56 := MaxDiscRadiusWithCadence(365, 1920, 1080, 56)
+	r14 := MaxDiscRadiusWithCadence(365, 1920, 1080, 14)
+
+	g.Expect(r56).To(BeNumerically(">", r14))
 }
 
 func TestMaxDiscRadius_HourlyResolution_ReturnsPositive(t *testing.T) {

--- a/internal/spiral/stages.go
+++ b/internal/spiral/stages.go
@@ -167,8 +167,9 @@ func LayoutStage(c *stages.CommonState, p *State) error {
 	bounds := c.DrawingBounds
 	availH := bounds.Height()
 
-	layout := Layout(p.Buckets, c.Width, availH, p.Resolution)
-	maxDisc := MaxDiscRadius(len(p.Buckets), c.Width, availH, p.Resolution)
+	p.SpotsPerLap = SpotsPerLap(p.Resolution, len(p.Buckets), c.Width, availH)
+	layout := LayoutWithCadence(p.Buckets, c.Width, availH, p.SpotsPerLap)
+	maxDisc := MaxDiscRadiusWithCadence(len(p.Buckets), c.Width, availH, p.SpotsPerLap)
 
 	ApplyDiscSizes(layout.Nodes, p.Buckets, maxDisc)
 

--- a/internal/spiral/stages_test.go
+++ b/internal/spiral/stages_test.go
@@ -1,6 +1,7 @@
 package spiral_test
 
 import (
+	"math"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -343,6 +344,8 @@ func TestLayoutStageSelectsAdaptiveDailyCadence(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
+	const bucketCount = 730
+
 	common := &stages.CommonState{
 		Width:  1920,
 		Height: 1080,
@@ -351,14 +354,33 @@ func TestLayoutStageSelectsAdaptiveDailyCadence(t *testing.T) {
 			MaxY: 1080,
 		},
 	}
+	buckets := make([]spiral.TimeBucket, bucketCount)
+	for i := range buckets {
+		buckets[i] = spiral.TimeBucket{
+			Files:      []*model.File{{Name: "file.go"}},
+			SizeValue:  float64(i + 1),
+			SizeValueAvailable: true,
+		}
+	}
 	viz := &spiral.State{
 		Resolution: spiral.Daily,
-		Buckets:    make([]spiral.TimeBucket, 365),
+		Buckets:    buckets,
 		Inks:       spiral.Inks{Fill: inks.FixedInk(palette.White)},
 	}
 
 	g.Expect(spiral.LayoutStage(common, viz)).To(Succeed())
-	g.Expect(viz.SpotsPerLap).To(Equal(spiral.DailySpotsPerLap(365, 1920, 1080)))
+	g.Expect(viz.SpotsPerLap).To(Equal(spiral.DailySpotsPerLap(bucketCount, 1920, 1080)))
+	g.Expect(viz.SpotsPerLap).NotTo(Equal(28))
+	g.Expect(viz.Layout.Nodes[1].Angle).To(
+		BeNumerically("~", 2*math.Pi/float64(viz.SpotsPerLap), 1e-9),
+	)
+	g.Expect(viz.Layout.Nodes[bucketCount-1].DiscRadius).To(
+		BeNumerically(
+			"~",
+			spiral.MaxDiscRadiusWithCadence(bucketCount, 1920, 1080, viz.SpotsPerLap),
+			1e-9,
+		),
+	)
 }
 
 func TestLayoutStageKeepsHourlyCadence(t *testing.T) {

--- a/internal/spiral/stages_test.go
+++ b/internal/spiral/stages_test.go
@@ -355,13 +355,15 @@ func TestLayoutStageSelectsAdaptiveDailyCadence(t *testing.T) {
 		},
 	}
 	buckets := make([]spiral.TimeBucket, bucketCount)
+
 	for i := range buckets {
 		buckets[i] = spiral.TimeBucket{
-			Files:      []*model.File{{Name: "file.go"}},
-			SizeValue:  float64(i + 1),
+			Files:              []*model.File{{Name: "file.go"}},
+			SizeValue:          float64(i + 1),
 			SizeValueAvailable: true,
 		}
 	}
+
 	viz := &spiral.State{
 		Resolution: spiral.Daily,
 		Buckets:    buckets,

--- a/internal/spiral/stages_test.go
+++ b/internal/spiral/stages_test.go
@@ -338,3 +338,47 @@ func TestBuildLegendStage_AddsSurfaceForSameMetricWithDifferentPalette(t *testin
 	g.Expect(viz.LegendConfig.Entries[2].Role).To(Equal(legend.RoleSurface))
 	g.Expect(viz.LegendConfig.Entries[2].MetricName).To(Equal("file-lines"))
 }
+
+func TestLayoutStageSelectsAdaptiveDailyCadence(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	common := &stages.CommonState{
+		Width:  1920,
+		Height: 1080,
+		DrawingBounds: stages.DrawingBounds{
+			MaxX: 1920,
+			MaxY: 1080,
+		},
+	}
+	viz := &spiral.State{
+		Resolution: spiral.Daily,
+		Buckets:    make([]spiral.TimeBucket, 365),
+		Inks:       spiral.Inks{Fill: inks.FixedInk(palette.White)},
+	}
+
+	g.Expect(spiral.LayoutStage(common, viz)).To(Succeed())
+	g.Expect(viz.SpotsPerLap).To(Equal(spiral.DailySpotsPerLap(365, 1920, 1080)))
+}
+
+func TestLayoutStageKeepsHourlyCadence(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	common := &stages.CommonState{
+		Width:  1920,
+		Height: 1080,
+		DrawingBounds: stages.DrawingBounds{
+			MaxX: 1920,
+			MaxY: 1080,
+		},
+	}
+	viz := &spiral.State{
+		Resolution: spiral.Hourly,
+		Buckets:    make([]spiral.TimeBucket, 720),
+		Inks:       spiral.Inks{Fill: inks.FixedInk(palette.White)},
+	}
+
+	g.Expect(spiral.LayoutStage(common, viz)).To(Succeed())
+	g.Expect(viz.SpotsPerLap).To(Equal(24))
+}

--- a/internal/spiral/state.go
+++ b/internal/spiral/state.go
@@ -20,6 +20,7 @@ type State struct {
 	SurfaceMetric  metric.Name
 	SurfacePalette palette.PaletteName
 	Resolution     Resolution
+	SpotsPerLap    int
 
 	Buckets      []TimeBucket
 	Inks         Inks


### PR DESCRIPTION
## Summary
- select daily spiral cadence from 14, 28, 42, or 56 dots per lap using midpoint radial and arc spacing
- propagate the selected cadence through spiral layout and disc sizing while preserving hourly cadence
- add coverage for selector fallbacks, geometry, and pipeline propagation

Fixes #611 

## Test Plan
- [x] task fmt
- [x] task test
- [x] task build
- [x] task lint