### PR TITLE
Improve/surface weights

### DIFF
--- a/docs/superpowers/plans/2026-08-15-surface-local-interpolation.md
+++ b/docs/superpowers/plans/2026-08-15-surface-local-interpolation.md
@@ -1,0 +1,760 @@
+# Surface Local Interpolation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace global inverse-distance weighting with a compact, globally adaptive reversed-smootherstep kernel and omit mesh geometry outside local data support.
+
+**Architecture:** Add a private interpolation model in `internal/surface` that filters observations, derives one support radius, and evaluates normalized smootherstep weights. Keep the public `Interpolate` signature unchanged, reuse one model throughout each mesh build, and carry a private unsupported flag on generated points so unsupported triangles are removed before rendering.
+
+**Tech Stack:** Go 1.26.1, Gomega, Goldie v2, fogleman/delaunay, gofumpt, Task.
+
+---
+
+## File Map
+
+| File | Responsibility |
+| --- | --- |
+| `internal/surface/interpolation.go` | Private smootherstep kernel, adaptive radius calculation, interpolation model, and public `Interpolate` wrapper. |
+| `internal/surface/interpolation_test.go` | White-box kernel, radius, support, duplicate, and finite-value tests. |
+| `internal/surface/types.go` | Remove the obsolete IDW constant and add private point support state. |
+| `internal/surface/mesh.go` | Build one interpolation model, assign support to generated points, and omit unsupported triangles. |
+| `internal/surface/mesh_test.go` | Update public interpolation behavior and finite-value coverage. |
+| `internal/surface/mesh_internal_test.go` | Verify unsupported triangle filtering. |
+| `internal/surface/mesh_refinement_test.go` | Adapt private mesh calls and expected-face filtering to the model-aware pipeline. |
+| `internal/goldentest/testdata/spiral-surface-*.golden` | Record the four expected PNG/SVG rendering changes. |
+
+No changes are planned for `internal/spiral`, rendering, palettes, CLI/config,
+or `samples/`. Spiral already consumes generic `surface.Build` output.
+
+### Task 1: Add The Compact Interpolation Model
+
+**Files:**
+- Create: `internal/surface/interpolation.go`
+- Create: `internal/surface/interpolation_test.go`
+- Modify: `internal/surface/mesh.go:15-43,73-85`
+- Modify: `internal/surface/mesh_test.go:11-39,85-116`
+- Modify: `internal/surface/types.go:5-12`
+
+- [ ] **Step 1: Replace the public IDW example with smootherstep behavior tests**
+
+In `internal/surface/mesh_test.go`, replace
+`TestInterpolate_UsesInverseDistanceWeighting` with a midpoint test. Two
+observations four pixels apart derive `R = 8`; the midpoint has equal kernel
+weights and must interpolate to `4`:
+
+```go
+func TestInterpolate_UsesCompactSmootherstepWeighting(t *testing.T) {
+	t.Parallel()
+
+	g := gomega.NewWithT(t)
+	originals := []surface.Point{
+		{X: 0, Y: 0, Value: 0},
+		{X: 4, Y: 0, Value: 8},
+	}
+
+	g.Expect(surface.Interpolate(surface.Point{X: 2, Y: 0}, originals)).To(
+		gomega.Equal(4.0),
+	)
+}
+```
+
+Keep `TestInterpolate_ReturnsObservedValueAtOriginalLocation`, but remove the
+unnecessary `Original: true` fields from its fixture. Exact coordinate matches,
+not caller-provided flags, are the measurement-preservation contract.
+
+- [ ] **Step 2: Add failing white-box kernel and radius tests**
+
+Create `internal/surface/interpolation_test.go` in package `surface`. Use the
+private APIs that this task will add:
+
+```go
+package surface
+
+import (
+	"math"
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestSmootherstepWeight_HasSmoothCompactEndpoints(t *testing.T) {
+	t.Parallel()
+
+	g := gomega.NewWithT(t)
+	g.Expect(smootherstepWeight(0)).To(gomega.Equal(1.0))
+	g.Expect(smootherstepWeight(0.5)).To(gomega.Equal(0.5))
+	g.Expect(smootherstepWeight(1)).To(gomega.Equal(0.0))
+	g.Expect(smootherstepWeight(2)).To(gomega.Equal(0.0))
+
+	const epsilon = 1e-4
+	g.Expect(1 - smootherstepWeight(epsilon)).To(gomega.BeNumerically("<", 1e-9))
+	g.Expect(smootherstepWeight(1 - epsilon)).To(gomega.BeNumerically("<", 1e-9))
+}
+
+func TestNewInterpolationModel_UsesTwiceNearestRankNinetiethPercentile(t *testing.T) {
+	t.Parallel()
+
+	g := gomega.NewWithT(t)
+	originals := make([]Point, 0, 20)
+	for gap := 1; gap <= 10; gap++ {
+		base := float64(gap * 100)
+		originals = append(originals,
+			Point{X: base, Value: float64(gap)},
+			Point{X: base + float64(gap), Value: float64(gap)},
+		)
+	}
+
+	model, ok := newInterpolationModel(originals)
+	g.Expect(ok).To(gomega.BeTrue())
+	// Distances 1..10 each occur twice; nearest-rank 90% is 9, then multiplied by 2.
+	g.Expect(model.radius).To(gomega.Equal(18.0))
+}
+
+func TestNewInterpolationModel_SkipsCoincidentAndNonFiniteObservations(t *testing.T) {
+	t.Parallel()
+
+	g := gomega.NewWithT(t)
+	model, ok := newInterpolationModel([]Point{
+		{X: 0, Y: 0, Value: 1},
+		{X: 0, Y: 0, Value: 2},
+		{X: 4, Y: 0, Value: 3},
+		{X: math.NaN(), Y: 0, Value: 4},
+		{X: 8, Y: 0, Value: math.Inf(1)},
+	})
+
+	g.Expect(ok).To(gomega.BeTrue())
+	g.Expect(model.observations).To(gomega.HaveLen(3))
+	g.Expect(model.radius).To(gomega.Equal(8.0))
+}
+
+func TestNewInterpolationModel_RejectsCoincidentOnlyObservations(t *testing.T) {
+	t.Parallel()
+
+	_, ok := newInterpolationModel([]Point{
+		{X: 1, Y: 2, Value: 3},
+		{X: 1, Y: 2, Value: 4},
+	})
+	if ok {
+		t.Fatal("coincident-only observations must not produce a support radius")
+	}
+}
+```
+
+- [ ] **Step 3: Add failing interpolation support tests**
+
+Append these tests to `internal/surface/interpolation_test.go`:
+
+```go
+func TestInterpolationModel_UsesOnlyObservationsInsideRadius(t *testing.T) {
+	t.Parallel()
+
+	g := gomega.NewWithT(t)
+	model := interpolationModel{
+		observations: []Point{
+			{X: 0, Y: 0, Value: 2},
+			{X: 20, Y: 0, Value: 100},
+		},
+		radius: 10,
+	}
+
+	value, supported := model.interpolate(Point{X: 5, Y: 0})
+	g.Expect(supported).To(gomega.BeTrue())
+	g.Expect(value).To(gomega.Equal(2.0))
+}
+
+func TestInterpolationModel_ReportsUnsupportedPoint(t *testing.T) {
+	t.Parallel()
+
+	g := gomega.NewWithT(t)
+	model := interpolationModel{
+		observations: []Point{{X: 0, Y: 0, Value: 2}},
+		radius:       10,
+	}
+
+	value, supported := model.interpolate(Point{X: 10, Y: 0})
+	g.Expect(supported).To(gomega.BeFalse())
+	g.Expect(value).To(gomega.Equal(0.0))
+}
+
+func TestInterpolationModel_UsesFirstCoincidentObservation(t *testing.T) {
+	t.Parallel()
+
+	g := gomega.NewWithT(t)
+	model, ok := newInterpolationModel([]Point{
+		{X: 0, Y: 0, Value: 3},
+		{X: 0, Y: 0, Value: 7},
+		{X: 4, Y: 0, Value: 11},
+	})
+	g.Expect(ok).To(gomega.BeTrue())
+
+	value, supported := model.interpolate(Point{X: 0, Y: 0})
+	g.Expect(supported).To(gomega.BeTrue())
+	g.Expect(value).To(gomega.Equal(3.0))
+}
+
+func TestInterpolate_ReturnsZeroOutsideSupport(t *testing.T) {
+	t.Parallel()
+
+	g := gomega.NewWithT(t)
+	value := Interpolate(Point{X: 100, Y: 100}, []Point{
+		{X: 0, Y: 0, Value: 2},
+		{X: 4, Y: 0, Value: 6},
+	})
+	g.Expect(value).To(gomega.Equal(0.0))
+}
+```
+
+- [ ] **Step 4: Run the interpolation tests to verify they fail**
+
+Run:
+
+```bash
+go test ./internal/surface -run 'Test(SmootherstepWeight|NewInterpolationModel|InterpolationModel|Interpolate_)' -count=1
+```
+
+Expected: compilation fails because `smootherstepWeight`,
+`newInterpolationModel`, and `interpolationModel` do not exist; the external
+midpoint test still uses the old implementation.
+
+- [ ] **Step 5: Implement the private model and public wrapper**
+
+Create `internal/surface/interpolation.go`:
+
+```go
+package surface
+
+import (
+	"math"
+	"sort"
+)
+
+const (
+	supportRadiusPercentile = 0.90
+	supportRadiusMultiplier = 2.0
+)
+
+type interpolationModel struct {
+	observations []Point
+	radius       float64
+}
+
+func newInterpolationModel(originals []Point) (interpolationModel, bool) {
+	observations := observedPoints(originals)
+	radius, ok := interpolationSupportRadius(observations)
+	if !ok {
+		return interpolationModel{}, false
+	}
+
+	return interpolationModel{observations: observations, radius: radius}, true
+}
+
+func interpolationSupportRadius(observations []Point) (float64, bool) {
+	distances := make([]float64, 0, len(observations))
+	for index, observation := range observations {
+		nearest := math.Inf(1)
+		for otherIndex, other := range observations {
+			if index == otherIndex {
+				continue
+			}
+
+			distance := Distance(observation, other)
+			if distance > 0 && distance < nearest {
+				nearest = distance
+			}
+		}
+
+		if isFinite(nearest) {
+			distances = append(distances, nearest)
+		}
+	}
+
+	if len(distances) == 0 {
+		return 0, false
+	}
+
+	sort.Float64s(distances)
+	rank := int(math.Ceil(supportRadiusPercentile*float64(len(distances)))) - 1
+	radius := distances[rank] * supportRadiusMultiplier
+
+	return radius, isFinite(radius) && radius > 0
+}
+
+func smootherstepWeight(t float64) float64 {
+	if !isFinite(t) || t >= 1 {
+		return 0
+	}
+
+	if t <= 0 {
+		return 1
+	}
+
+	return 1 - t*t*t*(t*(t*6-15)+10)
+}
+
+func (m interpolationModel) interpolate(point Point) (float64, bool) {
+	var weightedValue, totalWeight float64
+
+	for _, observation := range m.observations {
+		distance := Distance(point, observation)
+		if distance == 0 {
+			return observation.Value, true
+		}
+
+		weight := smootherstepWeight(distance / m.radius)
+		weightedValue += observation.Value * weight
+		totalWeight += weight
+	}
+
+	if totalWeight == 0 {
+		return 0, false
+	}
+
+	return weightedValue / totalWeight, true
+}
+
+// Interpolate estimates a point's value from spatially local observed points.
+func Interpolate(point Point, originals []Point) float64 {
+	model, ok := newInterpolationModel(originals)
+	if !ok {
+		return 0
+	}
+
+	value, _ := model.interpolate(point)
+
+	return value
+}
+```
+
+Remove the old `Interpolate` implementation and its `math.Pow` use from
+`internal/surface/mesh.go`. Remove `IDWPower` from the constants in
+`internal/surface/types.go`.
+
+Update `observedPoints` in `internal/surface/mesh.go` so metric values are
+filtered as required by the design:
+
+```go
+func observedPoints(originals []Point) []Point {
+	observed := make([]Point, 0, len(originals))
+	for _, original := range originals {
+		if !isFinitePoint(original) || !isFinite(original.Value) {
+			continue
+		}
+
+		original.Original = true
+		observed = append(observed, original)
+	}
+
+	return observed
+}
+```
+
+- [ ] **Step 6: Extend the existing non-finite build test to cover values**
+
+In `TestBuild_IgnoresNonFiniteOriginalCoordinates`, rename it to
+`TestBuild_IgnoresNonFiniteOriginals` and add these invalid observations:
+
+```go
+{X: 5, Y: 5, Value: math.NaN()},
+{X: 6, Y: 6, Value: math.Inf(1)},
+```
+
+After the existing coordinate assertions, assert all emitted values are
+finite:
+
+```go
+g.Expect(math.IsNaN(point.Value) || math.IsInf(point.Value, 0)).To(gomega.BeFalse())
+```
+
+- [ ] **Step 7: Format and run the focused tests**
+
+Run:
+
+```bash
+gofumpt -w internal/surface/interpolation.go internal/surface/interpolation_test.go internal/surface/mesh.go internal/surface/mesh_test.go internal/surface/types.go
+go test ./internal/surface -run 'Test(SmootherstepWeight|NewInterpolationModel|InterpolationModel|Interpolate_|Build_IgnoresNonFinite)' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run the complete surface package**
+
+Run:
+
+```bash
+go test ./internal/surface -count=1
+```
+
+Expected: PASS. Mesh construction still calls the public wrapper repeatedly in
+this intermediate commit; Task 2 replaces that with one reused model.
+
+- [ ] **Step 9: Commit the interpolation model**
+
+```bash
+git add internal/surface/interpolation.go internal/surface/interpolation_test.go internal/surface/mesh.go internal/surface/mesh_test.go internal/surface/types.go
+git commit -m "feat(surface): add compact interpolation kernel"
+```
+
+### Task 2: Propagate Support Through Mesh Construction
+
+**Files:**
+- Modify: `internal/surface/types.go:13-18`
+- Modify: `internal/surface/interpolation.go`
+- Modify: `internal/surface/mesh.go:45-137,176-197`
+- Modify: `internal/surface/mesh_internal_test.go`
+- Modify: `internal/surface/mesh_refinement_test.go:58-145`
+
+- [ ] **Step 1: Add a failing unsupported-triangle test**
+
+Append to `internal/surface/mesh_internal_test.go`:
+
+```go
+func TestRegionTriangles_OmitsTriangleWithUnsupportedVertex(t *testing.T) {
+	t.Parallel()
+
+	g := gomega.NewWithT(t)
+	points := []Point{
+		{X: 0, Y: 0, Value: 1},
+		{X: 1, Y: 0, Value: 2, unsupported: true},
+		{X: 0, Y: 1, Value: 3},
+	}
+
+	triangles, complete := regionTriangles(
+		Rect{MinX: 0, MinY: 0, MaxX: 1, MaxY: 1},
+		points,
+		[]int{0, 1, 2},
+	)
+
+	g.Expect(complete).To(gomega.BeTrue())
+	g.Expect(triangles).To(gomega.BeEmpty())
+}
+```
+
+- [ ] **Step 2: Run the new test to verify it fails**
+
+Run:
+
+```bash
+go test ./internal/surface -run '^TestRegionTriangles_OmitsTriangleWithUnsupportedVertex$' -count=1
+```
+
+Expected: compilation fails because `Point` has no `unsupported` field.
+
+- [ ] **Step 3: Add private support state and a point assignment helper**
+
+Add a private field to `Point` in `internal/surface/types.go`. Naming the
+negative state preserves zero-value compatibility for existing point literals:
+
+```go
+type Point struct {
+	X           float64
+	Y           float64
+	Value       float64
+	Original    bool
+	unsupported bool
+}
+```
+
+Add this helper to `internal/surface/interpolation.go`:
+
+```go
+func (m interpolationModel) assign(point Point) Point {
+	value, supported := m.interpolate(point)
+	point.Value = value
+	point.unsupported = !supported
+
+	return point
+}
+```
+
+- [ ] **Step 4: Build and reuse one model across the mesh pipeline**
+
+Replace the beginning of `Build` in `internal/surface/mesh.go` with:
+
+```go
+func Build(region Region, originals []Point, seed uint64) []Triangle {
+	if !isValidRegion(region) {
+		return nil
+	}
+
+	model, ok := newInterpolationModel(originals)
+	if !ok || len(model.observations) < 3 {
+		return nil
+	}
+
+	points, complete := meshPoints(region, model, seed)
+	if !complete || len(points) < 3 {
+		return nil
+	}
+```
+
+Keep the existing triangulation and `regionTriangles` tail unchanged.
+
+Change `meshPoints` and `refineMeshPoints` to accept the model and assign
+support once per generated point:
+
+```go
+func meshPoints(region Region, model interpolationModel, seed uint64) ([]Point, bool) {
+	boundary := boundarySamples(region, model.observations)
+	for index := range boundary {
+		boundary[index] = model.assign(boundary[index])
+	}
+
+	points := append([]Point(nil), model.observations...)
+	points = append(points, boundary...)
+	samplingSources := append([]Point(nil), points...)
+
+	infill := Sample(region, samplingSources, PoissonMinDistance, seed)
+	for _, point := range infill {
+		points = append(points, model.assign(point))
+	}
+
+	return refineMeshPoints(region, points, model)
+}
+
+func refineMeshPoints(
+	region Region,
+	points []Point,
+	model interpolationModel,
+) ([]Point, bool) {
+	limit := refinementPointLimit(region, len(points))
+
+	for {
+		triangulation, err := delaunay.Triangulate(delaunayPoints(points))
+		if err != nil {
+			return nil, false
+		}
+
+		candidates, oversized := refinementPoints(region, points, triangulation.Triangles)
+		if !oversized {
+			return points, true
+		}
+
+		if len(candidates) == 0 || len(points)+len(candidates) > limit {
+			return nil, false
+		}
+
+		for _, candidate := range candidates {
+			points = append(points, model.assign(candidate))
+		}
+	}
+}
+```
+
+- [ ] **Step 5: Filter unsupported triangles before calculating values**
+
+Add this helper in `internal/surface/mesh.go`:
+
+```go
+func triangleIsUnsupported(triangle Triangle) bool {
+	for _, point := range triangle.Points {
+		if point.unsupported {
+			return true
+		}
+	}
+
+	return false
+}
+```
+
+In `regionTriangles`, extend the existing early filter:
+
+```go
+if !ok || isDegenerateTriangle(triangle) || triangleIsUnsupported(triangle) {
+	continue
+}
+```
+
+Do this before calculating `triangle.Value`. Supported zero values remain
+valid because filtering uses the private flag rather than the numeric value.
+
+- [ ] **Step 6: Adapt white-box refinement tests to the new model signature**
+
+In both call sites in `internal/surface/mesh_refinement_test.go`, replace the
+direct `observedPoints` argument with:
+
+```go
+model, ok := newInterpolationModel(originals)
+if !ok {
+	t.Fatal("failed to create interpolation model")
+}
+
+points, complete := meshPoints(region, model, 42)
+```
+
+In `inRegionDelaunayTriangles`, skip unsupported triangles so its expected set
+matches `Build`:
+
+```go
+if !triangleInRegion(region, triangle) || triangleIsUnsupported(triangle) {
+	continue
+}
+```
+
+- [ ] **Step 7: Run the unsupported-triangle test**
+
+Run:
+
+```bash
+gofumpt -w internal/surface/interpolation.go internal/surface/types.go internal/surface/mesh.go internal/surface/mesh_internal_test.go internal/surface/mesh_refinement_test.go
+go test ./internal/surface -run '^TestRegionTriangles_OmitsTriangleWithUnsupportedVertex$' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run all surface tests and repair only locality-related expectations**
+
+Run:
+
+```bash
+go test ./internal/surface -count=1
+```
+
+Expected: PASS. Existing tests for observed values, annular boundaries,
+maximum edge length, refinement, deterministic builds, and subdivision remain
+green. A failure at this gate must be diagnosed before proceeding; do not
+weaken support filtering or add fallback values.
+
+- [ ] **Step 9: Verify spiral surface geometry remains available**
+
+Run:
+
+```bash
+go test ./internal/spiral -run 'Surface' -count=1
+```
+
+Expected: PASS, including short spirals, annulus constraints, band subdivision,
+layer ordering, and fixed-ink fallback.
+
+- [ ] **Step 10: Commit mesh support propagation**
+
+```bash
+git add internal/surface/interpolation.go internal/surface/types.go internal/surface/mesh.go internal/surface/mesh_internal_test.go internal/surface/mesh_refinement_test.go
+git commit -m "feat(surface): omit unsupported mesh regions"
+```
+
+### Task 3: Update And Inspect Spiral Surface Goldens
+
+**Files:**
+- Modify: `internal/goldentest/testdata/spiral-surface-shared-png.golden`
+- Modify: `internal/goldentest/testdata/spiral-surface-shared-svg.golden`
+- Modify: `internal/goldentest/testdata/spiral-surface-distinct-png.golden`
+- Modify: `internal/goldentest/testdata/spiral-surface-distinct-svg.golden`
+
+- [ ] **Step 1: Verify only surface goldens mismatch**
+
+Run:
+
+```bash
+go test ./internal/goldentest -run '^TestGolden_SpiralSurface(Shared|Distinct)$' -count=1
+```
+
+Expected: FAIL with Goldie mismatches for the changed PNG/SVG surface output,
+not a panic or pipeline error.
+
+- [ ] **Step 2: Regenerate only the four surface goldens**
+
+Run:
+
+```bash
+GOLDIE_UPDATE=1 go test ./internal/goldentest -run '^TestGolden_SpiralSurface(Shared|Distinct)$' -count=1
+```
+
+Expected: PASS and exactly four modified files under
+`internal/goldentest/testdata/`.
+
+- [ ] **Step 3: Inspect the golden scope and visual output**
+
+Run:
+
+```bash
+git status --short internal/goldentest/testdata
+git --no-pager diff --stat -- internal/goldentest/testdata/spiral-surface-*.golden
+```
+
+Expected: only the four files listed in this task changed. Use the image viewer
+on both PNG goldens. Inspect both SVG diffs or render them for comparison.
+Confirm:
+
+- nearby peaks blend rather than forming inverse-square spikes;
+- broad areas are no longer pulled toward a global mean;
+- no visible cutoff rings or step boundaries appear;
+- unsupported areas show background rather than fabricated colour;
+- track, discs, labels, legends, and annulus boundaries remain intact.
+
+Do not regenerate or stage `samples/`; existing sample modifications belong to
+the user and are outside this feature.
+
+- [ ] **Step 4: Re-run the focused golden tests without update mode**
+
+Run:
+
+```bash
+go test ./internal/goldentest -run '^TestGolden_SpiralSurface(Shared|Distinct)$' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the golden snapshots**
+
+```bash
+git add internal/goldentest/testdata/spiral-surface-shared-png.golden internal/goldentest/testdata/spiral-surface-shared-svg.golden internal/goldentest/testdata/spiral-surface-distinct-png.golden internal/goldentest/testdata/spiral-surface-distinct-svg.golden
+git commit -m "test(surface): update local interpolation goldens"
+```
+
+### Task 4: Final Verification
+
+**Files:**
+- Verify only; no planned modifications.
+
+- [ ] **Step 1: Check formatting without rewriting unrelated files**
+
+Run:
+
+```bash
+gofumpt -l internal/surface
+```
+
+Expected: no output.
+
+- [ ] **Step 2: Run focused packages**
+
+Run:
+
+```bash
+go test ./internal/surface ./internal/spiral ./internal/goldentest -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the complete test suite**
+
+Run:
+
+```bash
+task test
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run repository CI through an Explore subagent**
+
+Per `.github/copilot-instructions.md`, dispatch an `Explore` subagent to run
+`task ci` and return only the exit status, failing test/linter identities,
+offending file and message, or a one-line clean result.
+
+Expected: exit status `0`, no failing tests, and no lint issues. Locally,
+`verify-no-changes` may warn about the user's pre-existing sample image and
+`.superpowers/` changes; it must not introduce additional source changes.
+
+- [ ] **Step 5: Verify final change scope**
+
+Run:
+
+```bash
+git --no-pager diff origin/copilot/enhance-radial-visualization...HEAD --stat
+git status --short
+```
+
+Expected: feature commits contain the design, plan, surface implementation and
+tests, plus four spiral surface goldens. Pre-existing modified sample images
+and untracked `.superpowers/` remain unstaged and unchanged.

--- a/docs/superpowers/specs/2026-08-15-surface-local-interpolation-design.md
+++ b/docs/superpowers/specs/2026-08-15-surface-local-interpolation-design.md
@@ -1,0 +1,173 @@
+# Surface Local Interpolation Design
+
+## Purpose
+
+Replace global inverse-distance weighting in `internal/surface` with a smooth,
+compact spatial kernel. The current interpolation includes every observation,
+so a large population of individually weak distant observations can pull much
+of the surface toward the global mean.
+
+The replacement must suppress distant influence without creating sharp local
+peaks, cutoff rings, or visible steps. It remains a generic surface feature;
+the interpolation model contains no spiral or timeline semantics.
+
+## Scope
+
+This change affects interpolation and unsupported mesh geometry in
+`internal/surface`. Spiral remains the first consumer and requires no new
+configuration or visualization-specific interpolation logic.
+
+User-facing controls, timeline-aware distance, per-visualization tuning, and
+adding surfaces to other visualizations are out of scope.
+
+## Interpolation Model
+
+### Compact smootherstep kernel
+
+Replace inverse-square weighting with a reversed smootherstep kernel. For an
+observation at spatial distance `d` and a surface-wide support radius `R`:
+
+```text
+t = d / R
+
+w(d) = 1 - (6t^5 - 15t^4 + 10t^3)    when 0 <= t < 1
+w(d) = 0                                when t >= 1
+```
+
+The interpolated value is the normalized weighted mean of observations with
+positive weight:
+
+```text
+value = sum(observation.value * w(distance)) / sum(w(distance))
+```
+
+The kernel has zero slope at both endpoints. It decreases slowly near an
+observation, falls most quickly around the middle of its support, and reaches
+zero without a crease at `R`. It replaces IDW rather than multiplying IDW, so
+there is only one radial falloff.
+
+An interpolation request at an original observation's coordinates returns
+that observation's exact value. This preserves measurements independently of
+the kernel and floating-point normalization.
+
+### Global adaptive support radius
+
+Derive one fixed radius for each surface build from the spatial distribution
+of its finite observations:
+
+1. For each observation, find the shortest positive distance to another
+   observation. Coincident observations are skipped when finding that
+   positive distance.
+2. Discard observations for which no positive nearest-neighbor distance
+   exists.
+3. Sort the resulting distances in ascending order.
+4. Select the nearest-rank 90th percentile at one-based rank
+   `ceil(0.90 * count)`.
+5. Set `R` to twice that percentile distance.
+
+The high percentile accommodates most spacing variation without allowing a
+single isolated observation to determine the radius. The fixed multiplier of
+two gives neighboring kernels substantial overlap while remaining an
+internal, consistent surface characteristic.
+
+If there are no positive nearest-neighbor distances, or if the derived radius
+is zero or non-finite, the interpolation model is invalid and the build
+returns no surface.
+
+## Components And Data Flow
+
+### Interpolation model
+
+Add a private interpolation model in `internal/surface`. It owns the filtered
+observations and derived support radius. `Build` creates it once and reuses it
+for all boundary, Poisson infill, and mesh-refinement points, avoiding repeated
+nearest-neighbor and percentile calculations.
+
+The model's internal interpolation operation returns `(value, supported)`.
+It is supported when the point exactly matches an observation or at least one
+observation has positive kernel weight. It is unsupported when no observation
+lies within `R`.
+
+Keep `surface.Interpolate(point, originals) float64` as the simple public
+entry point used by callers and tests. It constructs the same model and
+returns zero when the model or point is unsupported, preserving the existing
+single-value API. Mesh generation uses the internal operation directly so it
+does not confuse an unsupported point with a legitimate zero value.
+
+### Mesh support state
+
+Surface points carry explicit support state during mesh construction.
+Original observations are supported and retain their exact values. Generated
+boundary, infill, and refinement points receive both value and support state
+from the interpolation model.
+
+Sampling, Delaunay triangulation, and refinement continue across the complete
+supplied region. This preserves deterministic mesh geometry and existing edge
+length constraints. Final triangle selection omits every triangle containing
+an unsupported vertex. The result may therefore contain holes where the
+region has no local data support; the surface does not invent fallback values
+for those areas.
+
+No changes are required to palette-band subdivision or rendering. They only
+receive supported triangles.
+
+## Edge Cases And Errors
+
+- Fewer than three finite observations still produce no mesh.
+- Observations with non-finite coordinates or values are excluded before
+  radius calculation and interpolation.
+- Coincident observations do not add zero distances to the percentile input.
+- If multiple observations share an exact location, exact interpolation uses
+  the first finite observation in input order, preserving deterministic
+  existing behavior.
+- An isolated observation may have no overlapping support and therefore only
+  preserve its exact original vertex; surrounding unsupported triangles are
+  omitted.
+- Failure to derive a valid radius, triangulate, or satisfy refinement limits
+  returns no surface through the existing failure path. Callers retain their
+  current fallback behavior, such as rendering a spiral without its surface.
+
+## Testing
+
+### Kernel and radius tests
+
+- Verify kernel weights at normalized distances `0`, `0.5`, and `1` are `1`,
+  `0.5`, and `0` respectively.
+- Verify the first derivative is flat at both endpoints through values close
+  to `0` and `1`.
+- Verify the support radius is twice the nearest-rank 90th percentile of
+  positive nearest-neighbor distances.
+- Verify coincident and non-finite observations do not distort radius
+  selection.
+
+### Interpolation tests
+
+- Preserve exact values at original coordinates.
+- Verify a known weighted average between observations.
+- Verify observations at or beyond `R` contribute no weight.
+- Verify unsupported public interpolation returns zero while the internal
+  operation reports `supported = false`.
+- Verify deterministic handling of duplicate coordinates.
+
+### Mesh and integration tests
+
+- Verify generated vertices within support receive the smootherstep value.
+- Verify triangles touching an unsupported vertex are omitted.
+- Preserve existing region, maximum-edge, refinement, boundary, and
+  determinism guarantees.
+- Update spiral PNG and SVG Goldie snapshots and inspect them for improved
+  locality without sharp peaks, visible cutoff rings, or unsupported fill.
+- Run the complete surface and spiral test suites, then the repository CI
+  checks.
+
+## Success Criteria
+
+- Distant observations outside the adaptive radius have exactly zero effect.
+- Nearby observations blend with a bounded S-shaped falloff rather than an
+  inverse-square peak.
+- Unsupported parts of a region are absent rather than assigned a fallback
+  value.
+- The interpolation policy remains entirely within the generic surface
+  package and exposes no new user configuration.
+- Existing mesh-quality and deterministic-rendering guarantees continue to
+  pass.

--- a/internal/surface/interpolation.go
+++ b/internal/surface/interpolation.go
@@ -147,3 +147,11 @@ func (model interpolationModel) interpolate(point Point) (float64, bool) {
 
 	return value, true
 }
+
+func (model interpolationModel) assign(point Point) Point {
+	value, supported := model.interpolate(point)
+	point.Value = value
+	point.unsupported = !supported
+
+	return point
+}

--- a/internal/surface/interpolation.go
+++ b/internal/surface/interpolation.go
@@ -2,7 +2,7 @@ package surface
 
 import (
 	"math"
-	"sort"
+	"slices"
 )
 
 const (
@@ -52,23 +52,7 @@ func interpolationSupportRadius(observations []Point) (float64, bool) {
 			continue
 		}
 
-		nearestDistance := math.Inf(1)
-		for otherIndex, other := range observations {
-			if otherIndex == index {
-				continue
-			}
-
-			distance := Distance(observation, other)
-			if !isFinite(distance) || distance <= 0 {
-				continue
-			}
-
-			if distance < nearestDistance {
-				nearestDistance = distance
-			}
-		}
-
-		if isFinite(nearestDistance) && nearestDistance > 0 {
+		if nearestDistance, found := nearestPositiveDistance(observations, index); found {
 			nearestPositiveDistances = append(nearestPositiveDistances, nearestDistance)
 		}
 	}
@@ -77,14 +61,9 @@ func interpolationSupportRadius(observations []Point) (float64, bool) {
 		return 0, false
 	}
 
-	sort.Float64s(nearestPositiveDistances)
+	slices.Sort(nearestPositiveDistances)
+
 	index := int(math.Ceil(supportRadiusPercentile*float64(len(nearestPositiveDistances)))) - 1
-	if index < 0 {
-		index = 0
-	}
-	if index >= len(nearestPositiveDistances) {
-		index = len(nearestPositiveDistances) - 1
-	}
 
 	radius := nearestPositiveDistances[index] * supportRadiusMultiplier
 	if !isFinite(radius) || radius <= 0 {
@@ -94,10 +73,28 @@ func interpolationSupportRadius(observations []Point) (float64, bool) {
 	return radius, true
 }
 
+func nearestPositiveDistance(observations []Point, observationIndex int) (float64, bool) {
+	nearestDistance := math.Inf(1)
+
+	for otherIndex, other := range observations {
+		if otherIndex == observationIndex {
+			continue
+		}
+
+		distance := Distance(observations[observationIndex], other)
+		if isFinite(distance) && distance > 0 {
+			nearestDistance = min(nearestDistance, distance)
+		}
+	}
+
+	return nearestDistance, isFinite(nearestDistance)
+}
+
 func smootherstepWeight(t float64) float64 {
 	if !isFinite(t) || t >= 1 {
 		return 0
 	}
+
 	if t <= 0 {
 		return 1
 	}
@@ -110,12 +107,24 @@ func (model interpolationModel) interpolate(point Point) (float64, bool) {
 		return 0, false
 	}
 
-	for _, observation := range model.observations {
+	if value, found := observedValueAt(point, model.observations); found {
+		return value, true
+	}
+
+	return model.weightedValue(point)
+}
+
+func observedValueAt(point Point, observations []Point) (float64, bool) {
+	for _, observation := range observations {
 		if point.X == observation.X && point.Y == observation.Y {
 			return observation.Value, true
 		}
 	}
 
+	return 0, false
+}
+
+func (model interpolationModel) weightedValue(point Point) (float64, bool) {
 	var (
 		weightedValue float64
 		totalWeight   float64
@@ -136,7 +145,7 @@ func (model interpolationModel) interpolate(point Point) (float64, bool) {
 		totalWeight += weight
 	}
 
-	if !isFinite(totalWeight) || totalWeight <= 0 || !isFinite(weightedValue) {
+	if totalWeight <= 0 || !isFinite(totalWeight) || !isFinite(weightedValue) {
 		return 0, false
 	}
 

--- a/internal/surface/interpolation.go
+++ b/internal/surface/interpolation.go
@@ -1,0 +1,149 @@
+package surface
+
+import (
+	"math"
+	"sort"
+)
+
+const (
+	supportRadiusPercentile = 0.90
+	supportRadiusMultiplier = 2.0
+)
+
+type interpolationModel struct {
+	observations []Point
+	radius       float64
+}
+
+// Interpolate estimates a point's value from observed points with compact support.
+func Interpolate(point Point, originals []Point) float64 {
+	model, ok := newInterpolationModel(originals)
+	if !ok {
+		return 0
+	}
+
+	value, ok := model.interpolate(point)
+	if !ok {
+		return 0
+	}
+
+	return value
+}
+
+func newInterpolationModel(originals []Point) (interpolationModel, bool) {
+	observations := observedPoints(originals)
+	if len(observations) == 0 {
+		return interpolationModel{}, false
+	}
+
+	radius, ok := interpolationSupportRadius(observations)
+	if !ok {
+		return interpolationModel{}, false
+	}
+
+	return interpolationModel{observations: observations, radius: radius}, true
+}
+
+func interpolationSupportRadius(observations []Point) (float64, bool) {
+	nearestPositiveDistances := make([]float64, 0, len(observations))
+
+	for index, observation := range observations {
+		if !isFinitePoint(observation) || !isFinite(observation.Value) {
+			continue
+		}
+
+		nearestDistance := math.Inf(1)
+		for otherIndex, other := range observations {
+			if otherIndex == index {
+				continue
+			}
+
+			distance := Distance(observation, other)
+			if !isFinite(distance) || distance <= 0 {
+				continue
+			}
+
+			if distance < nearestDistance {
+				nearestDistance = distance
+			}
+		}
+
+		if isFinite(nearestDistance) && nearestDistance > 0 {
+			nearestPositiveDistances = append(nearestPositiveDistances, nearestDistance)
+		}
+	}
+
+	if len(nearestPositiveDistances) == 0 {
+		return 0, false
+	}
+
+	sort.Float64s(nearestPositiveDistances)
+	index := int(math.Ceil(supportRadiusPercentile*float64(len(nearestPositiveDistances)))) - 1
+	if index < 0 {
+		index = 0
+	}
+	if index >= len(nearestPositiveDistances) {
+		index = len(nearestPositiveDistances) - 1
+	}
+
+	radius := nearestPositiveDistances[index] * supportRadiusMultiplier
+	if !isFinite(radius) || radius <= 0 {
+		return 0, false
+	}
+
+	return radius, true
+}
+
+func smootherstepWeight(t float64) float64 {
+	if !isFinite(t) || t >= 1 {
+		return 0
+	}
+	if t <= 0 {
+		return 1
+	}
+
+	return 1 - t*t*t*(t*(6*t-15)+10)
+}
+
+func (model interpolationModel) interpolate(point Point) (float64, bool) {
+	if !isFinitePoint(point) || !isFinite(model.radius) || model.radius <= 0 {
+		return 0, false
+	}
+
+	for _, observation := range model.observations {
+		if point.X == observation.X && point.Y == observation.Y {
+			return observation.Value, true
+		}
+	}
+
+	var (
+		weightedValue float64
+		totalWeight   float64
+	)
+
+	for _, observation := range model.observations {
+		distance := Distance(point, observation)
+		if !isFinite(distance) {
+			continue
+		}
+
+		weight := smootherstepWeight(distance / model.radius)
+		if weight <= 0 {
+			continue
+		}
+
+		weightedValue += observation.Value * weight
+		totalWeight += weight
+	}
+
+	if !isFinite(totalWeight) || totalWeight <= 0 || !isFinite(weightedValue) {
+		return 0, false
+	}
+
+	value := weightedValue / totalWeight
+	if !isFinite(value) {
+		return 0, false
+	}
+
+	return value, true
+}

--- a/internal/surface/interpolation_test.go
+++ b/internal/surface/interpolation_test.go
@@ -22,6 +22,7 @@ func TestSmootherstepWeight_IsFlatAtEndpoints(t *testing.T) {
 	t.Parallel()
 
 	g := gomega.NewWithT(t)
+
 	const epsilon = 1e-4
 
 	g.Expect(math.Abs(1 - smootherstepWeight(epsilon))).To(gomega.BeNumerically("<", 1e-9))
@@ -33,6 +34,7 @@ func TestInterpolationSupportRadius_UsesNinetiethPercentileNearestPositiveDistan
 
 	g := gomega.NewWithT(t)
 	observations := make([]Point, 0, 20)
+
 	for gap := range 10 {
 		base := float64((gap + 1) * 100)
 		delta := float64(gap + 1)
@@ -63,6 +65,7 @@ func TestNewInterpolationModel_FiltersNonFiniteAndKeepsCoincidentPoints(t *testi
 	g.Expect(ok).To(gomega.BeTrue())
 	g.Expect(model.observations).To(gomega.HaveLen(3))
 	g.Expect(model.radius).To(gomega.Equal(8.0))
+
 	for _, observation := range model.observations {
 		g.Expect(observation.Original).To(gomega.BeTrue())
 	}

--- a/internal/surface/interpolation_test.go
+++ b/internal/surface/interpolation_test.go
@@ -80,26 +80,26 @@ func TestNewInterpolationModel_RejectsCoincidentOnlyObservations(t *testing.T) {
 	g.Expect(ok).To(gomega.BeFalse())
 }
 
-func TestInterpolationModelInterpolate_ExcludesExactAndOutsideRadiusSupport(t *testing.T) {
+func TestInterpolationModelInterpolate_AssignsZeroWeightAtSupportRadiusBoundary(t *testing.T) {
 	t.Parallel()
 
 	g := gomega.NewWithT(t)
 	model := interpolationModel{
-		observations: []Point{
-			{X: 0, Y: 0, Value: 0},
-			{X: 2, Y: 0, Value: 10},
-			{X: 5, Y: 0, Value: 100},
-		},
-		radius: 4,
+		observations: []Point{{X: 0, Y: 0, Value: 10}},
+		radius:       4,
 	}
 
-	inside, ok := model.interpolate(Point{X: 1, Y: 0})
+	inside, ok := model.interpolate(Point{X: 3, Y: 0})
 	g.Expect(ok).To(gomega.BeTrue())
-	g.Expect(inside).To(gomega.Equal(5.0))
+	g.Expect(inside).To(gomega.Equal(10.0))
+
+	boundary, ok := model.interpolate(Point{X: 4, Y: 0})
+	g.Expect(ok).To(gomega.BeFalse())
+	g.Expect(boundary).To(gomega.Equal(0.0))
 
 	outside, ok := model.interpolate(Point{X: 7, Y: 0})
-	g.Expect(ok).To(gomega.BeTrue())
-	g.Expect(outside).To(gomega.Equal(100.0))
+	g.Expect(ok).To(gomega.BeFalse())
+	g.Expect(outside).To(gomega.Equal(0.0))
 }
 
 func TestInterpolationModelInterpolate_ReturnsUnsupportedWithoutPositiveWeights(t *testing.T) {

--- a/internal/surface/interpolation_test.go
+++ b/internal/surface/interpolation_test.go
@@ -1,0 +1,147 @@
+package surface
+
+import (
+	"math"
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestSmootherstepWeight_KnownValues(t *testing.T) {
+	t.Parallel()
+
+	g := gomega.NewWithT(t)
+	g.Expect(smootherstepWeight(0)).To(gomega.Equal(1.0))
+	g.Expect(smootherstepWeight(0.5)).To(gomega.Equal(0.5))
+	g.Expect(smootherstepWeight(1)).To(gomega.Equal(0.0))
+	g.Expect(smootherstepWeight(math.NaN())).To(gomega.Equal(0.0))
+	g.Expect(smootherstepWeight(math.Inf(1))).To(gomega.Equal(0.0))
+}
+
+func TestSmootherstepWeight_IsFlatAtEndpoints(t *testing.T) {
+	t.Parallel()
+
+	g := gomega.NewWithT(t)
+	const epsilon = 1e-4
+
+	g.Expect(math.Abs(1 - smootherstepWeight(epsilon))).To(gomega.BeNumerically("<", 1e-9))
+	g.Expect(math.Abs(smootherstepWeight(1 - epsilon))).To(gomega.BeNumerically("<", 1e-9))
+}
+
+func TestInterpolationSupportRadius_UsesNinetiethPercentileNearestPositiveDistance(t *testing.T) {
+	t.Parallel()
+
+	g := gomega.NewWithT(t)
+	observations := make([]Point, 0, 20)
+	for gap := range 10 {
+		base := float64((gap + 1) * 100)
+		delta := float64(gap + 1)
+		observations = append(
+			observations,
+			Point{X: base, Y: 0, Value: base},
+			Point{X: base + delta, Y: 0, Value: base + delta},
+		)
+	}
+
+	radius, ok := interpolationSupportRadius(observations)
+	g.Expect(ok).To(gomega.BeTrue())
+	g.Expect(radius).To(gomega.Equal(18.0))
+}
+
+func TestNewInterpolationModel_FiltersNonFiniteAndKeepsCoincidentPoints(t *testing.T) {
+	t.Parallel()
+
+	g := gomega.NewWithT(t)
+	model, ok := newInterpolationModel([]Point{
+		{X: 0, Y: 0, Value: 1},
+		{X: 0, Y: 0, Value: 2},
+		{X: 4, Y: 0, Value: 3},
+		{X: math.NaN(), Y: 1, Value: 4},
+		{X: 1, Y: 1, Value: math.Inf(1)},
+	})
+
+	g.Expect(ok).To(gomega.BeTrue())
+	g.Expect(model.observations).To(gomega.HaveLen(3))
+	g.Expect(model.radius).To(gomega.Equal(8.0))
+	for _, observation := range model.observations {
+		g.Expect(observation.Original).To(gomega.BeTrue())
+	}
+}
+
+func TestNewInterpolationModel_RejectsCoincidentOnlyObservations(t *testing.T) {
+	t.Parallel()
+
+	g := gomega.NewWithT(t)
+	_, ok := newInterpolationModel([]Point{
+		{X: 0, Y: 0, Value: 1},
+		{X: 0, Y: 0, Value: 2},
+	})
+
+	g.Expect(ok).To(gomega.BeFalse())
+}
+
+func TestInterpolationModelInterpolate_ExcludesExactAndOutsideRadiusSupport(t *testing.T) {
+	t.Parallel()
+
+	g := gomega.NewWithT(t)
+	model := interpolationModel{
+		observations: []Point{
+			{X: 0, Y: 0, Value: 0},
+			{X: 2, Y: 0, Value: 10},
+			{X: 5, Y: 0, Value: 100},
+		},
+		radius: 4,
+	}
+
+	inside, ok := model.interpolate(Point{X: 1, Y: 0})
+	g.Expect(ok).To(gomega.BeTrue())
+	g.Expect(inside).To(gomega.Equal(5.0))
+
+	outside, ok := model.interpolate(Point{X: 7, Y: 0})
+	g.Expect(ok).To(gomega.BeTrue())
+	g.Expect(outside).To(gomega.Equal(100.0))
+}
+
+func TestInterpolationModelInterpolate_ReturnsUnsupportedWithoutPositiveWeights(t *testing.T) {
+	t.Parallel()
+
+	g := gomega.NewWithT(t)
+	model := interpolationModel{
+		observations: []Point{{X: 0, Y: 0, Value: 1}},
+		radius:       1,
+	}
+
+	value, ok := model.interpolate(Point{X: 2, Y: 0})
+	g.Expect(ok).To(gomega.BeFalse())
+	g.Expect(value).To(gomega.Equal(0.0))
+}
+
+func TestInterpolationModelInterpolate_ReturnsFirstCoincidentObservationValue(t *testing.T) {
+	t.Parallel()
+
+	g := gomega.NewWithT(t)
+	model := interpolationModel{
+		observations: []Point{
+			{X: 1, Y: 1, Value: 10},
+			{X: 1, Y: 1, Value: 20},
+			{X: 3, Y: 1, Value: 30},
+		},
+		radius: 4,
+	}
+
+	value, ok := model.interpolate(Point{X: 1, Y: 1})
+	g.Expect(ok).To(gomega.BeTrue())
+	g.Expect(value).To(gomega.Equal(10.0))
+}
+
+func TestInterpolate_ReturnsZeroForUnsupportedInterpolation(t *testing.T) {
+	t.Parallel()
+
+	g := gomega.NewWithT(t)
+	value := Interpolate(Point{X: 5, Y: 0}, []Point{
+		{X: 0, Y: 0, Value: 1},
+		{X: 0, Y: 0, Value: 2},
+	})
+
+	g.Expect(value).To(gomega.Equal(0.0))
+}

--- a/internal/surface/interpolation_test.go
+++ b/internal/surface/interpolation_test.go
@@ -145,3 +145,24 @@ func TestInterpolate_ReturnsZeroForUnsupportedInterpolation(t *testing.T) {
 
 	g.Expect(value).To(gomega.Equal(0.0))
 }
+
+func TestInterpolationModelAssign_SetsUnsupportedFromSupportState(t *testing.T) {
+	t.Parallel()
+
+	g := gomega.NewWithT(t)
+	model := interpolationModel{
+		observations: []Point{
+			{X: 0, Y: 0, Value: 0},
+			{X: 2, Y: 0, Value: 0},
+		},
+		radius: 2,
+	}
+
+	supported := model.assign(Point{X: 1, Y: 0})
+	g.Expect(supported.Value).To(gomega.Equal(0.0))
+	g.Expect(supported.unsupported).To(gomega.BeFalse())
+
+	unsupported := model.assign(Point{X: 4, Y: 0})
+	g.Expect(unsupported.Value).To(gomega.Equal(0.0))
+	g.Expect(unsupported.unsupported).To(gomega.BeTrue())
+}

--- a/internal/surface/mesh.go
+++ b/internal/surface/mesh.go
@@ -19,12 +19,12 @@ func Build(region Region, originals []Point, seed uint64) []Triangle {
 		return nil
 	}
 
-	observed := observedPoints(originals)
-	if len(observed) < 3 {
+	model, ok := newInterpolationModel(originals)
+	if !ok || len(model.observations) < 3 {
 		return nil
 	}
 
-	points, complete := meshPoints(region, observed, seed)
+	points, complete := meshPoints(region, model, seed)
 	if !complete || len(points) < 3 {
 		return nil
 	}
@@ -56,26 +56,27 @@ func observedPoints(originals []Point) []Point {
 	return observed
 }
 
-func meshPoints(region Region, observed []Point, seed uint64) ([]Point, bool) {
-	boundary := boundarySamples(region, observed)
+func meshPoints(region Region, model interpolationModel, seed uint64) ([]Point, bool) {
+	boundary := boundarySamples(region, model.observations)
 	for index := range boundary {
-		boundary[index].Value = Interpolate(boundary[index], observed)
+		value, _ := model.interpolate(boundary[index])
+		boundary[index].Value = value
 	}
 
-	points := append([]Point(nil), observed...)
+	points := append([]Point(nil), model.observations...)
 	points = append(points, boundary...)
 	samplingSources := append([]Point(nil), points...)
 
 	infill := Sample(region, samplingSources, PoissonMinDistance, seed)
 	for _, point := range infill {
-		point.Value = Interpolate(point, observed)
+		point.Value, _ = model.interpolate(point)
 		points = append(points, point)
 	}
 
-	return refineMeshPoints(region, points, observed)
+	return refineMeshPoints(region, points, model)
 }
 
-func refineMeshPoints(region Region, points, observed []Point) ([]Point, bool) {
+func refineMeshPoints(region Region, points []Point, model interpolationModel) ([]Point, bool) {
 	limit := refinementPointLimit(region, len(points))
 
 	for {
@@ -94,7 +95,7 @@ func refineMeshPoints(region Region, points, observed []Point) ([]Point, bool) {
 		}
 
 		for _, candidate := range candidates {
-			candidate.Value = Interpolate(candidate, observed)
+			candidate.Value, _ = model.interpolate(candidate)
 			points = append(points, candidate)
 		}
 	}

--- a/internal/surface/mesh.go
+++ b/internal/surface/mesh.go
@@ -59,8 +59,7 @@ func observedPoints(originals []Point) []Point {
 func meshPoints(region Region, model interpolationModel, seed uint64) ([]Point, bool) {
 	boundary := boundarySamples(region, model.observations)
 	for index := range boundary {
-		value, _ := model.interpolate(boundary[index])
-		boundary[index].Value = value
+		boundary[index] = model.assign(boundary[index])
 	}
 
 	points := append([]Point(nil), model.observations...)
@@ -69,8 +68,7 @@ func meshPoints(region Region, model interpolationModel, seed uint64) ([]Point, 
 
 	infill := Sample(region, samplingSources, PoissonMinDistance, seed)
 	for _, point := range infill {
-		point.Value, _ = model.interpolate(point)
-		points = append(points, point)
+		points = append(points, model.assign(point))
 	}
 
 	return refineMeshPoints(region, points, model)
@@ -95,8 +93,7 @@ func refineMeshPoints(region Region, points []Point, model interpolationModel) (
 		}
 
 		for _, candidate := range candidates {
-			candidate.Value, _ = model.interpolate(candidate)
-			points = append(points, candidate)
+			points = append(points, model.assign(candidate))
 		}
 	}
 }
@@ -194,6 +191,10 @@ func regionTriangles(region Region, points []Point, indexes []int) ([]Triangle, 
 			continue
 		}
 
+		if triangleIsUnsupported(triangle) {
+			continue
+		}
+
 		triangle.Value = (triangle.Points[0].Value + triangle.Points[1].Value + triangle.Points[2].Value) / 3
 		if triangleInRegion(region, triangle) {
 			if LongestEdge(triangle) > MaxTriangleEdge {
@@ -205,6 +206,16 @@ func regionTriangles(region Region, points []Point, indexes []int) ([]Triangle, 
 	}
 
 	return triangles, true
+}
+
+func triangleIsUnsupported(triangle Triangle) bool {
+	for _, point := range triangle.Points {
+		if point.unsupported {
+			return true
+		}
+	}
+
+	return false
 }
 
 func triangleAt(points []Point, indexes [3]int) (Triangle, bool) {

--- a/internal/surface/mesh.go
+++ b/internal/surface/mesh.go
@@ -13,35 +13,6 @@ import (
 // them and leaving a ragged edge.
 const radiusTolerance = 1e-9
 
-// Interpolate estimates a point's value from observed points using inverse-distance weighting.
-func Interpolate(point Point, originals []Point) float64 {
-	if len(originals) == 0 {
-		return 0
-	}
-
-	if point.Original {
-		return point.Value
-	}
-
-	var (
-		weightedValue float64
-		totalWeight   float64
-	)
-
-	for _, original := range originals {
-		distance := Distance(point, original)
-		if distance == 0 {
-			return original.Value
-		}
-
-		weight := 1 / math.Pow(distance, IDWPower)
-		weightedValue += original.Value * weight
-		totalWeight += weight
-	}
-
-	return weightedValue / totalWeight
-}
-
 // Build creates an interpolated Delaunay triangle mesh restricted to region.
 func Build(region Region, originals []Point, seed uint64) []Triangle {
 	if !isValidRegion(region) {
@@ -74,7 +45,7 @@ func Build(region Region, originals []Point, seed uint64) []Triangle {
 func observedPoints(originals []Point) []Point {
 	observed := make([]Point, 0, len(originals))
 	for _, original := range originals {
-		if !isFinitePoint(original) {
+		if !isFinitePoint(original) || !isFinite(original.Value) {
 			continue
 		}
 

--- a/internal/surface/mesh.go
+++ b/internal/surface/mesh.go
@@ -187,22 +187,19 @@ func regionTriangles(region Region, points []Point, indexes []int) ([]Triangle, 
 			indexes[index+1],
 			indexes[index+2],
 		})
-		if !ok || isDegenerateTriangle(triangle) {
-			continue
-		}
-
-		if triangleIsUnsupported(triangle) {
+		if !ok ||
+			isDegenerateTriangle(triangle) ||
+			triangleIsUnsupported(triangle) ||
+			!triangleInRegion(region, triangle) {
 			continue
 		}
 
 		triangle.Value = (triangle.Points[0].Value + triangle.Points[1].Value + triangle.Points[2].Value) / 3
-		if triangleInRegion(region, triangle) {
-			if LongestEdge(triangle) > MaxTriangleEdge {
-				return nil, false
-			}
-
-			triangles = append(triangles, triangle)
+		if LongestEdge(triangle) > MaxTriangleEdge {
+			return nil, false
 		}
+
+		triangles = append(triangles, triangle)
 	}
 
 	return triangles, true

--- a/internal/surface/mesh_internal_test.go
+++ b/internal/surface/mesh_internal_test.go
@@ -200,6 +200,22 @@ func TestBoundaryLoops_ReturnsNilForTypedNilBoundaryProvider(t *testing.T) {
 	g.Expect(BoundaryLoops(region, MaxBoundarySegmentLength)).To(gomega.BeNil())
 }
 
+func TestRegionTriangles_OmitsTriangleWithUnsupportedVertex(t *testing.T) {
+	t.Parallel()
+
+	g := gomega.NewWithT(t)
+	region := Rect{MinX: -2, MinY: -2, MaxX: 2, MaxY: 2}
+	points := []Point{
+		{X: 0, Y: 0, Value: 1},
+		{X: 1, Y: 0, Value: 2, unsupported: true},
+		{X: 0, Y: 1, Value: 3},
+	}
+
+	triangles, complete := regionTriangles(region, points, []int{0, 1, 2})
+	g.Expect(complete).To(gomega.BeTrue())
+	g.Expect(triangles).To(gomega.BeEmpty())
+}
+
 func (*typedNilBoundaryProvider) Bounds() Rect {
 	panic("typed-nil provider Bounds should not be called")
 }

--- a/internal/surface/mesh_refinement_test.go
+++ b/internal/surface/mesh_refinement_test.go
@@ -60,8 +60,12 @@ func TestMeshPoints_RefinesInRegionTrianglesToMaximumEdge(t *testing.T) {
 	t.Parallel()
 
 	region, originals := refinementTestMesh()
+	model, ok := newInterpolationModel(originals)
+	if !ok {
+		t.Fatal("expected interpolation model")
+	}
 
-	points, complete := meshPoints(region, observedPoints(originals), 42)
+	points, complete := meshPoints(region, model, 42)
 	if !complete {
 		t.Fatal("mesh refinement did not complete")
 	}
@@ -80,9 +84,12 @@ func TestBuild_CoversEveryInRegionDelaunayFaceAfterRefinement(t *testing.T) {
 	t.Parallel()
 
 	region, originals := refinementTestMesh()
-	observed := observedPoints(originals)
+	model, ok := newInterpolationModel(originals)
+	if !ok {
+		t.Fatal("expected interpolation model")
+	}
 
-	points, complete := meshPoints(region, observed, 42)
+	points, complete := meshPoints(region, model, 42)
 	if !complete {
 		t.Fatal("mesh refinement did not complete")
 	}

--- a/internal/surface/mesh_refinement_test.go
+++ b/internal/surface/mesh_refinement_test.go
@@ -60,6 +60,7 @@ func TestMeshPoints_RefinesInRegionTrianglesToMaximumEdge(t *testing.T) {
 	t.Parallel()
 
 	region, originals := refinementTestMesh()
+
 	model, ok := newInterpolationModel(originals)
 	if !ok {
 		t.Fatal("expected interpolation model")
@@ -84,6 +85,7 @@ func TestBuild_CoversEveryInRegionDelaunayFaceAfterRefinement(t *testing.T) {
 	t.Parallel()
 
 	region, originals := refinementTestMesh()
+
 	model, ok := newInterpolationModel(originals)
 	if !ok {
 		t.Fatal("expected interpolation model")

--- a/internal/surface/mesh_refinement_test.go
+++ b/internal/surface/mesh_refinement_test.go
@@ -139,6 +139,10 @@ func inRegionDelaunayTriangles(t *testing.T, region Region, points []Point) []Tr
 			continue
 		}
 
+		if triangleIsUnsupported(triangle) {
+			continue
+		}
+
 		triangle.Value = (triangle.Points[0].Value +
 			triangle.Points[1].Value +
 			triangle.Points[2].Value) / 3

--- a/internal/surface/mesh_test.go
+++ b/internal/surface/mesh_test.go
@@ -335,9 +335,9 @@ func TestBuild_SeedsAnnulusBoundaries(t *testing.T) {
 	g.Expect(hasOuterBoundaryVertex).To(gomega.BeTrue())
 }
 
-// Every boundary sample must anchor a retained triangle, otherwise the rendered
-// surface shows a ragged rim where rim triangles were discarded.
-func TestBuild_RetainsEveryAnnulusBoundarySampleAsMeshVertex(t *testing.T) {
+// Unsupported boundary samples are intentionally omitted from retained
+// triangles; supported samples must still anchor the rendered rim.
+func TestBuild_RetainsEverySupportedAnnulusBoundarySampleAsMeshVertex(t *testing.T) {
 	t.Parallel()
 
 	g := gomega.NewWithT(t)
@@ -376,6 +376,10 @@ func TestBuild_RetainsEveryAnnulusBoundarySampleAsMeshVertex(t *testing.T) {
 
 	for _, loop := range loops {
 		for _, point := range loop {
+			if surface.Interpolate(point, originals) == 0 {
+				continue
+			}
+
 			g.Expect(vertices).To(gomega.HaveKey([2]float64{point.X, point.Y}))
 		}
 	}

--- a/internal/surface/mesh_test.go
+++ b/internal/surface/mesh_test.go
@@ -9,17 +9,17 @@ import (
 	"github.com/theunrepentantgeek/code-visualizer/internal/surface"
 )
 
-func TestInterpolate_UsesInverseDistanceWeighting(t *testing.T) {
+func TestInterpolate_InterpolatesMidpointWithCompactKernel(t *testing.T) {
 	t.Parallel()
 
 	g := gomega.NewWithT(t)
 	originals := []surface.Point{
-		{X: 0, Y: 0, Value: 0, Original: true},
-		{X: 4, Y: 0, Value: 8, Original: true},
+		{X: 0, Y: 0, Value: 0},
+		{X: 4, Y: 0, Value: 8},
 	}
 
-	g.Expect(surface.Interpolate(surface.Point{X: 1, Y: 0}, originals)).To(
-		gomega.BeNumerically("~", 0.8),
+	g.Expect(surface.Interpolate(surface.Point{X: 2, Y: 0}, originals)).To(
+		gomega.Equal(4.0),
 	)
 }
 
@@ -28,11 +28,11 @@ func TestInterpolate_ReturnsObservedValueAtOriginalLocation(t *testing.T) {
 
 	g := gomega.NewWithT(t)
 	originals := []surface.Point{
-		{X: 0, Y: 0, Value: 3, Original: true},
-		{X: 4, Y: 0, Value: 8, Original: true},
+		{X: 0, Y: 0, Value: 3},
+		{X: 4, Y: 0, Value: 8},
 	}
 
-	g.Expect(surface.Interpolate(originals[0], originals)).To(
+	g.Expect(surface.Interpolate(surface.Point{X: 0, Y: 0}, originals)).To(
 		gomega.Equal(3.0),
 	)
 	g.Expect(surface.Interpolate(surface.Point{X: 4, Y: 0}, originals)).To(gomega.Equal(8.0))
@@ -82,7 +82,7 @@ func TestBuildAndSample_RejectTypedNilAnnulusRegion(t *testing.T) {
 	g.Expect(samples).To(gomega.BeEmpty())
 }
 
-func TestBuild_IgnoresNonFiniteOriginalCoordinates(t *testing.T) {
+func TestBuild_IgnoresNonFiniteOriginalCoordinatesAndValues(t *testing.T) {
 	t.Parallel()
 
 	g := gomega.NewWithT(t)
@@ -93,6 +93,9 @@ func TestBuild_IgnoresNonFiniteOriginalCoordinates(t *testing.T) {
 		{X: math.NaN(), Y: 5, Value: 4},
 		{X: 5, Y: math.Inf(1), Value: 5},
 		{X: math.Inf(-1), Y: 5, Value: 6},
+		{X: 5, Y: 5, Value: math.NaN()},
+		{X: 6, Y: 6, Value: math.Inf(1)},
+		{X: 7, Y: 7, Value: math.Inf(-1)},
 	}
 
 	var triangles []surface.Triangle
@@ -111,6 +114,7 @@ func TestBuild_IgnoresNonFiniteOriginalCoordinates(t *testing.T) {
 		for _, point := range triangle.Points {
 			g.Expect(math.IsNaN(point.X) || math.IsInf(point.X, 0)).To(gomega.BeFalse())
 			g.Expect(math.IsNaN(point.Y) || math.IsInf(point.Y, 0)).To(gomega.BeFalse())
+			g.Expect(math.IsNaN(point.Value) || math.IsInf(point.Value, 0)).To(gomega.BeFalse())
 		}
 	}
 }

--- a/internal/surface/types.go
+++ b/internal/surface/types.go
@@ -10,10 +10,11 @@ const (
 )
 
 type Point struct {
-	X        float64
-	Y        float64
-	Value    float64
-	Original bool
+	X           float64
+	Y           float64
+	Value       float64
+	unsupported bool
+	Original    bool
 }
 
 type Rect struct {

--- a/internal/surface/types.go
+++ b/internal/surface/types.go
@@ -7,7 +7,6 @@ const (
 	MaxTriangleEdge          = 8.0
 	MaxBoundarySegmentLength = 1.0
 	PoissonMinDistance       = 4.0
-	IDWPower                 = 2.0
 )
 
 type Point struct {


### PR DESCRIPTION
This pull request introduces a new compact, smooth kernel-based interpolation model to the `internal/surface` package, replacing the previous global inverse-distance weighting (IDW) approach. The new model uses a reversed smootherstep kernel with an adaptive support radius, ensuring distant observations have zero influence and local blending is smooth without sharp artifacts. The mesh construction and refinement logic is updated to work with this new interpolation model, and unsupported mesh regions (where there is no local data support) are omitted instead of being assigned fallback values. Comprehensive tests and documentation are included to verify correct behavior and edge case handling.
