### PR TITLE
Report when git history finishes loading

### DIFF
--- a/docs/superpowers/plans/2026-08-23-history-loaded-progress.md
+++ b/docs/superpowers/plans/2026-08-23-history-loaded-progress.md
@@ -1,0 +1,115 @@
+# History Loaded Progress Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Emit a concise completion message with the commit count after git history loads successfully.
+
+**Architecture:** Keep success reporting at the `LoadGitHistory` operation boundary. After validating and storing the non-empty result, log `History loaded` with `len(commits)`; preserve quiet-mode suppression and all existing error paths.
+
+**Tech Stack:** Go 1.26.1, `log/slog`, Gomega
+
+---
+
+## File Structure
+
+- Modify `internal/stages/git_history.go`: emit the successful history completion event.
+- Modify `internal/stages/git_history_test.go`: verify the exact commit count and quiet-mode suppression through `LoadGitHistory`.
+
+### Task 1: Report Successful History Loading
+
+**Files:**
+- Modify: `internal/stages/git_history.go:62-64`
+- Test: `internal/stages/git_history_test.go:85-100`
+
+- [ ] **Step 1: Write the failing completion and quiet-mode tests**
+
+Replace `TestLoadGitHistory_ReportsInitialProgressInDefaultMode` and add the quiet-mode test:
+
+```go
+//nolint:paralleltest // mutates global slog default logger
+func TestLoadGitHistory_ReportsProgressAndCompletionInDefaultMode(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	var buf bytes.Buffer
+
+	oldDefault := slog.Default()
+
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{})))
+	defer slog.SetDefault(oldDefault)
+
+	state := buildHistoryState(setupHistoryRepo(t))
+
+	g.Expect(LoadGitHistory(state)).To(Succeed())
+	g.Expect(buf.String()).To(ContainSubstring(`msg="Loading git history"`))
+	g.Expect(buf.String()).To(ContainSubstring(`msg="History loaded" commits=3`))
+}
+
+//nolint:paralleltest // mutates global slog default logger
+func TestLoadGitHistory_QuietModeOmitsCompletion(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	var buf bytes.Buffer
+
+	oldDefault := slog.Default()
+
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{})))
+	defer slog.SetDefault(oldDefault)
+
+	state := buildHistoryState(setupHistoryRepo(t))
+	state.Flags.Quiet = true
+
+	g.Expect(LoadGitHistory(state)).To(Succeed())
+	g.Expect(buf.String()).NotTo(ContainSubstring("History loaded"))
+}
+```
+
+- [ ] **Step 2: Run the focused tests to verify the completion test fails**
+
+Run:
+
+```bash
+go test ./internal/stages -run 'TestLoadGitHistory_(ReportsProgressAndCompletionInDefaultMode|QuietModeOmitsCompletion)$' -count=1
+```
+
+Expected: FAIL because the default-mode output does not contain `msg="History loaded" commits=3`.
+
+- [ ] **Step 3: Add the minimal completion log**
+
+Update the successful end of `LoadGitHistory`:
+
+```go
+c.GitHistory = commits
+
+if !c.Flags.Quiet {
+	slog.Info("History loaded", "commits", len(commits))
+}
+
+return nil
+```
+
+- [ ] **Step 4: Run the focused tests to verify they pass**
+
+Run:
+
+```bash
+go test ./internal/stages -run 'TestLoadGitHistory_(ReportsProgressAndCompletionInDefaultMode|QuietModeOmitsCompletion)$' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the complete stages package tests**
+
+Run:
+
+```bash
+go test ./internal/stages
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the implementation**
+
+```bash
+git add internal/stages/git_history.go internal/stages/git_history_test.go
+git commit -m "feat: report completed history loading" -m "Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>"
+```

--- a/docs/superpowers/specs/2026-08-23-history-loaded-progress-design.md
+++ b/docs/superpowers/specs/2026-08-23-history-loaded-progress-design.md
@@ -1,0 +1,27 @@
+# History Loaded Progress Design
+
+## Goal
+
+Report successful completion of git history loading consistently with filesystem scanning. After history is loaded, emit an informational `History loaded` message with the number of commits loaded.
+
+## Behavior
+
+`LoadGitHistory` will log:
+
+```text
+History loaded commits=<count>
+```
+
+The message is emitted only after the history operation succeeds, returns at least one commit, and stores the result in `CommonState.GitHistory`. Quiet mode suppresses it, matching the existing start and progress messages.
+
+Failures continue to return their existing errors without emitting a success-shaped completion message.
+
+## Implementation
+
+Add the completion log directly to `LoadGitHistory`, immediately after assigning the loaded commits to `CommonState`. Use `len(commits)` as the authoritative count.
+
+This keeps completion reporting at the operation boundary. Logging from the progress ticker's stop callback was rejected because `stop` also runs after loading errors and could incorrectly report success. A separate completion callback abstraction would add unnecessary indirection for one message.
+
+## Testing
+
+Extend the existing `LoadGitHistory` logging test to assert that default mode emits `History loaded` with the fixture's three-commit count. Add coverage that quiet mode omits the completion message. Existing history-loading tests continue to cover successful state population and error behavior.

--- a/internal/stages/git_history.go
+++ b/internal/stages/git_history.go
@@ -60,6 +60,9 @@ func LoadGitHistory(c *CommonState) error {
 	}
 
 	c.GitHistory = commits
+	if !c.Flags.Quiet {
+		slog.Info("History loaded", "commits", len(commits))
+	}
 
 	return nil
 }

--- a/internal/stages/git_history_test.go
+++ b/internal/stages/git_history_test.go
@@ -83,7 +83,7 @@ func buildHistoryState(dir string) *CommonState {
 }
 
 //nolint:paralleltest // mutates global slog default logger
-func TestLoadGitHistory_ReportsInitialProgressInDefaultMode(t *testing.T) {
+func TestLoadGitHistory_ReportsProgressAndCompletionInDefaultMode(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	var buf bytes.Buffer
@@ -97,6 +97,25 @@ func TestLoadGitHistory_ReportsInitialProgressInDefaultMode(t *testing.T) {
 
 	g.Expect(LoadGitHistory(state)).To(Succeed())
 	g.Expect(buf.String()).To(ContainSubstring(`msg="Loading git history"`))
+	g.Expect(buf.String()).To(ContainSubstring(`msg="History loaded" commits=3`))
+}
+
+//nolint:paralleltest // mutates global slog default logger
+func TestLoadGitHistory_QuietModeOmitsCompletion(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	var buf bytes.Buffer
+
+	oldDefault := slog.Default()
+
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{})))
+	defer slog.SetDefault(oldDefault)
+
+	state := buildHistoryState(setupHistoryRepo(t))
+	state.Flags.Quiet = true
+
+	g.Expect(LoadGitHistory(state)).To(Succeed())
+	g.Expect(buf.String()).NotTo(ContainSubstring("History loaded"))
 }
 
 func TestLoadGitHistory_PopulatesGitHistory(t *testing.T) {


### PR DESCRIPTION
## Summary
- emit `History loaded` after successful git history loading
- include the number of loaded commits
- suppress completion output in quiet mode

## Test plan
- [x] `PATH="$PWD/tools:$PATH" task build test`
- [x] focused history progress tests
- [ ] `task ci` (custom lint reports 14 pre-existing nilaway/staticcheck findings, including unchanged `internal/stages/git_history_test.go:159-163`)
