### PR TITLE
Improve dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "github/gh-aw-actions/*"
     groups:
       # codeql actions need to be updated together
       codeql-action:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,6 @@ updates:
       codeql-action:
         patterns:
           - "github/codeql-action/*"
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,13 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      experimental:
+        patterns:
+          - "golang.org/x/*"
+      external:
+        patterns:
+          - "*/*"
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"


### PR DESCRIPTION
This pull request updates the Dependabot configuration in `.github/dependabot.yml` to improve dependency update management by introducing new grouping and ignoring rules. The changes help organize updates for Go modules and external dependencies, and exclude certain GitHub Actions from updates.
